### PR TITLE
Remove ArcGIS Pre-trained models

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,3 @@ We welcome contributions of all kinds! See our [contributing guide](https://geoa
 ## 📄 License
 
 GeoAI is free and open source software, licensed under the MIT License.
-
-## 💖 Acknowledgment
-
-Some of the pre-trained models used in the geoai package are adapted from the [ArcGIS Living Atlas](https://livingatlas.arcgis.com/en/browse/?q=dlpk#d=2&q=dlpk). Credits to Esri for making these models available.

--- a/docs/examples/building_footprints_usa.ipynb
+++ b/docs/examples/building_footprints_usa.ipynb
@@ -78,9 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Initialize building footprint extraction pretrained model\n",
-    "\n",
-    "The pretained model is adapted from the Esri [building footprint extraction](https://www.arcgis.com/home/item.html?id=a6857359a1cd44839781a4f113cd5934) model for the USA. Credits to Esri for the model."
+    "## Initialize building footprint extraction pretrained model"
    ]
   },
   {

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,3 @@ We welcome contributions of all kinds! See our [contributing guide](https://geoa
 ## 📄 License
 
 GeoAI is free and open source software, licensed under the MIT License.
-
-## 💖 Acknowledgment
-
-Some of the pre-trained models used in the geoai package are adapted from the [ArcGIS Living Atlas](https://livingatlas.arcgis.com/en/browse/?q=dlpk#d=2&q=dlpk). Credits to Esri for making these models available.


### PR DESCRIPTION
The  Esri Master License does not allow the pre-trained models to be used without ArcGIS. As a result, we have to discontinue the use of ArcGIS pre-trained models. We will train our own models from scratch going foward. 