### PR TITLE
fix: orient rasterio-loaded images upright in FTW/training-tile display

### DIFF
--- a/geoai/ftw.py
+++ b/geoai/ftw.py
@@ -432,11 +432,11 @@ def display_ftw_samples(
         with rasterio.open(mask_path) as src:
             mask = src.read(1)
 
-        axes[0, i].imshow(img)
+        axes[0, i].imshow(img, origin="lower")
         axes[0, i].set_title(f"Image {i + 1}")
         axes[0, i].axis("off")
 
-        axes[1, i].imshow(mask, cmap=cmap, interpolation="nearest")
+        axes[1, i].imshow(mask, cmap=cmap, interpolation="nearest", origin="lower")
         axes[1, i].set_title(f"Mask {i + 1}")
         axes[1, i].axis("off")
 

--- a/geoai/utils/visualization.py
+++ b/geoai/utils/visualization.py
@@ -932,10 +932,14 @@ def display_training_tiles(
         with rasterio.open(image_path) as src:
             if show_axes:
                 data = src.read()
+                # Pick imshow origin from the affine transform so south-up
+                # rasters (positive y-scale, e.g. FTW Sentinel-2 chips) are
+                # not displayed upside down.
+                origin = "lower" if src.transform.e > 0 else "upper"
                 if data.shape[0] >= 3:
-                    axes[0, idx].imshow(data[:3].transpose(1, 2, 0))
+                    axes[0, idx].imshow(data[:3].transpose(1, 2, 0), origin=origin)
                 else:
-                    axes[0, idx].imshow(data[0])
+                    axes[0, idx].imshow(data[0], origin=origin)
             else:
                 show(src, ax=axes[0, idx])
         axes[0, idx].set_title(f"Image {idx+1}")
@@ -948,7 +952,8 @@ def display_training_tiles(
             with rasterio.open(mask_path) as src:
                 if show_axes:
                     data = src.read(1)
-                    axes[1, idx].imshow(data, cmap=cmap)
+                    origin = "lower" if src.transform.e > 0 else "upper"
+                    axes[1, idx].imshow(data, cmap=cmap, origin=origin)
                 else:
                     show(src, ax=axes[1, idx], cmap=cmap)
         else:

--- a/tests/test_display_training_tiles_origin.py
+++ b/tests/test_display_training_tiles_origin.py
@@ -1,0 +1,84 @@
+"""Tests for orientation-aware ``imshow`` origin in ``display_training_tiles``.
+
+Issue #703: south-up rasters (positive y-scale in the affine transform) were
+being rendered upside-down because ``imshow`` defaulted to ``origin='upper'``.
+``display_training_tiles`` now derives ``origin`` from ``src.transform.e`` in
+the ``show_axes=True`` branch. These tests pin that behavior for both image
+and mask paths in both orientations.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")  # Headless backend so plt.show is a no-op in CI.
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import Affine
+
+from geoai.utils.visualization import display_training_tiles
+
+
+def _write_tile(path, data, transform):
+    """Write a small single-tile GeoTIFF used as a fixture.
+
+    Args:
+        path: Destination path for the GeoTIFF.
+        data: Array of shape (bands, H, W).
+        transform: Rasterio affine transform.
+    """
+    bands, height, width = data.shape
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=height,
+        width=width,
+        count=bands,
+        dtype=data.dtype,
+        transform=transform,
+        crs="EPSG:4326",
+    ) as dst:
+        dst.write(data)
+
+
+def _build_tile_pair(output_dir, transform):
+    """Create one image tile and matching mask tile under ``output_dir``."""
+    images_dir = output_dir / "images"
+    masks_dir = output_dir / "masks"
+    images_dir.mkdir()
+    masks_dir.mkdir()
+
+    image = np.random.randint(0, 255, size=(3, 8, 8), dtype=np.uint8)
+    mask = np.random.randint(0, 2, size=(1, 8, 8), dtype=np.uint8)
+
+    _write_tile(images_dir / "tile.tif", image, transform)
+    _write_tile(masks_dir / "tile.tif", mask, transform)
+
+
+# Affine ordering: (a, b, c, d, e, f) with ``e`` as the y-scale.
+# Non-zero translations keep GDAL from warning the matrix is identity-like.
+NORTH_UP = Affine(1.0, 0.0, 100.0, 0.0, -1.0, 208.0)  # e < 0
+SOUTH_UP = Affine(1.0, 0.0, 100.0, 0.0, 1.0, 200.0)  # e > 0
+
+
+@pytest.mark.parametrize(
+    "transform,expected_origin",
+    [(NORTH_UP, "upper"), (SOUTH_UP, "lower")],
+)
+def test_display_training_tiles_origin_matches_transform(
+    tmp_path, transform, expected_origin
+):
+    """Both image and mask imshow calls pick origin from the affine y-scale."""
+    _build_tile_pair(tmp_path, transform)
+
+    fig, axes = display_training_tiles(str(tmp_path), num_tiles=1, show_axes=True)
+    try:
+        image_axes_image = axes[0, 0].get_images()[0]
+        mask_axes_image = axes[1, 0].get_images()[0]
+
+        assert image_axes_image.origin == expected_origin
+        assert mask_axes_image.origin == expected_origin
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
## Summary
- `display_ftw_samples` and the `show_axes=True` branch of `display_training_tiles` were calling `matplotlib.imshow` without an explicit `origin`. South-up GeoTIFFs (e.g. FTW Sentinel-2 chips, whose affine `e` term is positive) therefore rendered vertically flipped.
- For `display_ftw_samples` (FTW-specific, consistently south-up), pass `origin="lower"` directly — matching the reporter's suggested fix.
- For `display_training_tiles` (generic, used with both FTW chips and north-up tiles from `export_geotiff_tiles`), derive `origin` from `src.transform.e` so south-up rasters render upright without regressing the common north-up case.
- The `show_axes=False` branch already routes through `rasterio.plot.show`, which respects the affine transform — left untouched.

Closes #703

## Test plan
- [ ] `geoai.display_ftw_samples("ftw_data", country="luxembourg", num_samples=4)` from `docs/examples/field_boundary_detection.ipynb` shows Sentinel-2 imagery and instance masks right-side up.
- [ ] `geoai.display_training_tiles(...)` against FTW tiles renders right-side up.
- [ ] `geoai.display_training_tiles(...)` against tiles from `geoai.export_geotiff_tiles` (north-up) still renders right-side up — no regression.
- [ ] `show_axes=False` path is visually unchanged.
- [ ] `pre-commit run --all-files` passes.