### PR TITLE
Improvement to export_geotiff_tiles to Avoid Overwriting IDs When Adding New Data

### DIFF
--- a/geoai/utils.py
+++ b/geoai/utils.py
@@ -3219,13 +3219,13 @@ def export_geotiff_tiles(
 
         # Process tiles
         tile_index = start_id
-        max_tiles = max_tiles+start_id
+        max_tiles = max_tiles + start_id
 
-        print('====================================================')
-        print('From start id:', start_id)
-        print('Max tiles:', max_tiles)
-        print('====================================================')
-        
+        print("====================================================")
+        print("From start id:", start_id)
+        print("Max tiles:", max_tiles)
+        print("====================================================")
+
         for y in range(num_tiles_y):
             for x in range(num_tiles_x):
                 if tile_index >= max_tiles:


### PR DESCRIPTION
Dear Professor Wu, While working with the export_geotiff_tiles function in GeoAI, I encountered a small issue when adding new data to an existing output folder. Currently, when I run the function multiple times to append new datasets, the id values restart from 0 each time. This causes the new tiles to overwrite the previously generated ones, since the IDs are not unique across different runs. To address this, I made a small modification so that the function checks the existing exported data and continues from the maximum existing ID, ensuring that all generated tiles have unique IDs even when more data are added later.

notebook:
0: ../1.tif
...
====================================================
From start id: 0
Max tiles: 1927
====================================================
Generated: 400, With features: 400 (100.0%)

------- Export Summary -------
Output saved to: /Dec

1: ../2.tif
...
====================================================
From start id: 1896
Max tiles: 3823
====================================================
Generated: 418, With features: 418 (100.0%)

------- Export Summary -------
Output saved to: /Dec

2: ../3.tif
...
====================================================
From start id: 3792
Max tiles: 5719
====================================================
Generated: 430, With features: 430 (100.0%)
