### PR TITLE
Contrast enhancement

### DIFF
--- a/geoai/utils.py
+++ b/geoai/utils.py
@@ -186,7 +186,7 @@ def view_image(
     elif isinstance(image, str):
         image = rasterio.open(image).read().transpose(1, 2, 0)
 
-    plt.figure(figsize=figsize)
+    ax = plt.figure(figsize=figsize)
 
     if transpose:
         image = image.transpose(1, 2, 0)
@@ -213,6 +213,8 @@ def view_image(
         plt.title(title)
     plt.show()
     plt.close()
+
+    return ax
 
 
 def plot_images(


### PR DESCRIPTION
When using geoai.view_image(test, bdx=[2,1,0], scale_factor=1), the displayed image appears too dark.
![output](https://github.com/user-attachments/assets/1a43f9ae-43c5-4222-b87c-76c97bb8d299)
Simply adjusting the scale_factor to brighten the image causes overexposure (all white) or underexposure (all black).
geoai.view_image(test,bdx=[2,1,0],scale_factor=0.9)
![image](https://github.com/user-attachments/assets/764de1f4-47bc-4784-a9de-e2697b7468b3)
geoai.view_image(test,bdx=[2,1,0],scale_factor=2)
![image](https://github.com/user-attachments/assets/10770a47-d213-4d20-9b65-dab61d2e9182)
Therefore, I modified the view_image function to include contrast enhancement techniques (e.g., percentile-based linear stretching and gamma correction), allowing better control over image brightness and contrast for improved visualization.
ax = view_image(test, bdx=[2, 1, 0], gamma=1, clip_percentiles=(2, 98))
![image](https://github.com/user-attachments/assets/60852489-53e5-4ee6-8821-6a5cdef18709)
