### PR TITLE
feat: support multi-class labels in ObjectDetectionDataset

### DIFF
--- a/geoai/train.py
+++ b/geoai/train.py
@@ -551,15 +551,27 @@ class ObjectDetectionDataset(Dataset):
                 labeling.  Use this when label masks already encode unique
                 integers per object (e.g., Fields of The World dataset).
                 Defaults to False.
-            multiclass (bool): If True, read class labels from the label mask
-                pixel values instead of assigning every instance to class ``1``.
-                Each connected component (or pre-assigned instance) is assigned
-                the class ID given by the most common non-zero pixel value
-                inside its mask. Use this when training a multi-class
-                Mask R-CNN with ``num_classes > 2`` where pixel values encode
-                class IDs (1..N, with 0 reserved for background). Defaults to
-                False for backward compatibility with binary training.
+            multiclass (bool): If True, read class labels from the label
+                mask pixel values instead of assigning every instance to
+                class ``1``. Connected-component labeling is run *per class
+                value* so that adjacent regions of different classes are
+                not merged into a single instance. Use this when training
+                a multi-class Mask R-CNN with ``num_classes > 2`` where
+                pixel values encode class IDs (1..N, with 0 reserved for
+                background). Cannot be combined with ``instance_labels``
+                (which uses the same raster to encode instance IDs).
+                Defaults to False for backward compatibility with binary
+                training.
         """
+        if multiclass and instance_labels:
+            raise ValueError(
+                "multiclass=True is incompatible with instance_labels=True: "
+                "when label pixel values encode pre-assigned instance IDs, "
+                "there is no reliable way to also recover class IDs from "
+                "the same raster. Use separate class and instance rasters, "
+                "or disable one of the options."
+            )
+
         self.image_paths = image_paths
         self.label_paths = label_paths
         self.transforms = transforms
@@ -606,28 +618,48 @@ class ObjectDetectionDataset(Dataset):
         with rasterio.open(self.label_paths[idx]) as src:
             label_mask = src.read(1)
 
+        # Build an iterable of (labeled_mask, instance_id, class_label)
+        # triples so the rest of the loop can stay shape-agnostic across
+        # the three extraction modes (instance_labels, multiclass, binary).
         if self.instance_labels:
-            # Use pre-assigned instance IDs directly (e.g., FTW dataset)
+            # Use pre-assigned instance IDs directly (e.g., FTW dataset).
+            # Always single-class in this mode (multiclass+instance_labels
+            # combination is rejected in __init__).
             unique_ids = np.unique(label_mask)
-            unique_ids = unique_ids[unique_ids > 0]  # Remove background
-            num_instances = len(unique_ids)
-            labeled_mask = label_mask
+            unique_ids = unique_ids[unique_ids > 0]
+            instance_sources = [(label_mask, int(i), 1) for i in unique_ids]
+        elif self.multiclass:
+            # Run connected components *per class* so that touching regions
+            # of different classes are not merged into a single instance.
+            class_values = np.unique(label_mask)
+            class_values = class_values[class_values > 0]
+            instance_sources = []
+            for cls in class_values:
+                cls_int = int(cls)
+                cls_mask = (label_mask == cls).astype(np.uint8)
+                cls_labeled, n_cls = measure.label(
+                    cls_mask, return_num=True, connectivity=2
+                )
+                for inst_id in range(1, n_cls + 1):
+                    instance_sources.append((cls_labeled, inst_id, cls_int))
         else:
-            # Find instances using connected components on binary mask
+            # Binary foreground: all instances share class label 1.
             binary_mask = (label_mask > 0).astype(np.uint8)
             labeled_mask, num_instances = measure.label(
                 binary_mask, return_num=True, connectivity=2
             )
-            unique_ids = range(1, num_instances + 1)
+            instance_sources = [
+                (labeled_mask, i, 1) for i in range(1, num_instances + 1)
+            ]
 
         # Create list to hold masks for each object instance
         masks = []
         boxes = []
         labels = []
 
-        for i in unique_ids:
+        for src_mask, i, class_label in instance_sources:
             # Create mask for this instance
-            instance_mask = (labeled_mask == i).astype(np.uint8)
+            instance_mask = (src_mask == i).astype(np.uint8)
 
             # Calculate area and filter out tiny instances (noise)
             area = instance_mask.sum()
@@ -653,21 +685,6 @@ class ObjectDetectionDataset(Dataset):
             ymin = max(0, ymin - 1)
             xmax = min(label_mask.shape[1] - 1, xmax + 1)
             ymax = min(label_mask.shape[0] - 1, ymax + 1)
-
-            # Determine the class label for this instance
-            if self.multiclass:
-                # Look up class ID from the original label mask pixel values
-                # within the instance footprint. Use the most common non-zero
-                # value to be robust to small labeling noise at boundaries.
-                instance_values = label_mask[instance_mask.astype(bool)]
-                instance_values = instance_values[instance_values > 0]
-                if instance_values.size == 0:
-                    continue
-                counts = np.bincount(instance_values.astype(np.int64))
-                class_label = int(counts.argmax())
-            else:
-                # Binary mode: single foreground class
-                class_label = 1
 
             boxes.append([xmin, ymin, xmax, ymax])
             masks.append(instance_mask)
@@ -1514,11 +1531,14 @@ def train_MaskRCNN_model(
             labeling. Use this when label masks already encode unique integers
             per object (e.g., Fields of The World dataset). Defaults to False.
         multiclass (bool): If True (and ``input_format='directory'``), read
-            per-instance class IDs from the label mask pixel values. Each
-            connected component is assigned the most common non-zero value in
-            its footprint as its class label. Use this with ``num_classes > 2``
-            for multi-class training where pixel values encode class IDs
-            (1..N, with 0 reserved for background). Defaults to False.
+            per-instance class IDs from the label mask pixel values by
+            running connected-component labeling *per class value*. Use
+            this with ``num_classes > 2`` for multi-class training where
+            pixel values encode class IDs (1..N, with 0 reserved for
+            background). When ``num_classes > 2`` and this is left False
+            (directory input format, no ``instance_labels``), a warning is
+            emitted because every target would silently collapse to class 1.
+            Defaults to False. Cannot be combined with ``instance_labels=True``.
     Returns:
         None: Model weights are saved to output_dir.
 
@@ -1676,6 +1696,24 @@ def train_MaskRCNN_model(
         logger.info(
             f"Found {len(image_files)} image files and {len(label_files)} label files"
         )
+
+        # Warn when users request multi-class training but forget to opt in
+        # to multiclass label parsing: every target would silently become
+        # class 1 and the model could only learn the first foreground class.
+        if (
+            input_format.lower() == "directory"
+            and num_classes > 2
+            and not multiclass
+            and not instance_labels
+        ):
+            logger.warning(
+                "num_classes=%d was requested but multiclass=False; "
+                "ObjectDetectionDataset will assign every instance label=1 "
+                "and the model will only learn one foreground class. "
+                "Pass multiclass=True to read class IDs from label mask "
+                "pixel values.",
+                num_classes,
+            )
 
         # Split data into train and validation sets
         train_imgs, val_imgs, train_labels, val_labels = train_test_split(
@@ -5543,9 +5581,13 @@ def train_instance_segmentation_model(
             labeling. Use this when label masks already encode unique integers
             per object (e.g., Fields of The World dataset). Defaults to False.
         multiclass (bool): If True (and ``input_format='directory'``), read
-            per-instance class IDs from the label mask pixel values. Required
-            for multi-class training with ``num_classes > 2`` when using the
-            directory input format. Defaults to False.
+            per-instance class IDs from the label mask pixel values using
+            per-class connected-component labeling. Recommended for
+            multi-class training with ``num_classes > 2`` when using the
+            directory input format. If left False with ``num_classes > 2``
+            in directory mode, every target is silently assigned label ``1``
+            and the model will only learn the first foreground class; a
+            warning is emitted in that case. Defaults to False.
         **kwargs: Additional arguments passed to train_MaskRCNN_model.
 
     Returns:

--- a/geoai/train.py
+++ b/geoai/train.py
@@ -535,6 +535,7 @@ class ObjectDetectionDataset(Dataset):
         transforms: Optional[Callable] = None,
         num_channels: Optional[int] = None,
         instance_labels: bool = False,
+        multiclass: bool = False,
     ) -> None:
         """
         Initialize dataset.
@@ -550,11 +551,20 @@ class ObjectDetectionDataset(Dataset):
                 labeling.  Use this when label masks already encode unique
                 integers per object (e.g., Fields of The World dataset).
                 Defaults to False.
+            multiclass (bool): If True, read class labels from the label mask
+                pixel values instead of assigning every instance to class ``1``.
+                Each connected component (or pre-assigned instance) is assigned
+                the class ID given by the most common non-zero pixel value
+                inside its mask. Use this when training a multi-class
+                Mask R-CNN with ``num_classes > 2`` where pixel values encode
+                class IDs (1..N, with 0 reserved for background). Defaults to
+                False for backward compatibility with binary training.
         """
         self.image_paths = image_paths
         self.label_paths = label_paths
         self.transforms = transforms
         self.instance_labels = instance_labels
+        self.multiclass = multiclass
 
         # Auto-detect the number of channels if not specified
         if num_channels is None:
@@ -644,9 +654,24 @@ class ObjectDetectionDataset(Dataset):
             xmax = min(label_mask.shape[1] - 1, xmax + 1)
             ymax = min(label_mask.shape[0] - 1, ymax + 1)
 
+            # Determine the class label for this instance
+            if self.multiclass:
+                # Look up class ID from the original label mask pixel values
+                # within the instance footprint. Use the most common non-zero
+                # value to be robust to small labeling noise at boundaries.
+                instance_values = label_mask[instance_mask.astype(bool)]
+                instance_values = instance_values[instance_values > 0]
+                if instance_values.size == 0:
+                    continue
+                counts = np.bincount(instance_values.astype(np.int64))
+                class_label = int(counts.argmax())
+            else:
+                # Binary mode: single foreground class
+                class_label = 1
+
             boxes.append([xmin, ymin, xmax, ymax])
             masks.append(instance_mask)
-            labels.append(1)  # 1 for building class
+            labels.append(class_label)
 
         # Handle case with no valid instances
         if len(boxes) == 0:
@@ -1432,6 +1457,7 @@ def train_MaskRCNN_model(
     verbose: bool = True,
     model_name: str = "maskrcnn_resnet50_fpn",
     instance_labels: bool = False,
+    multiclass: bool = False,
 ) -> torch.nn.Module:
     """Train and evaluate Mask R-CNN model for instance segmentation.
 
@@ -1487,6 +1513,12 @@ def train_MaskRCNN_model(
             pre-assigned instance IDs instead of running connected-component
             labeling. Use this when label masks already encode unique integers
             per object (e.g., Fields of The World dataset). Defaults to False.
+        multiclass (bool): If True (and ``input_format='directory'``), read
+            per-instance class IDs from the label mask pixel values. Each
+            connected component is assigned the most common non-zero value in
+            its footprint as its class label. Use this with ``num_classes > 2``
+            for multi-class training where pixel values encode class IDs
+            (1..N, with 0 reserved for background). Defaults to False.
     Returns:
         None: Model weights are saved to output_dir.
 
@@ -1661,12 +1693,14 @@ def train_MaskRCNN_model(
             train_labels,
             transforms=get_transform(train=True),
             instance_labels=instance_labels,
+            multiclass=multiclass,
         )
         val_dataset = ObjectDetectionDataset(
             val_imgs,
             val_labels,
             transforms=get_transform(train=False),
             instance_labels=instance_labels,
+            multiclass=multiclass,
         )
 
     # Create data loaders
@@ -5474,6 +5508,7 @@ def train_instance_segmentation_model(
     device: Optional[torch.device] = None,
     verbose: bool = True,
     instance_labels: bool = False,
+    multiclass: bool = False,
     **kwargs: Any,
 ) -> torch.nn.Module:
     """
@@ -5507,6 +5542,10 @@ def train_instance_segmentation_model(
             pre-assigned instance IDs instead of running connected-component
             labeling. Use this when label masks already encode unique integers
             per object (e.g., Fields of The World dataset). Defaults to False.
+        multiclass (bool): If True (and ``input_format='directory'``), read
+            per-instance class IDs from the label mask pixel values. Required
+            for multi-class training with ``num_classes > 2`` when using the
+            directory input format. Defaults to False.
         **kwargs: Additional arguments passed to train_MaskRCNN_model.
 
     Returns:
@@ -5533,6 +5572,7 @@ def train_instance_segmentation_model(
         device=device,
         verbose=verbose,
         instance_labels=instance_labels,
+        multiclass=multiclass,
         **kwargs,
     )
 

--- a/tests/test_instance_segmentation.py
+++ b/tests/test_instance_segmentation.py
@@ -338,6 +338,7 @@ class TestInferenceReturnStructure:
         """Inference time is a positive float."""
         _, inference_time, _ = mock_inference_result
         assert isinstance(inference_time, float)
+        assert inference_time >= 0
 
 
 # ---------------------------------------------------------------------------
@@ -394,6 +395,36 @@ class TestObjectDetectionDatasetMulticlass:
         assert sorted(labels) == [3, 5]
         assert target["boxes"].shape[0] == 2
         assert target["masks"].shape[0] == 2
+
+    def test_multiclass_per_class_connected_components(self, tmp_path):
+        """Touching regions of different classes stay as separate instances."""
+        pytest.importorskip("torch")
+        from geoai.train import ObjectDetectionDataset
+
+        image = np.ones((3, 64, 64), dtype=np.uint8) * 128
+        label = np.zeros((64, 64), dtype=np.uint8)
+        # Two rectangles sharing an edge: a binary CC would merge them,
+        # but per-class CC must keep them as two separate instances.
+        label[10:40, 10:30] = 2  # class 2
+        label[10:40, 30:50] = 4  # class 4
+
+        img, lbl = self._write_pair(tmp_path, image, label, "touch")
+        ds = ObjectDetectionDataset([img], [lbl], multiclass=True)
+        _, target = ds[0]
+
+        labels = sorted(target["labels"].tolist())
+        assert labels == [2, 4]
+        assert target["masks"].shape[0] == 2
+
+    def test_multiclass_and_instance_labels_rejected(self):
+        """Combining multiclass=True with instance_labels=True is a user error."""
+        pytest.importorskip("torch")
+        from geoai.train import ObjectDetectionDataset
+
+        with pytest.raises(ValueError, match="instance_labels"):
+            ObjectDetectionDataset(
+                ["x.tif"], ["y.tif"], multiclass=True, instance_labels=True
+            )
 
     def test_binary_default_still_assigns_one(self, tmp_path):
         """Backward compatible: without multiclass, labels are all 1."""

--- a/tests/test_instance_segmentation.py
+++ b/tests/test_instance_segmentation.py
@@ -338,4 +338,75 @@ class TestInferenceReturnStructure:
         """Inference time is a positive float."""
         _, inference_time, _ = mock_inference_result
         assert isinstance(inference_time, float)
-        assert inference_time >= 0
+
+
+# ---------------------------------------------------------------------------
+# Multiclass ObjectDetectionDataset
+# ---------------------------------------------------------------------------
+
+
+class TestObjectDetectionDatasetMulticlass:
+    """Ensure ObjectDetectionDataset reads multi-class labels from masks."""
+
+    def _write_pair(self, tmp_path, image_arr, label_arr, name):
+        """Write an image and its label mask as single-band GeoTIFFs."""
+        rasterio = pytest.importorskip("rasterio")
+        img_path = tmp_path / f"{name}_img.tif"
+        lbl_path = tmp_path / f"{name}_lbl.tif"
+        with rasterio.open(
+            img_path,
+            "w",
+            driver="GTiff",
+            height=image_arr.shape[1],
+            width=image_arr.shape[2],
+            count=image_arr.shape[0],
+            dtype=image_arr.dtype,
+        ) as dst:
+            dst.write(image_arr)
+        with rasterio.open(
+            lbl_path,
+            "w",
+            driver="GTiff",
+            height=label_arr.shape[0],
+            width=label_arr.shape[1],
+            count=1,
+            dtype=label_arr.dtype,
+        ) as dst:
+            dst.write(label_arr, 1)
+        return str(img_path), str(lbl_path)
+
+    def test_multiclass_reads_class_from_pixel_values(self, tmp_path):
+        """Each connected component is tagged with its mask pixel value."""
+        pytest.importorskip("torch")
+        from geoai.train import ObjectDetectionDataset
+
+        image = np.ones((3, 64, 64), dtype=np.uint8) * 128
+        label = np.zeros((64, 64), dtype=np.uint8)
+        # Two disjoint objects with different class IDs
+        label[5:20, 5:20] = 3  # class 3
+        label[30:50, 30:55] = 5  # class 5
+
+        img, lbl = self._write_pair(tmp_path, image, label, "mc")
+        ds = ObjectDetectionDataset([img], [lbl], multiclass=True)
+        _, target = ds[0]
+
+        labels = target["labels"].tolist()
+        assert sorted(labels) == [3, 5]
+        assert target["boxes"].shape[0] == 2
+        assert target["masks"].shape[0] == 2
+
+    def test_binary_default_still_assigns_one(self, tmp_path):
+        """Backward compatible: without multiclass, labels are all 1."""
+        pytest.importorskip("torch")
+        from geoai.train import ObjectDetectionDataset
+
+        image = np.ones((3, 64, 64), dtype=np.uint8) * 128
+        label = np.zeros((64, 64), dtype=np.uint8)
+        label[5:20, 5:20] = 3
+        label[30:50, 30:55] = 5
+
+        img, lbl = self._write_pair(tmp_path, image, label, "bin")
+        ds = ObjectDetectionDataset([img], [lbl], multiclass=False)
+        _, target = ds[0]
+
+        assert target["labels"].tolist() == [1, 1]


### PR DESCRIPTION
## Summary
- \`ObjectDetectionDataset\` previously hardcoded every instance's class label to \`1\`, so multi-class Mask R-CNN training via the \`directory\` input format could only ever learn one foreground class. This is the root cause of the issue reported in opengeos/geoai#683, where inference output assigns all features to the first class in \`class_names\`.
- Add a new \`multiclass\` option to \`ObjectDetectionDataset\` that derives each instance's class ID from the most common non-zero pixel value inside its footprint in the label mask.
- Plumb \`multiclass\` through \`train_MaskRCNN_model\` and \`train_instance_segmentation_model\`. Default is \`False\` to preserve backward compatibility with existing binary workflows.

Refs opengeos/geoai#683

## Test plan
- [x] \`pytest tests/test_instance_segmentation.py\` (21 passed), including new \`TestObjectDetectionDatasetMulticlass\` cases verifying:
  - multi-class mode reads per-instance class IDs from pixel values
  - binary default (unchanged) still assigns label \`1\`
- [ ] End-to-end: retrain a 7-class Mask R-CNN with \`multiclass=True\` and verify inference GeoPackage has diverse \`class_id\` values