### PR TITLE
Fix: Automatically visualize STAC search results on map

### DIFF
--- a/geoai/agents/geo_agents.py
+++ b/geoai/agents/geo_agents.py
@@ -881,7 +881,9 @@ CRITICAL: Return ONLY JSON. NO explanatory text, NO made-up data."""
 
         return getattr(result, "final_text", str(result))
 
-    def search_and_get_first_item(self, prompt: str, visualize: bool = True) -> Optional[Dict[str, Any]]:
+    def search_and_get_first_item(
+        self, prompt: str, visualize: bool = True
+    ) -> Optional[Dict[str, Any]]:
         """Search for imagery and return the first item as a structured dict.
 
         This method sends a search query to the agent, extracts the search results
@@ -952,7 +954,7 @@ CRITICAL: Return ONLY JSON. NO explanatory text, NO made-up data."""
             # Visualize on map if requested
             if visualize:
                 self._visualize_stac_item(item_data)
-                
+
             return item_data
 
         except json.JSONDecodeError:


### PR DESCRIPTION
Fixes #372

## Problem
When using `STACAgent.ask()` or `search_and_get_first_item()`, the agent successfully found STAC items but did not display them on the map. Visualization only worked when using the interactive `show_ui()` interface.

The user reported: "the chatbot is able to find an item but it doesn't show it on the map"

## Root Cause
The `ask()` and `search_and_get_first_item()` methods only returned JSON data but never called `_visualize_stac_item()` to add the results to the map. The visualization logic only existed in the `show_ui()` method.

## Solution
Added an optional `visualize` parameter (defaults to `True`) to both methods that automatically calls `_visualize_stac_item()` when search results are found.

## Changes
- **`ask(prompt, visualize=True)`**: Now automatically visualizes found items on the map
- **`search_and_get_first_item(prompt, visualize=True)`**: Now automatically visualizes found items on the map
- Both methods accept `visualize=False` to disable auto-visualization if needed
- **`show_ui()`**: Updated to pass `visualize=False` to `search_and_get_first_item()` to avoid double-visualization

## Behavior
**Before:**
```python
agent = STACAgent()
agent.ask("Find Sentinel-2 over Paris")  # Returns JSON, nothing on map
```

**After:**
```python
agent = STACAgent()
agent.ask("Find Sentinel-2 over Paris")  # Returns JSON AND adds to map ✓
```

**To disable visualization:**
```python
agent.ask("Find Sentinel-2 over Paris", visualize=False)  # Just return JSON
```

## Testing
The fix makes the behavior consistent between the interactive UI and programmatic usage. Items are now automatically displayed on the map in both cases.