### PR TITLE
Fix capitalization in paper.bib references

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,6 +1,6 @@
 @misc{Iakubovskii2019,
   author       = {Pavel Iakubovskii},
-  title        = {Segmentation Models Pytorch},
+  title        = {Segmentation Models {PyTorch}},
   year         = {2019},
   howpublished = {\url{https://github.com/qubvel/segmentation_models.pytorch}},
   note         = {GitHub repository}
@@ -13,8 +13,8 @@
                and Köpf, Andreas and Yang, Edward and DeVito, Zachary and Raison,
                Martin and Tejani, Alykhan and Chilamkurthy, Sasank and Steiner,
                Benoit and Fang, Lu and Bai, Junjie and Chintala, Soumith},
-  title     = {PyTorch: An imperative style, high-performance deep learning library},
-  journal   = {Neural Information Processing Systems},
+  title     = {{PyTorch}: An imperative style, high-performance deep learning library},
+  journal   = {Advances in Neural Information Processing Systems},
   year      = {2019},
   volume    = {abs/1912.01703},
   url       = {https://proceedings.neurips.cc/paper/2019/hash/bdbca288fee7f92f2bfa9f7012727740-Abstract.html},
@@ -29,7 +29,7 @@
                    and von Platen, Patrick and Ma, Clara and Jernite, Yacine and Plu, Julien
                    and Xu, Canwen and Le Scao, Teven and Gugger, Sylvain and Drame, Mariama
                    and Lhoest, Quentin and Rush, Alexander M},
-  title         = {HuggingFace's transformers: State-of-the-art natural language processing},
+  title         = {{HuggingFace}'s transformers: State-of-the-art natural language processing},
   journal       = {arXiv preprint arXiv:1910.03771},
   year          = {2019},
   url           = {http://arxiv.org/abs/1910.03771},
@@ -42,7 +42,7 @@
 @article{Zheng2024,
   author    = {Zheng, Zhuo and Zhong, Yanfei and Zhao, Ji and Ma, Ailong and Zhang, Liangpei},
   title     = {Unifying remote sensing change detection via deep probabilistic change models: From principles, models to applications},
-  journal   = {ISPRS Journal of Photogrammetry and Remote Sensing},
+  journal   = {{ISPRS} Journal of Photogrammetry and Remote Sensing},
   volume    = {215},
   pages     = {239--255},
   year      = {2024},
@@ -54,7 +54,7 @@
 
 @article{Wu2021,
   author    = {Wu, Qiusheng},
-  title     = {Leafmap: A Python package for interactive mapping and geospatial analysis with minimal coding in a Jupyter environment},
+  title     = {{Leafmap}: A {Python} package for interactive mapping and geospatial analysis with minimal coding in a {Jupyter} environment},
   journal   = {Journal of Open Source Software},
   year      = {2021},
   doi       = {10.21105/joss.03414},
@@ -63,8 +63,8 @@
 
 @article{Li2022,
   author    = {Li, Wenwen and Hsu, Chia-Yu},
-  title     = {GeoAI for large-scale image analysis and machine vision: Recent progress of artificial intelligence in Geography},
-  journal   = {ISPRS International Journal of Geo-Information},
+  title     = {{GeoAI} for large-scale image analysis and machine vision: Recent progress of artificial intelligence in {Geography}},
+  journal   = {{ISPRS} International Journal of Geo-Information},
   volume    = {11},
   pages     = {385},
   year      = {2022},
@@ -77,8 +77,8 @@
   author    = {Mai, Gengchen and Huang, Weiming and Sun, Jin and Song, Suhang and Mishra, Deepak
                and Liu, Ninghao and Gao, Song and Liu, Tianming and Cong, Gao and Hu, Yingjie
                and Cundy, Chris and Li, Ziyuan and Zhu, Rui and Lao, Ni},
-  title     = {On the Opportunities and Challenges of Foundation Models for GeoAI (Vision Paper)},
-  journal   = {ACM Transactions on Spatial Algorithms and Systems},
+  title     = {On the opportunities and challenges of foundation models for {GeoAI} (vision paper)},
+  journal   = {{ACM} Transactions on Spatial Algorithms and Systems},
   year      = {2024},
   publisher = {ACM},
   address   = {New York, NY, USA},
@@ -91,7 +91,7 @@
 @article{Reichstein2019,
   author    = {Reichstein, Markus and Camps-Valls, Gustau and Stevens, Bjorn and Jung, Martin
                and Denzler, Joachim and Carvalhais, Nuno and Prabhat},
-  title     = {Deep learning and process understanding for data-driven Earth system science},
+  title     = {Deep learning and process understanding for data-driven {Earth} system science},
   journal   = {Nature},
   volume    = {566},
   number    = {7743},
@@ -104,8 +104,8 @@
 @article{Zhu2017,
   author    = {Zhu, Xiao Xiang and Tuia, Devis and Mou, Lichao and Xia, Gui-Song and Zhang, Liangpei
                and Xu, Feng and Fraundorfer, Friedrich},
-  title     = {Deep learning in remote sensing: A comprehensive review and list of resources},
-  journal   = {IEEE Geoscience and Remote Sensing Magazine},
+  title     = {Deep learning in remote sensing: {A} comprehensive review and list of resources},
+  journal   = {{IEEE} Geoscience and Remote Sensing Magazine},
   volume    = {5},
   number    = {4},
   pages     = {8--36},
@@ -116,8 +116,8 @@
 
 @article{Ma2019,
   author    = {Ma, Lei and Liu, Yu and Zhang, Xueliang and Ye, Yuanxin and Yin, Gaofei and Johnson, Brian Alan},
-  title     = {Deep learning in remote sensing applications: A meta-analysis and review},
-  journal   = {ISPRS Journal of Photogrammetry and Remote Sensing},
+  title     = {Deep learning in remote sensing applications: {A} meta-analysis and review},
+  journal   = {{ISPRS} Journal of Photogrammetry and Remote Sensing},
   volume    = {152},
   pages     = {166--177},
   year      = {2019},
@@ -128,7 +128,7 @@
 @article{Stewart2022,
   author    = {Stewart, Adam J and Robinson, Caleb and Corley, Isaac A and Ortiz, Anthony
                and Lavista Ferres, Juan M and Banerjee, Arindam},
-  title     = {TorchGeo: Deep learning with geospatial data},
+  title     = {{TorchGeo}: Deep learning with geospatial data},
   journal   = {Proceedings of the 30th International Conference on Advances in Geographic Information Systems},
   pages     = {1--12},
   year      = {2022},
@@ -139,7 +139,7 @@
   author        = {Gomes, Carlos and Blumenstiel, Benedikt and Almeida, Joao Lucas de Sousa
                    and de Oliveira, Pedro Henrique and Fraccaro, Paolo and Escofet, Francesc Marti
                    and Szwarcman, Daniela and Simumba, Naomi and Kienzler, Romeo and Zadrozny, Bianca},
-  title         = {TerraTorch: The Geospatial Foundation Models toolkit},
+  title         = {{TerraTorch}: The geospatial foundation models toolkit},
   journal       = {arXiv preprint arXiv:2503.20563},
   year          = {2025},
   doi           = {10.48550/arXiv.2503.20563},
@@ -150,7 +150,7 @@
 }
 
 @article{Gramacki2023,
-  title         = {{SRAI: Towards standardization of geospatial {AI}}},
+  title         = {{SRAI}: Towards standardization of geospatial {AI}},
   author        = {Gramacki, Piotr and Leśniara, Kacper and Raczycki, Kamil and
                    Woźniak, Szymon and Przymus, Marcin and Szymański, Piotr},
   journal       = {arXiv [cs.LG]},


### PR DESCRIPTION
Wrap proper nouns, software names, and acronyms in `{}` to preserve capitalization in BibTeX output.

**Changes:**
- Software names: `{PyTorch}`, `{HuggingFace}`, `{Leafmap}`, `{Python}`, `{Jupyter}`, `{GeoAI}`, `{TorchGeo}`, `{TerraTorch}`, `{SRAI}`
- Proper nouns: `{Earth}`, `{Geography}`
- Acronyms in journal names: `{ISPRS}`, `{IEEE}`, `{ACM}`
- Subtitle capitalization preserved: `{A}` after colons
- Fixed journal name: `Neural Information Processing Systems` → `Advances in Neural Information Processing Systems`