### PR TITLE
Pin datasets version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 albumentations
 buildingregulariser
 contextily
+datasets>=3.0
 ever-beta
 geopandas
 huggingface_hub
@@ -12,7 +13,7 @@ maplibre
 opencv-python-headless
 overturemaps
 planetary-computer
-pyarrow<21.0
+pyarrow
 pystac-client
 rasterio
 rioxarray


### PR DESCRIPTION
Fix the error

> .venv/lib/python3.12/site-packages/datasets/features/features.py:634: in <module>
    class _ArrayXDExtensionType(pa.PyExtensionType):
                                ^^^^^^^^^^^^^^^^^^
E   AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'. Did you mean: 'ExtensionType'?
=========================== short test summary info ============================
ERROR tests/test_geoai.py - AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'. Did you mean: 'ExtensionType'?
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
============================== 1 error in 22.74s ===============================