### PR TITLE
fix: avoid shadowing module logger in train_image_classifier

### DIFF
--- a/geoai/recognize.py
+++ b/geoai/recognize.py
@@ -503,7 +503,7 @@ def train_image_classifier(
         verbose=True,
     )
 
-    logger = CSVLogger(model_dir, name="lightning_logs")
+    csv_logger = CSVLogger(model_dir, name="lightning_logs")
 
     # Trainer
     trainer = pl.Trainer(
@@ -511,7 +511,7 @@ def train_image_classifier(
         accelerator=accelerator,
         devices=devices,
         callbacks=[checkpoint_callback, early_stop_callback],
-        logger=logger,
+        logger=csv_logger,
         log_every_n_steps=10,
         **kwargs,
     )


### PR DESCRIPTION
## Summary
- Rename local `CSVLogger` variable to `csv_logger` in `train_image_classifier` to stop shadowing the module-level `logger`, which caused `UnboundLocalError` on earlier `logger.info()` calls.

Fixes #684

## Test plan
- [ ] Run the Image Recognition example notebook end-to-end