### PR TITLE
Fix tiles parameter ignored in view_vector_interactive

### DIFF
--- a/geoai/utils/visualization.py
+++ b/geoai/utils/visualization.py
@@ -580,9 +580,13 @@ def view_vector_interactive(
 
     if "tiles" in kwargs and isinstance(kwargs["tiles"], str):
         if kwargs["tiles"].title() in google_tiles:
-            basemap_layer_name = google_tiles[kwargs["tiles"].title()]["name"]
-            kwargs["tiles"] = google_tiles[kwargs["tiles"].title()]["url"]
-            kwargs["attr"] = "Google"
+            tile_key = kwargs["tiles"].title()
+            basemap_layer_name = google_tiles[tile_key]["name"]
+            url = google_tiles[tile_key]["url"]
+            m.add_tile_layer(url=url, name=basemap_layer_name, attribution="Google")
+            del kwargs["tiles"]
+            if "attr" in kwargs:
+                del kwargs["attr"]
         elif kwargs["tiles"].lower().endswith(".tif"):
             if tiles_args is None:
                 tiles_args = {}
@@ -599,6 +603,9 @@ def view_vector_interactive(
                     attribution="localtileserver",
                     **tiles_args,
                 )
+            del kwargs["tiles"]
+            if "attr" in kwargs:
+                del kwargs["attr"]
 
     if "max_zoom" not in kwargs:
         kwargs["max_zoom"] = 30


### PR DESCRIPTION
## Summary
- Fixes #563 where `tiles="Satellite"` (and other Google tile names) was silently ignored in `view_vector_interactive`
- The Google tiles branch resolved the tile name to a URL and stored it back in `kwargs`, but never called `m.add_tile_layer()` to actually add the basemap to the map
- Now explicitly adds the tile layer via `m.add_tile_layer()` and removes `tiles`/`attr` from `kwargs` so they don't leak into `add_gdf()`/`add_data()`
- Applies the same `kwargs` cleanup to the GeoTIFF (`.tif`) branch for consistency

## Test plan
- [ ] Run `geoai.view_vector_interactive(vector_path, tiles="Satellite")` and verify "Google Satellite" appears in the layer control
- [ ] Test other Google tile names: `"Roadmap"`, `"Terrain"`, `"Hybrid"`
- [ ] Test with a local `.tif` file as the `tiles` parameter
- [ ] Test without any `tiles` parameter (default behavior unchanged)