### PR TITLE
colab url correction

### DIFF
--- a/docs/examples/AlphaEarth.ipynb
+++ b/docs/examples/AlphaEarth.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "**Visualize AlphaEarth satellite embeddings in 3D**\n",
     "\n",
-    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/geoai/blob/main/docs/examples/batch_segmentation.ipynb)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/geoai/blob/main/docs/examples/AlphaEarth.ipynb)\n",
     "\n",
     "Google DeepMind has released a new satellite embedding dataset called AlphaEarth. This dataset contains annual satellite embeddings from 2017 to 2024, with each pixel representing a 10x10 meter area. The dataset is available on Google Earth Engine, and can be used to train machine learning models to classify satellite imagery.\n",
     "\n",


### PR DESCRIPTION
This notebook currently leads to another example from the same folder.