### PR TITLE
Improve code quality, documentation, and robustness

### DIFF
--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -1,0 +1,3 @@
+# embeddings module
+
+::: geoai.embeddings

--- a/docs/landcover_train.md
+++ b/docs/landcover_train.md
@@ -1,0 +1,3 @@
+# landcover_train module
+
+::: geoai.landcover_train

--- a/docs/landcover_utils.md
+++ b/docs/landcover_utils.md
@@ -1,0 +1,3 @@
+# landcover_utils module
+
+::: geoai.landcover_utils

--- a/docs/timm_regress.md
+++ b/docs/timm_regress.md
@@ -1,0 +1,3 @@
+# timm_regress module
+
+::: geoai.timm_regress

--- a/geoai/canopy.py
+++ b/geoai/canopy.py
@@ -38,6 +38,14 @@ except ImportError:
         "Please install it: pip install rasterio"
     )
 
+__all__ = [
+    "CanopyHeightEstimation",
+    "canopy_height_estimation",
+    "list_canopy_models",
+    "MODEL_VARIANTS",
+    "DEFAULT_CACHE_DIR",
+]
+
 # ---------------------------------------------------------------------------
 # Model architecture components vendored from Meta's HighResCanopyHeight
 # (Apache License 2.0). Adapted for standalone use without external deps.
@@ -61,6 +69,8 @@ def _resize(
 
 
 class _Mlp(nn.Module):
+    """MLP block with GELU activation and optional dropout."""
+
     def __init__(self, in_features, hidden_features=None, out_features=None, drop=0.0):
         super().__init__()
         out_features = out_features or in_features
@@ -80,6 +90,8 @@ class _Mlp(nn.Module):
 
 
 class _Attention(nn.Module):
+    """Multi-head self-attention module."""
+
     def __init__(self, dim, num_heads=8, qkv_bias=False, attn_drop=0.0, proj_drop=0.0):
         super().__init__()
         self.num_heads = num_heads
@@ -108,6 +120,8 @@ class _Attention(nn.Module):
 
 
 class _LayerScale(nn.Module):
+    """Per-channel learnable scaling layer."""
+
     def __init__(self, dim, init_values=1e-5):
         super().__init__()
         self.gamma = nn.Parameter(init_values * torch.ones(dim))
@@ -117,6 +131,8 @@ class _LayerScale(nn.Module):
 
 
 class _Block(nn.Module):
+    """Transformer block with attention, MLP, and optional layer scale."""
+
     def __init__(
         self,
         dim,
@@ -159,6 +175,8 @@ class _Block(nn.Module):
 
 
 class _PatchEmbed(nn.Module):
+    """Patch embedding using 2D convolution."""
+
     def __init__(
         self, img_size=224, patch_size=16, in_chans=3, embed_dim=768, norm_layer=None
     ):
@@ -189,6 +207,8 @@ class _PatchEmbed(nn.Module):
 
 
 class _AdaptivePadding(nn.Module):
+    """Adaptive padding to ensure input is divisible by kernel size."""
+
     def __init__(self, kernel_size=1, stride=1, padding="corner"):
         super().__init__()
         if isinstance(kernel_size, int):
@@ -424,6 +444,8 @@ def _kaiming_init(module, a=0, mode="fan_out", nonlinearity="relu", bias=0):
 
 
 class _ConvModule(nn.Module):
+    """Convolution module with optional activation and Kaiming initialization."""
+
     def __init__(
         self,
         in_channels,
@@ -482,6 +504,8 @@ class _ConvModule(nn.Module):
 
 
 class _Interpolate(nn.Module):
+    """Interpolation module wrapping F.interpolate."""
+
     def __init__(self, scale_factor, mode, align_corners=False):
         super().__init__()
         self.scale_factor = scale_factor
@@ -498,6 +522,8 @@ class _Interpolate(nn.Module):
 
 
 class _HeadDepth(nn.Module):
+    """Depth prediction head with optional classification into bins."""
+
     def __init__(self, features, classify=False, n_bins=256):
         super().__init__()
         self.head = nn.Sequential(
@@ -515,6 +541,8 @@ class _HeadDepth(nn.Module):
 
 
 class _ReassembleBlocks(nn.Module):
+    """Reassemble multi-scale features from ViT for the DPT decoder."""
+
     def __init__(
         self,
         in_channels=1024,
@@ -577,6 +605,8 @@ class _ReassembleBlocks(nn.Module):
 
 
 class _PreActResidualConvUnit(nn.Module):
+    """Pre-activation residual convolution unit."""
+
     def __init__(self, in_channels, dilation=1):
         super().__init__()
         self.conv1 = _ConvModule(
@@ -607,6 +637,8 @@ class _PreActResidualConvUnit(nn.Module):
 
 
 class _FeatureFusionBlock(nn.Module):
+    """Feature fusion block with residual processing and 2x upsampling."""
+
     def __init__(self, in_channels, expand=False, align_corners=True):
         super().__init__()
         self.in_channels = in_channels

--- a/geoai/embeddings.py
+++ b/geoai/embeddings.py
@@ -39,6 +39,23 @@ import torch
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "list_embedding_datasets",
+    "load_embedding_dataset",
+    "get_embedding_info",
+    "extract_patch_embeddings",
+    "extract_pixel_embeddings",
+    "visualize_embeddings",
+    "plot_embedding_vector",
+    "plot_embedding_raster",
+    "cluster_embeddings",
+    "embedding_similarity",
+    "train_embedding_classifier",
+    "compare_embeddings",
+    "embedding_to_geotiff",
+    "EMBEDDING_DATASETS",
+]
+
 # ---------------------------------------------------------------------------
 # Embedding dataset registry
 # ---------------------------------------------------------------------------

--- a/geoai/segmentation.py
+++ b/geoai/segmentation.py
@@ -75,12 +75,13 @@ class CustomDataset(Dataset):
             image = transformed["image"]
             mask = transformed["mask"]
 
-        assert (
-            mask.max() < self.num_classes
-        ), f"Mask values should be less than {self.num_classes}, but found {mask.max()}"
-        assert (
-            mask.min() >= 0
-        ), f"Mask values should be greater than or equal to 0, but found {mask.min()}"
+        if mask.max() >= self.num_classes:
+            raise ValueError(
+                f"Mask values should be less than {self.num_classes}, "
+                f"but found {mask.max()}"
+            )
+        if mask.min() < 0:
+            raise ValueError(f"Mask values should be >= 0, but found {mask.min()}")
 
         mask = mask.clone().detach().long()
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,8 @@ plugins:
                   "examples/building_detection_whu.ipynb",
                   "examples/canopy_height.ipynb",
                   "examples/water_segmentation.ipynb",
+                  "examples/moondream_sliding_window.ipynb",
+                  "examples/torchgeo_embeddings.ipynb",
                   "workshops/GeoAI_Workshop_2025.ipynb",
               ]
 
@@ -172,6 +174,7 @@ nav:
           - examples/cloud_detection.ipynb
           - examples/moondream.ipynb
           - examples/moondream_gui.ipynb
+          - examples/moondream_sliding_window.ipynb
           - examples/AutoModel.ipynb
           - examples/onnx.ipynb
           - examples/smooth_vector.ipynb
@@ -180,6 +183,7 @@ nav:
           - examples/train_timm_regressor.ipynb
           - examples/canopy_height.ipynb
           - examples/tessera.ipynb
+          - examples/torchgeo_embeddings.ipynb
           - examples/building_detection_whu.ipynb
     - Workshops:
           - workshops/GeoAI_Workshop_2025.ipynb
@@ -197,18 +201,23 @@ nav:
           - geo_agents module: geo_agents.md
           - geoai module: geoai.md
           - download module: download.md
+          - embeddings module: embeddings.md
           - extract module: extract.md
           - hf module: hf.md
+          - landcover_train module: landcover_train.md
+          - landcover_utils module: landcover_utils.md
           - map_tools module: map_tools.md
           - map_widgets module: map_widgets.md
           - moondream module: moondream.md
           - onnx module: onnx.md
           - prithvi module: prithvi.md
           - sam module: sam.md
+          - segment module: segment.md
           - segmentation module: segmentation.md
           - tessera module: tessera.md
-          - timm_train module: timm_train.md
+          - timm_regress module: timm_regress.md
           - timm_segment module: timm_segment.md
+          - timm_train module: timm_train.md
           - train module: train.md
           - utils module: utils.md
           - water module: water.md


### PR DESCRIPTION
## Summary

- **Bug fix**: Replace `assert` statements with proper `ValueError`/`TypeError` exceptions in `prithvi.py`, `segmentation.py`, and `landcover_train.py` — assertions are silently stripped when Python runs with `-O` flag
- **Code quality**: Remove emoji characters from `landcover_train.py` print statements to avoid `UnicodeEncodeError` on systems with limited locale support
- **Code quality**: Add class docstrings to 12 private NN architecture classes in `canopy.py`
- **API hygiene**: Add `__all__` exports to `canopy.py`, `embeddings.py`, and `prithvi.py` to control public API namespace and prevent wildcard import pollution
- **Documentation**: Add missing API doc pages for `embeddings`, `timm_regress`, `landcover_train`, `landcover_utils`, and `segment` modules
- **Documentation**: Add `moondream_sliding_window` and `torchgeo_embeddings` example notebooks to mkdocs.yml navigation

## Test plan

- [x] `pre-commit run --all-files` passes (Black, codespell, YAML, etc.)
- [ ] `python -c "import geoai"` succeeds
- [ ] `python -O -c "from geoai.prithvi import PatchEmbed"` no longer silently skips validation
- [ ] Verify mkdocs nav renders correctly with new entries