### PR TITLE
Suppress Bandit false-positive warnings in QGIS plugin

### DIFF
--- a/qgis_plugin/geoai/dialogs/deepforest_panel.py
+++ b/qgis_plugin/geoai/dialogs/deepforest_panel.py
@@ -915,7 +915,7 @@ class DeepForestDockWidget(QDockWidget):
                     self.progress_bar.setVisible(False)
                     self.load_model_btn.setEnabled(True)
                     error_msg = (
-                        f"CUDA device requested but not available.\n\n{warning_message}\n\n"
+                        f"CUDA device requested but not available.\n\n{warning_message}\n\n"  # nosec B608
                         "Please select 'cpu' from the Device dropdown or fix your CUDA installation."
                     )
                     self.show_error(error_msg)

--- a/qgis_plugin/geoai/dialogs/samgeo.py
+++ b/qgis_plugin/geoai/dialogs/samgeo.py
@@ -1233,7 +1233,7 @@ class SamGeoDockWidget(QDockWidget):
                     self.progress_bar.setVisible(False)
                     self.load_model_btn.setEnabled(True)
                     error_msg = (
-                        f"CUDA device requested but not available.\n\n{warning_message}\n\n"
+                        f"CUDA device requested but not available.\n\n{warning_message}\n\n"  # nosec B608
                         "Please select 'cpu' from the Device dropdown or fix your CUDA installation."
                     )
                     self.show_error(error_msg)

--- a/qgis_plugin/geoai/dialogs/update_checker.py
+++ b/qgis_plugin/geoai/dialogs/update_checker.py
@@ -45,7 +45,7 @@ class VersionCheckWorker(QThread):
     def run(self):
         """Fetch the latest metadata from GitHub."""
         try:
-            with urlopen(METADATA_URL, timeout=15) as response:
+            with urlopen(METADATA_URL, timeout=15) as response:  # nosec B310
                 content = response.read().decode("utf-8")
 
             # Parse version from metadata
@@ -106,7 +106,7 @@ class DownloadWorker(QThread):
                     percent = min(int((downloaded / total_size) * 50), 50)
                     self.progress.emit(10 + percent, "Downloading...")
 
-            urlretrieve(ZIP_URL, zip_path, reporthook)
+            urlretrieve(ZIP_URL, zip_path, reporthook)  # nosec B310
 
             self.progress.emit(60, "Extracting files...")
 


### PR DESCRIPTION
## Summary
- Add `# nosec B608` to f-string error messages in `deepforest_panel.py` and `samgeo.py` (CUDA diagnostic text used for UI display, not SQL)
- Add `# nosec B310` to `urlopen` and `urlretrieve` calls in `update_checker.py` (hardcoded `https://` constants with no user input)

## Test plan
- [x] Verified `bandit` reports 0 issues for the 4 previously flagged lines (all suppressed via `# nosec`)
- [x] Verified `pre-commit run` passes on all modified files