### PR TITLE
fix: run SamGeo vector export in venv subprocess (#688)

### DIFF
--- a/qgis_plugin/geoai/dialogs/samgeo.py
+++ b/qgis_plugin/geoai/dialogs/samgeo.py
@@ -2082,52 +2082,45 @@ class SamGeoDockWidget(QDockWidget):
                 try:
                     self.sam.save_masks(output=temp_raster, unique=unique)
 
-                    from .._geoai_lib import get_geoai
-
-                    geoai = get_geoai()
+                    # Run vector conversion in the managed venv subprocess so
+                    # geoai.utils (which requires numpy>=2) is not imported
+                    # into the QGIS process (which may have an older numpy
+                    # already loaded). See issue #688.
+                    from ..core.geoai_task_subprocess import run_geoai_task
 
                     if vector_mode == 0:
                         # Simple mode - just convert raster to vector
-                        geoai.raster_to_vector(
-                            temp_raster,
-                            output_path=output_path,
-                            min_area=min_area if min_area > 0 else 0,
-                            simplify_tolerance=None,
-                            output_format=vec_format,
+                        run_geoai_task(
+                            "raster_to_vector",
+                            {
+                                "mask_path": temp_raster,
+                                "output_path": output_path,
+                                "min_area": min_area if min_area > 0 else 0,
+                                "output_format": vec_format,
+                            },
                         )
                     elif vector_mode == 2:
                         # Use smooth_vector for natural features
-                        gdf = geoai.raster_to_vector(
-                            temp_raster,
-                            min_area=min_area if min_area > 0 else 0,
-                            simplify_tolerance=None,
-                        )
-                        geoai.smooth_vector(
-                            gdf,
-                            smooth_iterations=smooth_iterations,
-                            output_path=output_path,
+                        run_geoai_task(
+                            "smooth_vector",
+                            {
+                                "mask_path": temp_raster,
+                                "output_path": output_path,
+                                "smooth_iterations": smooth_iterations,
+                                "min_area": min_area if min_area > 0 else 0,
+                            },
                         )
                     else:
                         # Use orthogonalize for regularization (buildings)
-                        gdf = geoai.orthogonalize(
-                            temp_raster,
-                            output_path,
-                            epsilon=epsilon,
+                        run_geoai_task(
+                            "vectorize_mask",
+                            {
+                                "mask_path": temp_raster,
+                                "output_path": output_path,
+                                "epsilon": epsilon,
+                                "min_area": min_area if min_area > 0 else None,
+                            },
                         )
-                        if min_area > 0:
-                            gdf = geoai.add_geometric_properties(gdf, area_unit="m2")
-                            gdf = gdf[gdf["area_m2"] >= min_area]
-                            if output_path.endswith(".geojson"):
-                                driver = "GeoJSON"
-                            elif output_path.endswith(".gpkg"):
-                                driver = "GPKG"
-                            elif output_path.endswith(".shp"):
-                                driver = "ESRI Shapefile"
-                            else:
-                                driver = None
-                            from ..core.proj_utils import safe_to_file
-
-                            safe_to_file(gdf, output_path, driver=driver)
                 finally:
                     if os.path.exists(temp_raster):
                         os.remove(temp_raster)
@@ -2217,52 +2210,45 @@ class SamGeoDockWidget(QDockWidget):
                 try:
                     self.sam.save_masks(output=temp_raster, unique=unique)
 
-                    from .._geoai_lib import get_geoai
-
-                    geoai = get_geoai()
+                    # Run vector conversion in the managed venv subprocess so
+                    # geoai.utils (which requires numpy>=2) is not imported
+                    # into the QGIS process (which may have an older numpy
+                    # already loaded). See issue #688.
+                    from ..core.geoai_task_subprocess import run_geoai_task
 
                     if vector_mode == 0:
                         # Simple mode - just convert raster to vector
-                        geoai.raster_to_vector(
-                            temp_raster,
-                            output_path=output_path,
-                            min_area=min_area if min_area > 0 else 0,
-                            simplify_tolerance=None,
-                            output_format=vec_format,
+                        run_geoai_task(
+                            "raster_to_vector",
+                            {
+                                "mask_path": temp_raster,
+                                "output_path": output_path,
+                                "min_area": min_area if min_area > 0 else 0,
+                                "output_format": vec_format,
+                            },
                         )
                     elif vector_mode == 2:
                         # Use smooth_vector for natural features
-                        gdf = geoai.raster_to_vector(
-                            temp_raster,
-                            min_area=min_area if min_area > 0 else 0,
-                            simplify_tolerance=None,
-                        )
-                        geoai.smooth_vector(
-                            gdf,
-                            smooth_iterations=smooth_iterations,
-                            output_path=output_path,
+                        run_geoai_task(
+                            "smooth_vector",
+                            {
+                                "mask_path": temp_raster,
+                                "output_path": output_path,
+                                "smooth_iterations": smooth_iterations,
+                                "min_area": min_area if min_area > 0 else 0,
+                            },
                         )
                     else:
                         # Use orthogonalize for regularization (buildings)
-                        gdf = geoai.orthogonalize(
-                            temp_raster,
-                            output_path,
-                            epsilon=epsilon,
+                        run_geoai_task(
+                            "vectorize_mask",
+                            {
+                                "mask_path": temp_raster,
+                                "output_path": output_path,
+                                "epsilon": epsilon,
+                                "min_area": min_area if min_area > 0 else None,
+                            },
                         )
-                        if min_area > 0:
-                            gdf = geoai.add_geometric_properties(gdf, area_unit="m2")
-                            gdf = gdf[gdf["area_m2"] >= min_area]
-                            if output_path.endswith(".geojson"):
-                                driver = "GeoJSON"
-                            elif output_path.endswith(".gpkg"):
-                                driver = "GPKG"
-                            elif output_path.endswith(".shp"):
-                                driver = "ESRI Shapefile"
-                            else:
-                                driver = None
-                            from ..core.proj_utils import safe_to_file
-
-                            safe_to_file(gdf, output_path, driver=driver)
                 finally:
                     if os.path.exists(temp_raster):
                         os.remove(temp_raster)

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -2,7 +2,7 @@
 name=GeoAI
 qgisMinimumVersion=3.28
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.0.8
+version=1.0.9
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -58,6 +58,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.0.9
+        - fix: run SamGeo vector export in venv subprocess (#688)
     1.0.8
         - Add support for terrainseg loss functions
         - fix: validate training paths to prevent PermissionError crash

--- a/qgis_plugin/geoai/workers/geoai_task_worker.py
+++ b/qgis_plugin/geoai/workers/geoai_task_worker.py
@@ -145,6 +145,26 @@ def _task_instance_segmentation(params: Dict[str, Any]) -> Dict[str, Any]:
     return {"output_path": params["output_path"]}
 
 
+def _task_raster_to_vector(params: Dict[str, Any]) -> Dict[str, Any]:
+    from geoai.utils.raster import raster_to_vector
+
+    mask_path = params["mask_path"]
+    output_path = params["output_path"]
+    min_area = params.get("min_area") or 0
+    output_format = params.get("output_format", "geojson")
+    simplify_tolerance = params.get("simplify_tolerance")
+
+    _progress("Converting raster to vector...")
+    raster_to_vector(
+        mask_path,
+        output_path=output_path,
+        min_area=min_area,
+        simplify_tolerance=simplify_tolerance,
+        output_format=output_format,
+    )
+    return {"output_path": output_path}
+
+
 def _task_vectorize_mask(params: Dict[str, Any]) -> Dict[str, Any]:
     from geoai.utils.geometry import orthogonalize
     from geoai.utils.vector import add_geometric_properties
@@ -220,6 +240,7 @@ _TASKS = {
     "export_geotiff_tiles": _task_export_geotiff_tiles,
     "semantic_segmentation": _task_semantic_segmentation,
     "instance_segmentation": _task_instance_segmentation,
+    "raster_to_vector": _task_raster_to_vector,
     "vectorize_mask": _task_vectorize_mask,
     "smooth_vector": _task_smooth_vector,
     "segment_water": _task_segment_water,


### PR DESCRIPTION
## Summary
- Routes SamGeo Segment Anything vector output (simple, smooth, orthogonalize modes) through the managed venv subprocess via `run_geoai_task` instead of importing `geoai.utils` inside the QGIS process.
- Adds a `raster_to_vector` task to `geoai_task_worker.py` for vector_mode 0 alongside the existing `vectorize_mask` and `smooth_vector` tasks.

Fixes #688. On native Windows QGIS, the bundled numpy 1.26.4 is loaded before the plugin venv (numpy 2.3.5) is prepended to `sys.path`, so direct `geoai.utils` imports in the QGIS process fail with `No module named 'numpy.lib.array_utils'`. Raster output already ran in the SamGeo subprocess; this change brings the vector path onto the same subprocess pattern already used by `segmentation.py` and `instance_segmentation.py`.

## Test plan
- [ ] Native Windows QGIS: Segment Anything -> load `uc_berkeley.tif` -> Output Format = Vector (GeoJSON) -> Segment by Box -> vector output written without numpy error
- [ ] Repeat with vector_mode = 1 (orthogonalize) and vector_mode = 2 (smooth)
- [ ] Linux: exercise same three modes, confirm no regression