### PR TITLE
Add min and max object area params to generate_masks

### DIFF
--- a/docs/examples/solar_panel_detection.ipynb
+++ b/docs/examples/solar_panel_detection.ipynb
@@ -124,9 +124,11 @@
     "    output_path=output_path,\n",
     "    confidence_threshold=0.4,\n",
     "    mask_threshold=0.5,\n",
+    "    min_object_area=100,\n",
     "    overlap=0.25,\n",
     "    chip_size=(400, 400),\n",
     "    batch_size=4,\n",
+    "    verbose=False,\n",
     ")"
    ]
   },


### PR DESCRIPTION
Add `min_object_area` and `max_object_area` for filtering out objects from the object masks. 