### PR TITLE
Add Google Satellite Embedding download and interactive notebook

### DIFF
--- a/docs/examples/google_satellite_embedding.ipynb
+++ b/docs/examples/google_satellite_embedding.ipynb
@@ -1,0 +1,749 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Google Satellite Embedding with TorchGeo\n",
+    "\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/geoai/blob/main/docs/examples/google_satellite_embedding.ipynb)\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "The [AlphaEarth Foundations Satellite Embedding](https://developers.google.com/earth-engine/datasets/catalog/GOOGLE_SATELLITE_EMBEDDING_V1_ANNUAL) dataset, produced by Google and Google DeepMind, provides pre-computed 64-dimensional embedding vectors at 10-meter resolution. Each pixel encodes information from optical, radar, LiDAR, and other Earth observation sources into a unit-length vector.\n",
+    "\n",
+    "Key characteristics:\n",
+    "- **Resolution**: 10 m per pixel\n",
+    "- **Dimensions**: 64 (bands A00-A63)\n",
+    "- **Temporal**: Annual composites from 2018-2024\n",
+    "- **Coverage**: Global\n",
+    "- **License**: CC-BY-4.0\n",
+    "\n",
+    "This notebook demonstrates how to:\n",
+    "1. **Download** embedding data from [Source Cooperative](https://source.coop/tge-labs/aef)\n",
+    "2. **Load** with TorchGeo's `GoogleSatelliteEmbedding` via `geoai`\n",
+    "3. **Visualize** embeddings as PCA-based RGB images\n",
+    "4. **Cluster** embeddings to discover land cover patterns\n",
+    "5. **Search** for similar pixels using cosine similarity\n",
+    "6. **Detect change** by comparing embeddings across years\n",
+    "\n",
+    "References:\n",
+    "- [Paper](https://arxiv.org/abs/2507.22291)\n",
+    "- [Blog post](https://medium.com/google-earth/ai-powered-pixels-introducing-googles-satellite-embedding-dataset-31744c1f4650)\n",
+    "- [Data source](https://source.coop/tge-labs/aef)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Install Package\n",
+    "\n",
+    "Uncomment the command below if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install geoai-py scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import rasterio\n",
+    "\n",
+    "import geoai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Dataset Info\n",
+    "\n",
+    "View metadata about the Google Satellite Embedding dataset from the geoai registry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "info = geoai.get_embedding_info(\"google_satellite\")\n",
+    "for key, value in info.items():\n",
+    "    print(f\"{key}: {value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Download Embedding Data\n",
+    "\n",
+    "Download embeddings for a small region near Paradise, CA for two years (2018 and 2024). The 2018 Camp Fire destroyed much of this area, so comparing pre-fire (2018) and post-rebuilding (2024) embeddings should reveal significant change.\n",
+    "\n",
+    "The download function fetches data from [Source Cooperative](https://source.coop/tge-labs/aef) using windowed reads from Cloud-Optimized GeoTIFFs, so only the requested region is transferred."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bbox = (-121.65, 39.73, -121.55, 39.80)\n",
+    "output_dir = \"aef_data\"\n",
+    "\n",
+    "files = geoai.download_google_satellite_embedding(\n",
+    "    bbox=bbox,\n",
+    "    output_dir=output_dir,\n",
+    "    years=[2018, 2024],\n",
+    "    crs=None,\n",
+    ")\n",
+    "print(f\"Downloaded {len(files)} file(s): {files}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Inspect Downloaded Data\n",
+    "\n",
+    "Check the properties of the downloaded GeoTIFF files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for f in files:\n",
+    "    with rasterio.open(f) as src:\n",
+    "        print(f\"File: {f}\")\n",
+    "        print(f\"  Shape: {src.count} bands x {src.height}H x {src.width}W\")\n",
+    "        print(f\"  CRS: {src.crs}\")\n",
+    "        print(f\"  Bounds: {src.bounds}\")\n",
+    "        print(f\"  Resolution: {src.res}\")\n",
+    "        print(f\"  Dtype: {src.dtypes[0]}\")\n",
+    "        print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## Load with TorchGeo\n",
+    "\n",
+    "Load the downloaded data using TorchGeo's `GoogleSatelliteEmbedding` dataset class via `geoai.load_embedding_dataset()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = geoai.load_embedding_dataset(\"google_satellite\", paths=output_dir)\n",
+    "print(f\"Dataset type: {type(ds).__name__}\")\n",
+    "print(f\"CRS: {ds.crs}\")\n",
+    "print(f\"Resolution: {ds.res}\")\n",
+    "print(f\"Bounds: {ds.bounds}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "## Extract Pixel Embeddings\n",
+    "\n",
+    "Use `extract_pixel_embeddings()` to sample patches from the dataset and flatten the pixels into an `(N, 64)` array suitable for analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = geoai.extract_pixel_embeddings(ds, num_samples=20, size=256, flatten=True)\n",
+    "embeddings = data[\"embeddings\"]\n",
+    "print(f\"Embeddings shape: {embeddings.shape}\")\n",
+    "print(f\"Value range: [{embeddings.min():.4f}, {embeddings.max():.4f}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "## Visualize Embeddings as RGB\n",
+    "\n",
+    "Use PCA to project the 64-band embedding raster into 3 principal components for RGB visualization. Each sample patch is visualized individually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a single sample for visualization\n",
+    "from torchgeo.samplers import RandomGeoSampler\n",
+    "\n",
+    "sampler = RandomGeoSampler(ds, size=512, length=1)\n",
+    "query = next(iter(sampler))\n",
+    "sample = ds[query]\n",
+    "print(f\"Sample image shape: {sample['image'].shape}\")\n",
+    "\n",
+    "fig = geoai.plot_embedding_raster(\n",
+    "    sample[\"image\"],\n",
+    "    title=\"Google Satellite Embedding (PCA RGB)\",\n",
+    ")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "## Interactive Map: PCA RGB\n",
+    "\n",
+    "Save PCA-projected embeddings as a 3-band GeoTIFF and display on an interactive map with a satellite basemap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import leafmap\n",
+    "from sklearn.decomposition import PCA\n",
+    "\n",
+    "# Save derived products to a separate directory outside of output_dir\n",
+    "# to avoid interfering with TorchGeo's recursive directory scanning\n",
+    "viz_dir = \"aef_viz\"\n",
+    "os.makedirs(viz_dir, exist_ok=True)\n",
+    "\n",
+    "# Create PCA RGB GeoTIFFs for both years\n",
+    "pca = PCA(n_components=3)\n",
+    "pca_files = []\n",
+    "\n",
+    "for f in files:\n",
+    "    with rasterio.open(f) as src:\n",
+    "        data = src.read()  # (64, H, W)\n",
+    "        h, w = data.shape[1], data.shape[2]\n",
+    "        pixels = data.reshape(64, -1).T  # (H*W, 64)\n",
+    "        mask = ~np.isnan(pixels).any(axis=1)\n",
+    "\n",
+    "        rgb = np.zeros((pixels.shape[0], 3))\n",
+    "        if mask.any():\n",
+    "            rgb[mask] = pca.fit_transform(pixels[mask])\n",
+    "            rgb -= rgb[mask].min(axis=0)\n",
+    "            maxv = rgb[mask].max(axis=0)\n",
+    "            maxv[maxv == 0] = 1\n",
+    "            rgb /= maxv\n",
+    "        rgb = rgb.reshape(h, w, 3).clip(0, 1)\n",
+    "\n",
+    "        # Save as 3-band uint8 GeoTIFF\n",
+    "        basename = os.path.basename(f).replace(\".tif\", \"_pca_rgb.tif\")\n",
+    "        pca_output = os.path.join(viz_dir, basename)\n",
+    "        with rasterio.open(\n",
+    "            pca_output,\n",
+    "            \"w\",\n",
+    "            driver=\"GTiff\",\n",
+    "            height=h,\n",
+    "            width=w,\n",
+    "            count=3,\n",
+    "            dtype=\"uint8\",\n",
+    "            crs=src.crs,\n",
+    "            transform=src.transform,\n",
+    "            compress=\"lzw\",\n",
+    "        ) as dst:\n",
+    "            for b in range(3):\n",
+    "                dst.write((rgb[:, :, b] * 255).astype(np.uint8), b + 1)\n",
+    "        pca_files.append(pca_output)\n",
+    "\n",
+    "print(f\"PCA RGB files: {pca_files}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display PCA RGB on an interactive map\n",
+    "m = leafmap.Map()\n",
+    "m.add_basemap(\"Esri.WorldImagery\")\n",
+    "m.add_raster(pca_files[0], layer_name=\"Embeddings 2018 (PCA RGB)\")\n",
+    "m.add_raster(pca_files[1], layer_name=\"Embeddings 2024 (PCA RGB)\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "## Cluster Embeddings\n",
+    "\n",
+    "Use K-Means clustering to discover spatial patterns in the embeddings without any labels. Each cluster may correspond to a distinct land cover type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove NaN pixels before clustering\n",
+    "valid_mask = ~np.isnan(embeddings).any(axis=1)\n",
+    "valid_embeddings = embeddings[valid_mask]\n",
+    "print(f\"Valid pixels: {valid_embeddings.shape[0]} / {embeddings.shape[0]}\")\n",
+    "\n",
+    "result = geoai.cluster_embeddings(valid_embeddings, n_clusters=8, method=\"kmeans\")\n",
+    "cluster_labels = result[\"labels\"]\n",
+    "print(f\"Number of clusters: {result['n_clusters']}\")\n",
+    "print(f\"Cluster sizes: {np.bincount(cluster_labels)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize clusters in PCA space\n",
+    "fig = geoai.visualize_embeddings(\n",
+    "    valid_embeddings,\n",
+    "    labels=cluster_labels,\n",
+    "    method=\"pca\",\n",
+    "    figsize=(10, 8),\n",
+    "    s=1,\n",
+    "    alpha=0.3,\n",
+    "    title=\"K-Means Clusters of Satellite Embeddings (PCA)\",\n",
+    ")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize clusters as a spatial map from a single patch\n",
+    "sampler = RandomGeoSampler(ds, size=512, length=1)\n",
+    "query = next(iter(sampler))\n",
+    "sample = ds[query]\n",
+    "image = sample[\"image\"].numpy()  # (64, H, W)\n",
+    "\n",
+    "c, h, w = image.shape\n",
+    "pixels = image.reshape(c, -1).T  # (H*W, 64)\n",
+    "\n",
+    "# Remove NaN pixels\n",
+    "pixel_valid = ~np.isnan(pixels).any(axis=1)\n",
+    "valid_px = pixels[pixel_valid]\n",
+    "\n",
+    "# Predict clusters using the fitted model\n",
+    "pred_labels = result[\"model\"].predict(valid_px)\n",
+    "\n",
+    "# Reconstruct spatial map\n",
+    "cluster_map = np.full(h * w, -1, dtype=int)\n",
+    "cluster_map[pixel_valid] = pred_labels\n",
+    "cluster_map = cluster_map.reshape(h, w)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 8))\n",
+    "im = ax.imshow(cluster_map, cmap=\"tab10\", interpolation=\"nearest\")\n",
+    "ax.set_title(\"Embedding Cluster Map\")\n",
+    "ax.axis(\"off\")\n",
+    "plt.colorbar(im, ax=ax, shrink=0.7, label=\"Cluster\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24",
+   "metadata": {},
+   "source": [
+    "## Interactive Map: Cluster Map\n",
+    "\n",
+    "Save the cluster map as a georeferenced GeoTIFF and display it on an interactive map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save cluster map for the full 2024 embedding as a GeoTIFF\n",
+    "with rasterio.open(files[1]) as src:\n",
+    "    emb_data = src.read()  # (64, H, W)\n",
+    "    emb_h, emb_w = emb_data.shape[1], emb_data.shape[2]\n",
+    "    # Match dtype to the KMeans model's cluster centers\n",
+    "    target_dtype = result[\"model\"].cluster_centers_.dtype\n",
+    "    emb_pixels = emb_data.reshape(64, -1).T.astype(target_dtype)\n",
+    "\n",
+    "    emb_valid = ~np.isnan(emb_pixels).any(axis=1)\n",
+    "    emb_valid_px = emb_pixels[emb_valid]\n",
+    "\n",
+    "    # Predict clusters\n",
+    "    full_labels = result[\"model\"].predict(emb_valid_px)\n",
+    "\n",
+    "    # Reconstruct spatial map (use 255 as nodata for uint8)\n",
+    "    full_cluster_map = np.full(emb_h * emb_w, 255, dtype=np.uint8)\n",
+    "    full_cluster_map[emb_valid] = full_labels.astype(np.uint8)\n",
+    "    full_cluster_map = full_cluster_map.reshape(emb_h, emb_w)\n",
+    "\n",
+    "    cluster_output = os.path.join(viz_dir, \"cluster_map_2024.tif\")\n",
+    "    with rasterio.open(\n",
+    "        cluster_output,\n",
+    "        \"w\",\n",
+    "        driver=\"GTiff\",\n",
+    "        height=emb_h,\n",
+    "        width=emb_w,\n",
+    "        count=1,\n",
+    "        dtype=\"uint8\",\n",
+    "        crs=src.crs,\n",
+    "        transform=src.transform,\n",
+    "        compress=\"lzw\",\n",
+    "        nodata=255,\n",
+    "    ) as dst:\n",
+    "        dst.write(full_cluster_map, 1)\n",
+    "\n",
+    "print(f\"Cluster map saved to {cluster_output}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display cluster map on an interactive map\n",
+    "m = leafmap.Map()\n",
+    "m.add_basemap(\"Esri.WorldImagery\")\n",
+    "m.add_raster(\n",
+    "    cluster_output, cmap=\"tab10\", nodata=255, opacity=0.7, layer_name=\"Clusters\"\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27",
+   "metadata": {},
+   "source": [
+    "## Similarity Search\n",
+    "\n",
+    "Find pixels with the most similar embedding vectors to a query pixel using cosine similarity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the center pixel as a query\n",
+    "center_idx = len(valid_embeddings) // 2\n",
+    "query_embedding = valid_embeddings[center_idx]\n",
+    "\n",
+    "results = geoai.embedding_similarity(\n",
+    "    query=query_embedding,\n",
+    "    embeddings=valid_embeddings,\n",
+    "    metric=\"cosine\",\n",
+    "    top_k=10,\n",
+    ")\n",
+    "\n",
+    "print(\"Top 10 most similar pixels:\")\n",
+    "for rank, (idx, score) in enumerate(\n",
+    "    zip(results[\"indices\"], results[\"scores\"]), start=1\n",
+    "):\n",
+    "    print(f\"  {rank}. Index {idx}: similarity={score:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29",
+   "metadata": {},
+   "source": [
+    "## Change Detection\n",
+    "\n",
+    "Compare embeddings from two years to detect changes on the ground. We read a matching patch from each year and compute the cosine similarity between corresponding pixels. Low similarity values indicate change."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read the two downloaded files directly\n",
+    "with rasterio.open(files[0]) as src1, rasterio.open(files[1]) as src2:\n",
+    "    data1 = src1.read()  # (64, H, W)\n",
+    "    data2 = src2.read()\n",
+    "\n",
+    "    # Use the smaller common extent\n",
+    "    min_h = min(data1.shape[1], data2.shape[1])\n",
+    "    min_w = min(data1.shape[2], data2.shape[2])\n",
+    "    data1 = data1[:, :min_h, :min_w]\n",
+    "    data2 = data2[:, :min_h, :min_w]\n",
+    "\n",
+    "print(f\"Year 1 shape: {data1.shape}\")\n",
+    "print(f\"Year 2 shape: {data2.shape}\")\n",
+    "\n",
+    "# Flatten to (N_pixels, 64)\n",
+    "emb1 = data1.reshape(64, -1).T\n",
+    "emb2 = data2.reshape(64, -1).T\n",
+    "\n",
+    "# Remove pixels where either year has NaN\n",
+    "valid = ~(np.isnan(emb1).any(axis=1) | np.isnan(emb2).any(axis=1))\n",
+    "emb1_valid = emb1[valid]\n",
+    "emb2_valid = emb2[valid]\n",
+    "print(f\"Valid pixel pairs: {emb1_valid.shape[0]}\")\n",
+    "\n",
+    "# Compute cosine similarity\n",
+    "similarity = geoai.compare_embeddings(emb1_valid, emb2_valid, metric=\"cosine\")\n",
+    "print(f\"Mean similarity: {similarity.mean():.4f}\")\n",
+    "print(f\"Min similarity: {similarity.min():.4f}\")\n",
+    "print(f\"Max similarity: {similarity.max():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the similarity distribution\n",
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "ax.hist(similarity, bins=100, edgecolor=\"black\", alpha=0.7, color=\"steelblue\")\n",
+    "ax.axvline(\n",
+    "    similarity.mean(),\n",
+    "    color=\"red\",\n",
+    "    linestyle=\"--\",\n",
+    "    linewidth=2,\n",
+    "    label=f\"Mean: {similarity.mean():.3f}\",\n",
+    ")\n",
+    "ax.set_xlabel(\"Cosine Similarity\")\n",
+    "ax.set_ylabel(\"Pixel Count\")\n",
+    "ax.set_title(\"Embedding Similarity Between 2018 and 2024\")\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a spatial change map\n",
+    "change_map = np.full(min_h * min_w, np.nan)\n",
+    "change_map[valid] = similarity\n",
+    "change_map = change_map.reshape(min_h, min_w)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(18, 6))\n",
+    "\n",
+    "# Year 1 PCA RGB\n",
+    "from sklearn.decomposition import PCA\n",
+    "\n",
+    "pca = PCA(n_components=3)\n",
+    "for ax_idx, (data, year) in enumerate([(data1, \"2018\"), (data2, \"2024\")]):\n",
+    "    pixels = data.reshape(64, -1).T\n",
+    "    mask = ~np.isnan(pixels).any(axis=1)\n",
+    "    rgb = np.zeros((pixels.shape[0], 3))\n",
+    "    if mask.any():\n",
+    "        rgb[mask] = pca.fit_transform(pixels[mask])\n",
+    "        rgb -= rgb[mask].min(axis=0)\n",
+    "        maxv = rgb[mask].max(axis=0)\n",
+    "        maxv[maxv == 0] = 1\n",
+    "        rgb /= maxv\n",
+    "    rgb = rgb.reshape(min_h, min_w, 3).clip(0, 1)\n",
+    "    axes[ax_idx].imshow(rgb)\n",
+    "    axes[ax_idx].set_title(f\"Embeddings {year} (PCA RGB)\")\n",
+    "    axes[ax_idx].axis(\"off\")\n",
+    "\n",
+    "# Change map\n",
+    "im = axes[2].imshow(change_map, cmap=\"RdYlGn\", vmin=0, vmax=1, interpolation=\"nearest\")\n",
+    "axes[2].set_title(\"Cosine Similarity (Change Map)\")\n",
+    "axes[2].axis(\"off\")\n",
+    "plt.colorbar(im, ax=axes[2], shrink=0.7, label=\"Similarity\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33",
+   "metadata": {},
+   "source": [
+    "## Save Embeddings as GeoTIFF\n",
+    "\n",
+    "Export the change map or embedding data as a georeferenced GeoTIFF for use in GIS software."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save the change map as a single-band GeoTIFF\n",
+    "with rasterio.open(files[0]) as src:\n",
+    "    bounds = src.bounds\n",
+    "    transform = src.transform\n",
+    "    file_crs = src.crs\n",
+    "\n",
+    "change_output = os.path.join(viz_dir, \"change_map_2018_2024.tif\")\n",
+    "with rasterio.open(\n",
+    "    change_output,\n",
+    "    \"w\",\n",
+    "    driver=\"GTiff\",\n",
+    "    height=min_h,\n",
+    "    width=min_w,\n",
+    "    count=1,\n",
+    "    dtype=\"float64\",\n",
+    "    crs=file_crs,\n",
+    "    transform=transform,\n",
+    "    compress=\"lzw\",\n",
+    "    nodata=np.nan,\n",
+    ") as dst:\n",
+    "    dst.write(change_map, 1)\n",
+    "    dst.set_band_description(1, \"cosine_similarity\")\n",
+    "\n",
+    "print(f\"Change map saved to {change_output}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35",
+   "metadata": {},
+   "source": [
+    "## Interactive Map: Change Detection\n",
+    "\n",
+    "Visualize the change detection results on interactive maps. Use a split map to compare PCA-projected embeddings from 2018 and 2024 side by side, and overlay the change map on satellite imagery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Split map comparing 2018 vs 2024 PCA RGB embeddings\n",
+    "m = leafmap.Map()\n",
+    "m.split_map(left_layer=pca_files[0], right_layer=pca_files[1])\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display change map overlaid on satellite imagery\n",
+    "m = leafmap.Map()\n",
+    "m.add_basemap(\"Esri.WorldImagery\")\n",
+    "m.add_raster(change_output, cmap=\"RdYlGn\", layer_name=\"Change Map (Cosine Similarity)\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated the end-to-end workflow for working with Google/AlphaEarth Satellite Embeddings using `geoai` and TorchGeo:\n",
+    "\n",
+    "- **64-D embedding vectors** at 10 m resolution encode multi-source satellite observations\n",
+    "- **No GPU required** — embeddings are pre-computed and ready for analysis\n",
+    "- **Windowed download** fetches only the region of interest from Cloud-Optimized GeoTIFFs\n",
+    "- **Unsupervised clustering** reveals distinct land cover patterns\n",
+    "- **Cosine similarity** between years enables change detection\n",
+    "- **Interactive maps** via leafmap for exploring embeddings, clusters, and change maps\n",
+    "- Data is freely available from [Source Cooperative](https://source.coop/tge-labs/aef) under CC-BY-4.0"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -278,6 +278,7 @@ try:
         train_embedding_classifier,
         compare_embeddings,
         embedding_to_geotiff,
+        download_google_satellite_embedding,
         EMBEDDING_DATASETS,
     )
 except ImportError:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,6 +184,7 @@ nav:
           - examples/canopy_height.ipynb
           - examples/tessera.ipynb
           - examples/torchgeo_embeddings.ipynb
+          - examples/google_satellite_embedding.ipynb
           - examples/building_detection_whu.ipynb
     - Workshops:
           - workshops/GeoAI_Workshop_2025.ipynb


### PR DESCRIPTION
## Summary

- Add `download_google_satellite_embedding()` function to `geoai/embeddings.py` for downloading AlphaEarth Foundations Satellite Embedding data from [Source Cooperative](https://source.coop/tge-labs/aef)
- Handle bottom-up COG orientation with manual window computation and vertical flip
- Support spatial index-based tile discovery, band-by-band reading with tqdm progress bar, de-quantization, optional reprojection, and band subsetting
- Create end-to-end notebook (`docs/examples/google_satellite_embedding.ipynb`) demonstrating:
  - Download embedding data for Paradise, CA (2018 & 2024)
  - Load with TorchGeo's `GoogleSatelliteEmbedding`
  - PCA RGB visualization (static + interactive leafmap)
  - K-Means clustering with interactive map overlay
  - Cosine similarity search
  - Change detection between years with histogram, spatial map, and interactive split-view comparison
  - Export derived products as GeoTIFFs
- Export `download_google_satellite_embedding` from `geoai/__init__.py`
- Add notebook to mkdocs navigation

## Test plan

- [ ] Run notebook end-to-end in Jupyter
- [ ] Verify download produces valid 64-band GeoTIFFs
- [ ] Verify interactive maps render (PCA RGB, cluster, split map, change map)
- [ ] Verify pre-commit passes