### PR TITLE
Replace eager imports with PEP 562 lazy loading in __init__.py

### DIFF
--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -446,9 +446,7 @@ def __getattr__(name):
 def __dir__():
     """List all public attributes including lazily-loaded symbols."""
     module_attrs = list(globals().keys())
-    return sorted(
-        set(module_attrs) | set(_LAZY_SYMBOL_MAP.keys()) | _LAZY_SUBMODULES
-    )
+    return sorted(set(module_attrs) | set(_LAZY_SYMBOL_MAP.keys()) | _LAZY_SUBMODULES)
 
 
 __all__ = [

--- a/tests/test_lazy_import.py
+++ b/tests/test_lazy_import.py
@@ -141,9 +141,7 @@ class TestLazyImportInfrastructure(unittest.TestCase):
         """Verify that importing geoai does not pull torch into sys.modules."""
         # Remove all geoai modules
         saved_geoai = {
-            k: sys.modules.pop(k)
-            for k in list(sys.modules)
-            if k.startswith("geoai")
+            k: sys.modules.pop(k) for k in list(sys.modules) if k.startswith("geoai")
         }
         # Remove all torch modules (torch, torch.nn, torch.cuda, etc.)
         saved_torch = {
@@ -155,9 +153,7 @@ class TestLazyImportInfrastructure(unittest.TestCase):
         try:
             importlib.import_module("geoai")
             torch_loaded = [
-                k
-                for k in sys.modules
-                if k == "torch" or k.startswith("torch.")
+                k for k in sys.modules if k == "torch" or k.startswith("torch.")
             ]
             self.assertFalse(
                 torch_loaded,


### PR DESCRIPTION
## Summary

- Replace all 19 eager `try/except` import blocks with PEP 562 `__getattr__`-based lazy loading
- Add `tests/test_lazy_import.py` with 10 tests validating the infrastructure

**Relates to:** #422 (addresses the root cause — eager torch loading at import time)

## Problem

The current `__init__.py` eagerly imports every submodule at package load time, which:

1. **Crashes on CPU-only systems** — `dinov3.py` does bare `import torch` at module level, triggering DLL/CUDA errors (#422)
2. **Takes 2-5 seconds** even on GPU systems — loads PyTorch, torchvision, transformers, geopandas on every `import geoai`
3. **Breaks when optional deps are missing** — any single missing package crashes the entire package

## Solution

| Component | Purpose |
|-----------|---------|
| `_LAZY_SYMBOL_MAP` | 170+ symbol → `(module, attr)` mappings |
| `_LAZY_SUBMODULES` | 11 submodule names for `from geoai import <mod>` |
| `__getattr__(name)` | Resolves on first access, caches in `globals()` |
| `__dir__()` | Full symbol list for IDE autocompletion |
| `__all__` | 242 symbols for `from geoai import *` |

## Results

| Metric | Before | After |
|--------|--------|-------|
| Import time | Crash / 2-5s | **< 1ms** |
| torch loaded on import | Yes | **No** |
| geopandas loaded on import | Yes | **No** |
| CPU-only systems | Broken | **Works** |
| Public symbols in `dir()` | N/A | **257** |
| Backward compatibility | — | **All patterns preserved** |

## Testing

Added `tests/test_lazy_import.py` with 10 tests covering:
- Import completes in <2s with zero submodule loading
- All symbols resolve correctly via `__getattr__`
- `from geoai import <module>` works for all submodules
- `__all__` and `__dir__` return expected symbols
- `__version__` remains accessible
- Invalid attribute access raises `AttributeError`
- torch not loaded into `sys.modules` after bare import

All 10 tests pass.

## Backward Compatibility

Zero breaking changes. All existing access patterns work identically:

```python
import geoai; geoai.LeafMap              # ✅ lazy resolves
from geoai import ObjectDetector         # ✅ triggers __getattr__
from geoai.sam import SamGeo             # ✅ direct submodule (unchanged)
from geoai import classify, extract      # ✅ submodule import
from geoai import *                      # ✅ uses __all__
```

The only observable difference: submodules are no longer imported until first use, which means `sys.modules` won't contain `geoai.sam` etc. until a symbol from that module is actually accessed.