### PR TITLE
feat: add fine-tuning support for pretrained segmentation models

### DIFF
--- a/geoai/train.py
+++ b/geoai/train.py
@@ -3950,7 +3950,6 @@ def train_segmentation_model(
     device: Optional[torch.device] = None,
     checkpoint_path: Optional[str] = None,
     resume_training: bool = False,
-    freeze_encoder: bool = False,
     target_size: Optional[Tuple[int, int]] = None,
     resize_mode: str = "resize",
     num_workers: Optional[int] = None,
@@ -3960,6 +3959,7 @@ def train_segmentation_model(
     loss_fn: Optional[torch.nn.Module] = None,
     class_weights: Optional[List[float]] = None,
     ignore_index: int = -100,
+    freeze_encoder: bool = False,
     **kwargs: Any,
 ) -> torch.nn.Module:
     """
@@ -4004,9 +4004,6 @@ def train_segmentation_model(
             If provided, will load model weights and optionally optimizer/scheduler state.
         resume_training (bool): If True and checkpoint_path is provided, will resume training
             from the checkpoint including optimizer and scheduler state. Defaults to False.
-        freeze_encoder (bool): If True, freeze the encoder parameters so only the
-            decoder is trained. Useful for fine-tuning on small datasets to prevent
-            overfitting. Defaults to False.
         target_size (tuple, optional): Target size (height, width) for standardizing images.
             If None, the function will automatically detect if images have varying sizes and set
             a default target_size of (512, 512) to prevent batching errors. To disable automatic
@@ -4036,6 +4033,9 @@ def train_segmentation_model(
         ignore_index (int): Target value that is ignored by the default
             CrossEntropyLoss. Ignored when *loss_fn* is provided.
             Defaults to -100 (PyTorch default, i.e., no pixels ignored).
+        freeze_encoder (bool): If True, freeze the encoder parameters so only the
+            decoder is trained. Useful for fine-tuning on small datasets to prevent
+            overfitting. Defaults to False.
         **kwargs: Additional arguments passed to smp.create_model().
     Returns:
         None: Model weights are saved to output_dir.
@@ -4408,6 +4408,12 @@ def train_segmentation_model(
 
             logger.info(f"Resuming training from epoch {start_epoch}")
             logger.info(f"Previous best IoU: {best_iou:.4f}")
+        else:
+            logger.warning(
+                "resume_training=True but checkpoint does not contain training "
+                "state (optimizer, scheduler, epoch). Only model weights were "
+                "loaded. Training will start from epoch 0 with a fresh optimizer."
+            )
 
     logger.info(f"Starting training with {architecture} + {encoder_name}")
     trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)

--- a/geoai/train.py
+++ b/geoai/train.py
@@ -3950,6 +3950,7 @@ def train_segmentation_model(
     device: Optional[torch.device] = None,
     checkpoint_path: Optional[str] = None,
     resume_training: bool = False,
+    freeze_encoder: bool = False,
     target_size: Optional[Tuple[int, int]] = None,
     resize_mode: str = "resize",
     num_workers: Optional[int] = None,
@@ -4003,6 +4004,9 @@ def train_segmentation_model(
             If provided, will load model weights and optionally optimizer/scheduler state.
         resume_training (bool): If True and checkpoint_path is provided, will resume training
             from the checkpoint including optimizer and scheduler state. Defaults to False.
+        freeze_encoder (bool): If True, freeze the encoder parameters so only the
+            decoder is trained. Useful for fine-tuning on small datasets to prevent
+            overfitting. Defaults to False.
         target_size (tuple, optional): Target size (height, width) for standardizing images.
             If None, the function will automatically detect if images have varying sizes and set
             a default target_size of (512, 512) to prevent batching errors. To disable automatic
@@ -4300,16 +4304,6 @@ def train_segmentation_model(
     else:
         criterion = torch.nn.CrossEntropyLoss(ignore_index=ignore_index)
 
-    # Set up optimizer
-    optimizer = torch.optim.Adam(
-        model.parameters(), lr=learning_rate, weight_decay=weight_decay
-    )
-
-    # Set up learning rate scheduler
-    lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        optimizer, mode="min", factor=0.5, patience=5
-    )
-
     # Initialize tracking variables
     best_iou = 0
     train_losses = []
@@ -4320,6 +4314,7 @@ def train_segmentation_model(
     val_recalls = []
     start_epoch = 0
     epochs_without_improvement = 0
+    checkpoint = None
 
     # Load checkpoint if provided
     if checkpoint_path is not None:
@@ -4333,43 +4328,7 @@ def train_segmentation_model(
             if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
                 # Load model state
                 model.load_state_dict(checkpoint["model_state_dict"])
-
-                if resume_training:
-                    # Resume training from checkpoint
-                    start_epoch = checkpoint.get("epoch", 0) + 1
-                    best_iou = checkpoint.get("best_iou", 0)
-
-                    # Load optimizer state if available
-                    if "optimizer_state_dict" in checkpoint:
-                        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
-
-                    # Load scheduler state if available
-                    if "scheduler_state_dict" in checkpoint:
-                        lr_scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
-
-                    # Load training history if available
-                    if "train_losses" in checkpoint:
-                        train_losses = checkpoint["train_losses"]
-                    if "val_losses" in checkpoint:
-                        val_losses = checkpoint["val_losses"]
-                    if "val_ious" in checkpoint:
-                        val_ious = checkpoint["val_ious"]
-                    if "val_f1s" in checkpoint:
-                        val_f1s = checkpoint["val_f1s"]
-                    # Also check for old val_dices format for backward compatibility
-                    elif "val_dices" in checkpoint:
-                        val_f1s = checkpoint["val_dices"]
-                    if "val_precisions" in checkpoint:
-                        val_precisions = checkpoint["val_precisions"]
-                    if "val_recalls" in checkpoint:
-                        val_recalls = checkpoint["val_recalls"]
-
-                    logger.info(f"Resuming training from epoch {start_epoch}")
-                    logger.info(f"Previous best IoU: {best_iou:.4f}")
-                else:
-                    logger.info(
-                        "Loaded model weights only (not resuming training state)"
-                    )
+                logger.info("Loaded model weights from checkpoint")
             else:
                 # Assume it's just model weights
                 model.load_state_dict(checkpoint)
@@ -4378,8 +4337,82 @@ def train_segmentation_model(
         except Exception as e:
             raise RuntimeError(f"Failed to load checkpoint: {str(e)}")
 
+    # Freeze encoder if requested (for fine-tuning)
+    if freeze_encoder:
+        if checkpoint_path is None:
+            logger.warning(
+                "freeze_encoder=True but no checkpoint_path provided. "
+                "Freezing encoder on a randomly initialized model is not recommended."
+            )
+        base_model = model.module if isinstance(model, torch.nn.DataParallel) else model
+        if hasattr(base_model, "encoder"):
+            for param in base_model.encoder.parameters():
+                param.requires_grad = False
+            frozen = sum(p.numel() for p in model.parameters() if not p.requires_grad)
+            total = sum(p.numel() for p in model.parameters())
+            logger.info(
+                f"Encoder frozen: {frozen:,}/{total:,} parameters frozen "
+                f"({frozen / total * 100:.1f}%)"
+            )
+        else:
+            logger.warning("Model does not have an encoder attribute to freeze.")
+
+    # Set up optimizer (uses only trainable parameters when encoder is frozen)
+    optimizer = torch.optim.Adam(
+        [p for p in model.parameters() if p.requires_grad],
+        lr=learning_rate,
+        weight_decay=weight_decay,
+    )
+
+    # Set up learning rate scheduler
+    lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, mode="min", factor=0.5, patience=5
+    )
+
+    # Resume training state from checkpoint if requested
+    if resume_training and checkpoint_path is not None:
+        if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
+            start_epoch = checkpoint.get("epoch", 0) + 1
+            best_iou = checkpoint.get("best_iou", 0)
+
+            # Load optimizer state if available
+            if "optimizer_state_dict" in checkpoint:
+                try:
+                    optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+                except Exception:
+                    logger.warning(
+                        "Could not load optimizer state (parameter groups may have "
+                        "changed due to encoder freezing). Using fresh optimizer."
+                    )
+
+            # Load scheduler state if available
+            if "scheduler_state_dict" in checkpoint:
+                lr_scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
+
+            # Load training history if available
+            if "train_losses" in checkpoint:
+                train_losses = checkpoint["train_losses"]
+            if "val_losses" in checkpoint:
+                val_losses = checkpoint["val_losses"]
+            if "val_ious" in checkpoint:
+                val_ious = checkpoint["val_ious"]
+            if "val_f1s" in checkpoint:
+                val_f1s = checkpoint["val_f1s"]
+            # Also check for old val_dices format for backward compatibility
+            elif "val_dices" in checkpoint:
+                val_f1s = checkpoint["val_dices"]
+            if "val_precisions" in checkpoint:
+                val_precisions = checkpoint["val_precisions"]
+            if "val_recalls" in checkpoint:
+                val_recalls = checkpoint["val_recalls"]
+
+            logger.info(f"Resuming training from epoch {start_epoch}")
+            logger.info(f"Previous best IoU: {best_iou:.4f}")
+
     logger.info(f"Starting training with {architecture} + {encoder_name}")
-    logger.info(f"Model parameters: {sum(p.numel() for p in model.parameters()):,}")
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total_params = sum(p.numel() for p in model.parameters())
+    logger.info(f"Model parameters: {total_params:,} (trainable: {trainable:,})")
     if start_epoch > 0:
         logger.info(f"Resuming from epoch {start_epoch}/{num_epochs}")
 

--- a/qgis_plugin/geoai/dialogs/segmentation.py
+++ b/qgis_plugin/geoai/dialogs/segmentation.py
@@ -87,6 +87,9 @@ class TrainingWorker(QThread):
         val_split: float,
         input_format: str = "directory",
         plot_curves: bool = False,
+        checkpoint_path: Optional[str] = None,
+        resume_training: bool = False,
+        freeze_encoder: bool = False,
     ):
         super().__init__()
         self.images_dir = images_dir
@@ -103,6 +106,9 @@ class TrainingWorker(QThread):
         self.val_split = val_split
         self.input_format = input_format
         self.plot_curves = plot_curves
+        self.checkpoint_path = checkpoint_path
+        self.resume_training = resume_training
+        self.freeze_encoder = freeze_encoder
         self._epoch_pattern = None
 
     def _parse_output_line(self, line: str):
@@ -150,6 +156,9 @@ class TrainingWorker(QThread):
                     "val_split": self.val_split,
                     "verbose": True,
                     "plot_curves": self.plot_curves,
+                    "checkpoint_path": self.checkpoint_path,
+                    "resume_training": self.resume_training,
+                    "freeze_encoder": self.freeze_encoder,
                 },
                 progress_callback=self._parse_output_line,
             )
@@ -753,6 +762,32 @@ class SegmentationDockWidget(QDockWidget):
         output_group.setLayout(output_layout)
         layout.addWidget(output_group)
 
+        # Fine-tuning Group (Optional)
+        finetune_group = QGroupBox("Fine-tuning (Optional)")
+        finetune_layout = QFormLayout()
+        finetune_layout.setSpacing(5)
+
+        checkpoint_layout = QHBoxLayout()
+        self.checkpoint_path_edit = QLineEdit()
+        self.checkpoint_path_edit.setPlaceholderText(
+            "Path to pretrained model (.pth)..."
+        )
+        self.checkpoint_path_edit.setStyleSheet(self.line_style)
+        checkpoint_layout.addWidget(self.checkpoint_path_edit)
+        self.checkpoint_browse_btn = QPushButton("...")
+        self.checkpoint_browse_btn.setFixedSize(30, self.input_height)
+        checkpoint_layout.addWidget(self.checkpoint_browse_btn)
+        finetune_layout.addRow("Checkpoint:", checkpoint_layout)
+
+        self.resume_training_check = QCheckBox("Resume training (load optimizer state)")
+        finetune_layout.addRow("", self.resume_training_check)
+
+        self.freeze_encoder_check = QCheckBox("Freeze encoder (train decoder only)")
+        finetune_layout.addRow("", self.freeze_encoder_check)
+
+        finetune_group.setLayout(finetune_layout)
+        layout.addWidget(finetune_group)
+
         # Train button
         btn_layout = QHBoxLayout()
         self.train_btn = QPushButton("Start Training")
@@ -1049,6 +1084,7 @@ class SegmentationDockWidget(QDockWidget):
         self.images_browse_btn.clicked.connect(self.browse_images_dir)
         self.labels_browse_btn.clicked.connect(self.browse_labels_dir)
         self.model_output_browse_btn.clicked.connect(self.browse_model_output)
+        self.checkpoint_browse_btn.clicked.connect(self.browse_checkpoint)
         self.train_btn.clicked.connect(self.start_training)
 
         # Inference tab
@@ -1161,6 +1197,16 @@ class SegmentationDockWidget(QDockWidget):
         dir_path = QFileDialog.getExistingDirectory(self, "Select Output Directory")
         if dir_path:
             self.model_output_dir_edit.setText(dir_path)
+
+    def browse_checkpoint(self):
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select Pretrained Model",
+            "",
+            "PyTorch Model (*.pth *.pt);;All (*)",
+        )
+        if file_path:
+            self.checkpoint_path_edit.setText(file_path)
 
     def browse_inf_raster(self):
         file_path, _ = QFileDialog.getOpenFileName(
@@ -1387,6 +1433,17 @@ class SegmentationDockWidget(QDockWidget):
                 )
                 return
 
+        # Validate checkpoint path if provided
+        checkpoint_path = self.checkpoint_path_edit.text() or None
+        if checkpoint_path and not os.path.isfile(checkpoint_path):
+            QMessageBox.warning(
+                self,
+                "Invalid Path",
+                f"Checkpoint file does not exist:\n{checkpoint_path}\n\n"
+                "Please check the path and try again.",
+            )
+            return
+
         self.train_btn.setEnabled(False)
         num_epochs = self.epochs_spin.value()
         self.train_progress.setRange(0, num_epochs)
@@ -1395,6 +1452,12 @@ class SegmentationDockWidget(QDockWidget):
         self.log(f"Starting training: {self.architecture_combo.currentText()}")
         self.log(f"  Encoder: {self.encoder_combo.currentText()}")
         self.log(f"  Epochs: {num_epochs}, Batch size: {self.batch_size_spin.value()}")
+        if checkpoint_path:
+            self.log(f"  Fine-tuning from: {checkpoint_path}")
+            if self.freeze_encoder_check.isChecked():
+                self.log("  Encoder: frozen")
+            if self.resume_training_check.isChecked():
+                self.log("  Resuming training state")
 
         self.train_worker = TrainingWorker(
             images_dir,
@@ -1411,6 +1474,9 @@ class SegmentationDockWidget(QDockWidget):
             self.val_split_spin.value(),
             self.input_format_combo.currentText(),
             self.plot_curves_check.isChecked(),
+            checkpoint_path,
+            self.resume_training_check.isChecked(),
+            self.freeze_encoder_check.isChecked(),
         )
         self.train_worker.finished.connect(self.on_training_finished)
         self.train_worker.error.connect(self.on_training_error)

--- a/qgis_plugin/geoai/dialogs/segmentation.py
+++ b/qgis_plugin/geoai/dialogs/segmentation.py
@@ -780,9 +780,11 @@ class SegmentationDockWidget(QDockWidget):
         finetune_layout.addRow("Checkpoint:", checkpoint_layout)
 
         self.resume_training_check = QCheckBox("Resume training (load optimizer state)")
+        self.resume_training_check.setEnabled(False)
         finetune_layout.addRow("", self.resume_training_check)
 
         self.freeze_encoder_check = QCheckBox("Freeze encoder (train decoder only)")
+        self.freeze_encoder_check.setEnabled(False)
         finetune_layout.addRow("", self.freeze_encoder_check)
 
         finetune_group.setLayout(finetune_layout)
@@ -1085,6 +1087,7 @@ class SegmentationDockWidget(QDockWidget):
         self.labels_browse_btn.clicked.connect(self.browse_labels_dir)
         self.model_output_browse_btn.clicked.connect(self.browse_model_output)
         self.checkpoint_browse_btn.clicked.connect(self.browse_checkpoint)
+        self.checkpoint_path_edit.textChanged.connect(self._on_checkpoint_path_changed)
         self.train_btn.clicked.connect(self.start_training)
 
         # Inference tab
@@ -1156,6 +1159,15 @@ class SegmentationDockWidget(QDockWidget):
     def sync_classes_to_inference(self, value):
         """Sync classes to inference tab."""
         self.inf_num_classes_spin.setValue(value)
+
+    def _on_checkpoint_path_changed(self, text):
+        """Enable/disable fine-tuning checkboxes based on checkpoint path."""
+        has_checkpoint = bool(text.strip())
+        self.resume_training_check.setEnabled(has_checkpoint)
+        self.freeze_encoder_check.setEnabled(has_checkpoint)
+        if not has_checkpoint:
+            self.resume_training_check.setChecked(False)
+            self.freeze_encoder_check.setChecked(False)
 
     def log(self, message: str):
         """Add message to log."""
@@ -1434,7 +1446,7 @@ class SegmentationDockWidget(QDockWidget):
                 return
 
         # Validate checkpoint path if provided
-        checkpoint_path = self.checkpoint_path_edit.text() or None
+        checkpoint_path = self.checkpoint_path_edit.text().strip() or None
         if checkpoint_path and not os.path.isfile(checkpoint_path):
             QMessageBox.warning(
                 self,

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -2,7 +2,7 @@
 name=GeoAI
 qgisMinimumVersion=3.28
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.0.9
+version=1.1.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -58,6 +58,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.1.0
+        - Add fine-tuning support for pretrained segmentation models (#693)
     1.0.9
         - fix: run SamGeo vector export in venv subprocess (#688)
     1.0.8

--- a/tests/test_freeze_encoder.py
+++ b/tests/test_freeze_encoder.py
@@ -1,0 +1,121 @@
+"""Tests for freeze_encoder functionality in train_segmentation_model."""
+
+import os
+import tempfile
+
+import pytest
+import torch
+
+import segmentation_models_pytorch as smp
+
+from geoai.train import get_smp_model
+
+
+class TestFreezeEncoder:
+    """Tests for the freeze_encoder parameter behavior."""
+
+    def _make_model(self):
+        """Create a small SMP model for testing."""
+        return get_smp_model(
+            architecture="unet",
+            encoder_name="resnet18",
+            encoder_weights=None,
+            in_channels=3,
+            classes=2,
+        )
+
+    def test_encoder_frozen_after_flag(self):
+        """Verify encoder params have requires_grad=False after freezing."""
+        model = self._make_model()
+
+        # Freeze encoder
+        for param in model.encoder.parameters():
+            param.requires_grad = False
+
+        # All encoder params should be frozen
+        for param in model.encoder.parameters():
+            assert not param.requires_grad
+
+        # Decoder params should still be trainable
+        for param in model.decoder.parameters():
+            assert param.requires_grad
+
+    def test_optimizer_excludes_frozen_params(self):
+        """Verify optimizer only contains trainable parameters."""
+        model = self._make_model()
+
+        # Freeze encoder
+        for param in model.encoder.parameters():
+            param.requires_grad = False
+
+        trainable_params = [p for p in model.parameters() if p.requires_grad]
+        optimizer = torch.optim.Adam(trainable_params, lr=0.001)
+
+        # Optimizer param groups should only have trainable params
+        total_optimizer_params = sum(
+            p.numel() for group in optimizer.param_groups for p in group["params"]
+        )
+        total_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        total_all = sum(p.numel() for p in model.parameters())
+
+        assert total_optimizer_params == total_trainable
+        assert total_optimizer_params < total_all
+
+    def test_frozen_param_count(self):
+        """Verify frozen params are a subset of total params."""
+        model = self._make_model()
+
+        total_before = sum(p.numel() for p in model.parameters())
+
+        for param in model.encoder.parameters():
+            param.requires_grad = False
+
+        frozen = sum(p.numel() for p in model.parameters() if not p.requires_grad)
+        trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+        assert frozen > 0
+        assert trainable > 0
+        assert frozen + trainable == total_before
+
+    def test_checkpoint_load_then_freeze(self, tmp_path):
+        """Verify checkpoint loading works correctly with encoder freezing."""
+        model = self._make_model()
+
+        # Save a checkpoint
+        checkpoint_path = str(tmp_path / "test_model.pth")
+        torch.save(
+            {"model_state_dict": model.state_dict(), "epoch": 5, "best_iou": 0.75},
+            checkpoint_path,
+        )
+
+        # Load into a new model and freeze
+        model2 = self._make_model()
+        checkpoint = torch.load(checkpoint_path, map_location="cpu")
+        model2.load_state_dict(checkpoint["model_state_dict"])
+
+        for param in model2.encoder.parameters():
+            param.requires_grad = False
+
+        # Verify weights match after loading
+        for (n1, p1), (n2, p2) in zip(
+            model.named_parameters(), model2.named_parameters()
+        ):
+            assert torch.equal(p1, p2), f"Parameter {n1} mismatch after loading"
+
+        # Verify encoder is frozen
+        for param in model2.encoder.parameters():
+            assert not param.requires_grad
+
+    def test_dataparallel_freeze(self):
+        """Verify freezing works through DataParallel wrapper."""
+        model = self._make_model()
+        # Simulate DataParallel wrapping (without actual multi-GPU)
+        wrapped = torch.nn.DataParallel(model)
+
+        base_model = wrapped.module
+        for param in base_model.encoder.parameters():
+            param.requires_grad = False
+
+        # Check through the wrapper
+        frozen = sum(p.numel() for p in wrapped.parameters() if not p.requires_grad)
+        assert frozen > 0


### PR DESCRIPTION
## Summary

Closes #692

- Add `freeze_encoder` parameter to `train_segmentation_model()` to freeze encoder weights during fine-tuning, so only the decoder is trained (reduces overfitting on small datasets)
- Reorder optimizer creation to come after checkpoint loading and encoder freezing, ensuring only trainable parameters are optimized
- Add "Fine-tuning (Optional)" group box to the QGIS plugin Train tab with:
  - Checkpoint file browser for selecting a pretrained `.pth` model
  - "Resume training" checkbox to restore optimizer/scheduler state
  - "Freeze encoder" checkbox to train decoder only
- Add checkpoint path validation and fine-tuning info logging in the GUI

The backend `checkpoint_path` and `resume_training` parameters already existed but were not exposed in the GUI. This PR wires them through and adds the new `freeze_encoder` capability.

## Test plan

- [ ] Train a model from scratch (no checkpoint) to verify no regressions
- [ ] Fine-tune from a checkpoint with `freeze_encoder=True` and verify encoder parameters are frozen
- [ ] Resume training from a checkpoint with `resume_training=True` and verify epoch/optimizer state is restored
- [ ] Verify the QGIS plugin Train tab shows the new Fine-tuning group with working file browser
- [ ] Verify checkpoint path validation rejects non-existent files