### PR TITLE
feat: add Parquet file support for geospatial data

### DIFF
--- a/geoai/extract.py
+++ b/geoai/extract.py
@@ -608,7 +608,7 @@ class ObjectDetector:
 
         Args:
             mask_path: Path to the object masks GeoTIFF
-            output_path: Path to save the output GeoJSON (default: mask_path with .geojson extension)
+            output_path: Path to save the output GeoJSON or Parquet file (default: mask_path with .geojson extension)
             simplify_tolerance: Tolerance for polygon simplification (default: self.simplify_tolerance)
             mask_threshold: Threshold for mask binarization (default: self.mask_threshold)
             min_object_area: Minimum area in pixels to keep an object (default: self.min_object_area)
@@ -793,7 +793,10 @@ class ObjectDetector:
 
             # Save to file
             if output_path:
-                gdf.to_file(output_path)
+                if output_path.endswith(".parquet"):
+                    gdf.to_parquet(output_path)
+                else:
+                    gdf.to_file(output_path)
                 print(f"Saved {len(gdf)} objects to {output_path}")
 
             return gdf
@@ -814,7 +817,7 @@ class ObjectDetector:
 
         Args:
             raster_path: Path to input raster file
-            output_path: Path to output GeoJSON file (optional)
+            output_path: Path to output GeoJSON or Parquet file (optional)
             batch_size: Batch size for processing
             filter_edges: Whether to filter out objects at the edges of the image
             edge_buffer: Size of edge buffer in pixels to filter out objects (if filter_edges=True)
@@ -1040,7 +1043,10 @@ class ObjectDetector:
 
         # Save to file if requested
         if output_path:
-            gdf.to_file(output_path, driver="GeoJSON")
+            if output_path.endswith(".parquet"):
+                gdf.to_parquet(output_path)
+            else:
+                gdf.to_file(output_path, driver="GeoJSON")
             print(f"Saved {len(gdf)} objects to {output_path}")
 
         return gdf

--- a/geoai/utils.py
+++ b/geoai/utils.py
@@ -752,7 +752,10 @@ def view_vector_interactive(
         kwargs["max_zoom"] = 30
 
     if isinstance(vector_data, str):
-        vector_data = gpd.read_file(vector_data)
+        if vector_data.endswith(".parquet"):
+            vector_data = gpd.read_parquet(vector_data)
+        else:
+            vector_data = gpd.read_file(vector_data)
 
     # Check if input is a GeoDataFrame
     if not isinstance(vector_data, gpd.GeoDataFrame):


### PR DESCRIPTION
# Add Parquet File Support for Geospatial Data

## Overview
This PR adds support for reading and writing Parquet files in the GeoAI library, enhancing data I/O capabilities with this efficient columnar storage format.

## Changes
- Add Parquet output support in `process_raster` and `mask_to_vector` functions
- Implement Parquet file reading capability in utility functions when `vector_data` is a string path
- Maintain backward compatibility with existing formats

## Technical Details
### In `extract.py`:
- Added `.parquet` as output option in `process_raster`
- Added `.parquet` as output option in `mask_vector`

### In `utils.py`:
- Enhanced vector data loading to support Parquet files when input path ends with `.parquet`

## Observations:
I’m still making PRs for small details as I’m getting used to the code and don’t want to interfere with your work. I hope these small contributions are adding some value to the package. Soon, I hope to contribute with more relevant functions. Thank you!
