### PR TITLE
Fix: Moondream GUI point markers not displaying on map

### DIFF
--- a/geoai/map_widgets.py
+++ b/geoai/map_widgets.py
@@ -483,7 +483,7 @@ def moondream_gui(
 
         if "gdf" in result and len(result["gdf"]) > 0:
             gdf = result["gdf"].copy().to_crs("EPSG:4326")
-            
+
             # Use add_gdf with point_style for more reliable display
             m.add_gdf(
                 gdf,
@@ -602,11 +602,15 @@ def moondream_gui(
                         text_prompt.value,
                     )
                     num_points = len(result.get("points", []))
-                    
+
                     # Show point detection info
-                    info_text = f"Locating: {text_prompt.value}\nFound {num_points} point(s)."
+                    info_text = (
+                        f"Locating: {text_prompt.value}\nFound {num_points} point(s)."
+                    )
                     if "gdf" in result and len(result["gdf"]) > 0:
-                        info_text += f"\nAdded {len(result['gdf'])} point marker(s) to map."
+                        info_text += (
+                            f"\nAdded {len(result['gdf'])} point marker(s) to map."
+                        )
                     update_output(info_text)
 
                     if num_points > 0:


### PR DESCRIPTION
Fixes #372

## Problem
The Moondream GUI's Point mode was able to detect objects but the point markers were not displaying on the map.

## Root Cause
The `add_point_markers()` function was using `m.add_circle_markers_from_xy()` which required manual extraction of x/y coordinates from the Point geometry. This approach was less reliable than the method used for detection boxes.

## Solution
Changed `add_point_markers()` to use `m.add_gdf()` with `point_style` parameter, which:
- Directly uses the GeoDataFrame's geometry column
- More reliable rendering (consistent with detection box display)
- No manual coordinate extraction needed
- Better compatibility across leafmap versions

## Changes
- Replaced `m.add_circle_markers_from_xy()` with `m.add_gdf()` in `add_point_markers()`
- Added `point_style` dict with radius, color, fillColor, fillOpacity, and weight
- Improved feedback message to show number of points added to map
- Removed redundant x/y column creation from geometry

## Testing
The fix makes the point display method consistent with the detection box method, which is known to work reliably.

cc @Tayrac-Thomas - This should resolve the issue you reported. Please test and let us know if it works!