### PR TITLE
fix: pad undersized edge tiles in sliding-window inference

### DIFF
--- a/geoai/train.py
+++ b/geoai/train.py
@@ -2020,6 +2020,15 @@ def inference_on_geotiff(
                     current_height = window_size
                     current_width = window_size
 
+                # Pad window to window_size if needed (edge tiles may be smaller)
+                if current_height < window_size or current_width < window_size:
+                    padded_window = np.zeros(
+                        (window.shape[0], window_size, window_size),
+                        dtype=window.dtype,
+                    )
+                    padded_window[:, :current_height, :current_width] = window
+                    window = padded_window
+
                 # Normalize and prepare input
                 image = window.astype(np.float32) / 255.0
 
@@ -2028,7 +2037,7 @@ def inference_on_geotiff(
                     image = image[:num_channels]
                 elif image.shape[0] < num_channels:
                     padded = np.zeros(
-                        (num_channels, current_height, current_width), dtype=np.float32
+                        (num_channels, window_size, window_size), dtype=np.float32
                     )
                     padded[: image.shape[0]] = image
                     image = padded
@@ -2088,6 +2097,8 @@ def inference_on_geotiff(
                                 combined_mask = (
                                     combined_mask.cpu().numpy().astype(np.float32)
                                 )
+                                # Crop to actual tile dimensions
+                                combined_mask = combined_mask[:h, :w]
 
                                 # Apply weight to prediction
                                 weighted_pred = combined_mask * weight
@@ -2260,6 +2271,15 @@ def instance_segmentation_inference_on_geotiff(
                 # Handle edge cases where window might be smaller than expected
                 actual_height, actual_width = window.shape[1], window.shape[2]
 
+                # Pad window to window_size if needed (edge tiles may be smaller)
+                if actual_height < window_size or actual_width < window_size:
+                    padded_window = np.zeros(
+                        (window.shape[0], window_size, window_size),
+                        dtype=window.dtype,
+                    )
+                    padded_window[:, :actual_height, :actual_width] = window
+                    window = padded_window
+
                 # Convert to [C, H, W] format and normalize
                 image = window.astype(np.float32) / 255.0
 
@@ -2269,7 +2289,7 @@ def instance_segmentation_inference_on_geotiff(
                 elif image.shape[0] < num_channels:
                     # Pad with zeros if less than expected channels
                     padded = np.zeros(
-                        (num_channels, image.shape[1], image.shape[2]), dtype=np.float32
+                        (num_channels, window_size, window_size), dtype=np.float32
                     )
                     padded[: image.shape[0]] = image
                     image = padded
@@ -2307,6 +2327,12 @@ def instance_segmentation_inference_on_geotiff(
                                 score = scores[k].cpu().item()
                                 box = boxes[k].cpu().numpy()
                                 label = det_labels[k].cpu().item()
+
+                                # Skip detections centered in the padding region
+                                box_cx = (box[0] + box[2]) / 2
+                                box_cy = (box[1] + box[3]) / 2
+                                if box_cx >= w or box_cy >= h:
+                                    continue
 
                                 # Convert box to global coordinates
                                 global_box = [
@@ -4689,6 +4715,15 @@ def semantic_inference_on_geotiff(
                 current_height = window.shape[1]
                 current_width = window.shape[2]
 
+                # Pad window to window_size if needed (edge tiles may be smaller)
+                if current_height < window_size or current_width < window_size:
+                    padded_window = np.zeros(
+                        (window.shape[0], window_size, window_size),
+                        dtype=window.dtype,
+                    )
+                    padded_window[:, :current_height, :current_width] = window
+                    window = padded_window
+
                 # Normalize and prepare input
                 image = window.astype(np.float32) / 255.0
 
@@ -4697,7 +4732,7 @@ def semantic_inference_on_geotiff(
                     image = image[:num_channels]
                 elif image.shape[0] < num_channels:
                     padded = np.zeros(
-                        (num_channels, current_height, current_width), dtype=np.float32
+                        (num_channels, window_size, window_size), dtype=np.float32
                     )
                     padded[: image.shape[0]] = image
                     image = padded
@@ -4747,8 +4782,8 @@ def semantic_inference_on_geotiff(
                         if overlap == 0:
                             weight = np.ones_like(weight)
 
-                        # Convert probabilities to numpy [C, H, W]
-                        prob_np = prob.cpu().numpy()
+                        # Convert probabilities to numpy [C, H, W] - crop to actual size
+                        prob_np = prob.cpu().numpy()[:, :h, :w]
 
                         # Accumulate weighted probabilities for each class
                         y_slice = slice(y_pos, y_pos + h)

--- a/geoai/train.py
+++ b/geoai/train.py
@@ -1910,6 +1910,33 @@ def train_MaskRCNN_model(
     logger.info(f"Training complete! Trained model saved to {output_dir}")
 
 
+def _pad_window(
+    window: np.ndarray,
+    window_size: int,
+) -> tuple:
+    """Pad an undersized edge tile to ``(C, window_size, window_size)``.
+
+    Args:
+        window: Array of shape ``(C, H, W)`` read from a raster window.
+        window_size: Target spatial size for the model input.
+
+    Returns:
+        A tuple ``(padded_window, actual_h, actual_w)`` where
+        ``padded_window`` has shape ``(C, window_size, window_size)`` and
+        ``actual_h``/``actual_w`` are the original spatial dimensions.
+    """
+    actual_h = window.shape[1]
+    actual_w = window.shape[2]
+    if actual_h < window_size or actual_w < window_size:
+        padded = np.zeros(
+            (window.shape[0], window_size, window_size),
+            dtype=window.dtype,
+        )
+        padded[:, :actual_h, :actual_w] = window
+        return padded, actual_h, actual_w
+    return window, actual_h, actual_w
+
+
 def inference_on_geotiff(
     model: torch.nn.Module,
     geotiff_path: str,
@@ -2020,14 +2047,7 @@ def inference_on_geotiff(
                     current_height = window_size
                     current_width = window_size
 
-                # Pad window to window_size if needed (edge tiles may be smaller)
-                if current_height < window_size or current_width < window_size:
-                    padded_window = np.zeros(
-                        (window.shape[0], window_size, window_size),
-                        dtype=window.dtype,
-                    )
-                    padded_window[:, :current_height, :current_width] = window
-                    window = padded_window
+                window, current_height, current_width = _pad_window(window, window_size)
 
                 # Normalize and prepare input
                 image = window.astype(np.float32) / 255.0
@@ -2269,16 +2289,7 @@ def instance_segmentation_inference_on_geotiff(
                     continue
 
                 # Handle edge cases where window might be smaller than expected
-                actual_height, actual_width = window.shape[1], window.shape[2]
-
-                # Pad window to window_size if needed (edge tiles may be smaller)
-                if actual_height < window_size or actual_width < window_size:
-                    padded_window = np.zeros(
-                        (window.shape[0], window_size, window_size),
-                        dtype=window.dtype,
-                    )
-                    padded_window[:, :actual_height, :actual_width] = window
-                    window = padded_window
+                window, actual_height, actual_width = _pad_window(window, window_size)
 
                 # Convert to [C, H, W] format and normalize
                 image = window.astype(np.float32) / 255.0
@@ -2328,10 +2339,14 @@ def instance_segmentation_inference_on_geotiff(
                                 box = boxes[k].cpu().numpy()
                                 label = det_labels[k].cpu().item()
 
-                                # Skip detections centered in the padding region
-                                box_cx = (box[0] + box[2]) / 2
-                                box_cy = (box[1] + box[3]) / 2
-                                if box_cx >= w or box_cy >= h:
+                                # Clip box to actual tile dims and skip
+                                # if no area remains inside the real region
+                                box = box.copy()
+                                box[0] = np.clip(box[0], 0, w)
+                                box[1] = np.clip(box[1], 0, h)
+                                box[2] = np.clip(box[2], 0, w)
+                                box[3] = np.clip(box[3], 0, h)
+                                if box[2] <= box[0] or box[3] <= box[1]:
                                     continue
 
                                 # Convert box to global coordinates
@@ -4712,17 +4727,7 @@ def semantic_inference_on_geotiff(
                 if window.shape[1] == 0 or window.shape[2] == 0:
                     continue
 
-                current_height = window.shape[1]
-                current_width = window.shape[2]
-
-                # Pad window to window_size if needed (edge tiles may be smaller)
-                if current_height < window_size or current_width < window_size:
-                    padded_window = np.zeros(
-                        (window.shape[0], window_size, window_size),
-                        dtype=window.dtype,
-                    )
-                    padded_window[:, :current_height, :current_width] = window
-                    window = padded_window
+                window, current_height, current_width = _pad_window(window, window_size)
 
                 # Normalize and prepare input
                 image = window.astype(np.float32) / 255.0
@@ -5030,16 +5035,7 @@ def semantic_inference_on_image(
                 if window.shape[1] == 0 or window.shape[2] == 0:
                     continue
 
-                current_height = window.shape[1]
-                current_width = window.shape[2]
-
-                # Pad window to window_size if needed
-                if current_height < window_size or current_width < window_size:
-                    padded_window = np.zeros(
-                        (window.shape[0], window_size, window_size), dtype=window.dtype
-                    )
-                    padded_window[:, :current_height, :current_width] = window
-                    window = padded_window
+                window, current_height, current_width = _pad_window(window, window_size)
 
                 # Normalize and prepare input
                 image = window.astype(np.float32) / 255.0

--- a/tests/test_pad_window.py
+++ b/tests/test_pad_window.py
@@ -1,0 +1,75 @@
+"""Tests for _pad_window helper and edge-tile padding in inference functions."""
+
+import numpy as np
+import pytest
+
+from geoai.train import _pad_window
+
+
+class TestPadWindow:
+    """Tests for the _pad_window helper function."""
+
+    def test_no_padding_when_full_size(self):
+        window = np.ones((3, 256, 256), dtype=np.uint8)
+        result, h, w = _pad_window(window, 256)
+        assert result.shape == (3, 256, 256)
+        assert h == 256
+        assert w == 256
+        np.testing.assert_array_equal(result, window)
+
+    def test_pads_smaller_height(self):
+        window = np.ones((3, 100, 256), dtype=np.uint8)
+        result, h, w = _pad_window(window, 256)
+        assert result.shape == (3, 256, 256)
+        assert h == 100
+        assert w == 256
+        # Original data preserved in top-left
+        np.testing.assert_array_equal(result[:, :100, :256], 1)
+        # Padded region is zero
+        np.testing.assert_array_equal(result[:, 100:, :], 0)
+
+    def test_pads_smaller_width(self):
+        window = np.ones((3, 256, 100), dtype=np.uint8)
+        result, h, w = _pad_window(window, 256)
+        assert result.shape == (3, 256, 256)
+        assert h == 256
+        assert w == 100
+        np.testing.assert_array_equal(result[:, :256, :100], 1)
+        np.testing.assert_array_equal(result[:, :, 100:], 0)
+
+    def test_pads_both_dimensions(self):
+        window = np.ones((3, 80, 120), dtype=np.float32)
+        result, h, w = _pad_window(window, 256)
+        assert result.shape == (3, 256, 256)
+        assert h == 80
+        assert w == 120
+        np.testing.assert_array_equal(result[:, :80, :120], 1)
+        np.testing.assert_array_equal(result[:, 80:, :], 0)
+        np.testing.assert_array_equal(result[:, :, 120:], 0)
+
+    def test_preserves_dtype(self):
+        for dtype in [np.uint8, np.float32, np.float64]:
+            window = np.ones((3, 50, 50), dtype=dtype)
+            result, _, _ = _pad_window(window, 256)
+            assert result.dtype == dtype
+
+    def test_single_channel(self):
+        window = np.ones((1, 64, 128), dtype=np.float32)
+        result, h, w = _pad_window(window, 256)
+        assert result.shape == (1, 256, 256)
+        assert h == 64
+        assert w == 128
+
+    def test_non_square_input_one_dim_smaller(self):
+        window = np.ones((3, 256, 100), dtype=np.uint8)
+        result, h, w = _pad_window(window, 256)
+        # Height == window_size but width < window_size
+        assert result.shape == (3, 256, 256)
+        assert h == 256
+        assert w == 100
+
+    def test_returns_same_array_when_no_padding_needed(self):
+        window = np.ones((3, 256, 256), dtype=np.uint8)
+        result, h, w = _pad_window(window, 256)
+        # Should return the original array (not a copy)
+        assert result is window


### PR DESCRIPTION
## Summary

Closes #696

- Add zero-padding for undersized edge tiles in `semantic_inference_on_geotiff`, `inference_on_geotiff`, and `object_detection_inference_on_geotiff`
- Crop model output back to actual tile dimensions before accumulating into the output array
- Filter spurious object detections that fall in the zero-padded region

## Test plan

- [x] All 1166 existing tests pass
- [x] Pre-commit hooks pass
- [ ] Manual test with a non-square Sentinel-2 clip where one dimension is smaller than `window_size`