### PR TITLE
fix: qualify remaining short-form Qt enums for PyQt6 (#715)

### DIFF
--- a/qgis_plugin/geoai/dialogs/deepforest_panel.py
+++ b/qgis_plugin/geoai/dialogs/deepforest_panel.py
@@ -581,7 +581,9 @@ class DeepForestDockWidget(QDockWidget):
         super().__init__("Tree Segmentation", parent)
         self.iface = iface
         self.canvas = iface.mapCanvas()
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         # DeepForest model instance
         self.deepforest = None
@@ -610,7 +612,7 @@ class DeepForestDockWidget(QDockWidget):
         # Main widget with scroll area
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
         main_widget = QWidget()
         main_layout = QVBoxLayout()

--- a/qgis_plugin/geoai/dialogs/deps_install_dialog.py
+++ b/qgis_plugin/geoai/dialogs/deps_install_dialog.py
@@ -42,7 +42,9 @@ class DepsInstallDockWidget(QDockWidget):
         """
         super().__init__("GeoAI - Setup", parent)
         self.setObjectName("GeoAIDepsInstallDock")
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         container = QWidget()
         layout = QVBoxLayout(container)

--- a/qgis_plugin/geoai/dialogs/instance_segmentation.py
+++ b/qgis_plugin/geoai/dialogs/instance_segmentation.py
@@ -378,7 +378,9 @@ class InstanceSegmentationDockWidget(QDockWidget):
         self.smooth_worker = None
         self.last_output_path = None
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
         self.setup_ui()
         self.connect_signals()
 
@@ -397,7 +399,9 @@ class InstanceSegmentationDockWidget(QDockWidget):
         # Top part: scrollable tabs
         self.scroll_area = QScrollArea()
         self.scroll_area.setWidgetResizable(True)
-        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.scroll_area.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
 
         tab_container = QWidget()
         tab_layout = QVBoxLayout()

--- a/qgis_plugin/geoai/dialogs/map_tools.py
+++ b/qgis_plugin/geoai/dialogs/map_tools.py
@@ -29,7 +29,7 @@ class PointPromptTool(QgsMapTool):
         self.markers = []
 
         # Set cursor
-        self.setCursor(Qt.CrossCursor)
+        self.setCursor(Qt.CursorShape.CrossCursor)
 
     def set_foreground(self, foreground):
         """Set whether we're adding foreground or background points."""
@@ -41,7 +41,7 @@ class PointPromptTool(QgsMapTool):
 
     def canvasReleaseEvent(self, event):
         """Handle mouse release event - add a point."""
-        if event.button() == Qt.LeftButton:
+        if event.button() == Qt.MouseButton.LeftButton:
             point = self.toMapCoordinates(event.pos())
 
             # Add visual marker
@@ -65,7 +65,7 @@ class PointPromptTool(QgsMapTool):
             else:
                 self.plugin.add_point(point, self.is_foreground)
 
-        elif event.button() == Qt.RightButton:
+        elif event.button() == Qt.MouseButton.RightButton:
             # Right-click to finish
             self.deactivate()
             if self.batch_mode:
@@ -111,11 +111,11 @@ class BoxPromptTool(QgsMapTool):
         self.is_drawing = False
 
         # Set cursor
-        self.setCursor(Qt.CrossCursor)
+        self.setCursor(Qt.CursorShape.CrossCursor)
 
     def canvasPressEvent(self, event):
         """Handle mouse press event - start drawing."""
-        if event.button() == Qt.LeftButton:
+        if event.button() == Qt.MouseButton.LeftButton:
             self.start_point = self.toMapCoordinates(event.pos())
             self.is_drawing = True
             self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
@@ -128,7 +128,7 @@ class BoxPromptTool(QgsMapTool):
 
     def canvasReleaseEvent(self, event):
         """Handle mouse release event - finish drawing."""
-        if event.button() == Qt.LeftButton and self.is_drawing:
+        if event.button() == Qt.MouseButton.LeftButton and self.is_drawing:
             end_point = self.toMapCoordinates(event.pos())
             self.is_drawing = False
 
@@ -145,7 +145,7 @@ class BoxPromptTool(QgsMapTool):
             self.deactivate()
             self.plugin.draw_box_btn.setChecked(False)
 
-        elif event.button() == Qt.RightButton:
+        elif event.button() == Qt.MouseButton.RightButton:
             # Right-click to cancel
             self.is_drawing = False
             self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)

--- a/qgis_plugin/geoai/dialogs/moondream.py
+++ b/qgis_plugin/geoai/dialogs/moondream.py
@@ -158,7 +158,9 @@ class MoondreamDockWidget(QDockWidget):
         self.worker = None
         self.model_load_worker = None
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
         self.setup_ui()
         self.connect_signals()
 
@@ -167,7 +169,7 @@ class MoondreamDockWidget(QDockWidget):
         # Main widget with scroll area
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
-        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
         main_widget = QWidget()
         layout = QVBoxLayout()

--- a/qgis_plugin/geoai/dialogs/samgeo.py
+++ b/qgis_plugin/geoai/dialogs/samgeo.py
@@ -176,7 +176,9 @@ class SamGeoDockWidget(QDockWidget):
         super().__init__("Segment Anything", parent)
         self.iface = iface
         self.canvas = iface.mapCanvas()
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         # SamGeo model instance
         self.sam = None
@@ -211,7 +213,7 @@ class SamGeoDockWidget(QDockWidget):
         # Main widget with scroll area
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
         main_widget = QWidget()
         main_layout = QVBoxLayout()

--- a/qgis_plugin/geoai/dialogs/segmentation.py
+++ b/qgis_plugin/geoai/dialogs/segmentation.py
@@ -411,7 +411,9 @@ class SegmentationDockWidget(QDockWidget):
         self.smooth_worker = None
         self.last_output_path = None
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
         self.setup_ui()
         self.connect_signals()
 
@@ -427,7 +429,7 @@ class SegmentationDockWidget(QDockWidget):
         # Main scroll area
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
-        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
         main_widget = QWidget()
         layout = QVBoxLayout()

--- a/qgis_plugin/geoai/dialogs/water_segmentation.py
+++ b/qgis_plugin/geoai/dialogs/water_segmentation.py
@@ -206,7 +206,9 @@ class WaterSegmentationDockWidget(QDockWidget):
         super().__init__("Water Segmentation", parent)
         self.iface = iface
         self.canvas = iface.mapCanvas()
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         self.worker = None
         self._temp_files = []
@@ -217,7 +219,7 @@ class WaterSegmentationDockWidget(QDockWidget):
         """Set up the user interface."""
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
         main_widget = QWidget()
         main_layout = QVBoxLayout()

--- a/qgis_plugin/geoai/geoai_plugin.py
+++ b/qgis_plugin/geoai/geoai_plugin.py
@@ -345,7 +345,7 @@ class GeoAIPlugin:
         self._deps_dock.install_requested.connect(self._on_install_requested)
         self._deps_dock.cancel_requested.connect(self._on_cancel_install)
 
-        self.iface.addDockWidget(Qt.RightDockWidgetArea, self._deps_dock)
+        self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self._deps_dock)
         self._deps_dock.show()
         self._deps_dock.raise_()
 
@@ -442,7 +442,9 @@ class GeoAIPlugin:
                 self._moondream_dock.visibilityChanged.connect(
                     self._on_moondream_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._moondream_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._moondream_dock
+                )
                 self._moondream_dock.show()
                 self._moondream_dock.raise_()
                 return
@@ -484,7 +486,7 @@ class GeoAIPlugin:
                     self._on_segmentation_visibility_changed
                 )
                 self.iface.addDockWidget(
-                    Qt.RightDockWidgetArea, self._segmentation_dock
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._segmentation_dock
                 )
                 self._segmentation_dock.show()
                 self._segmentation_dock.raise_()
@@ -526,7 +528,9 @@ class GeoAIPlugin:
                 self._samgeo_dock.visibilityChanged.connect(
                     self._on_samgeo_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._samgeo_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._samgeo_dock
+                )
                 self._samgeo_dock.show()
                 self._samgeo_dock.raise_()
                 return
@@ -567,7 +571,9 @@ class GeoAIPlugin:
                 self._deepforest_dock.visibilityChanged.connect(
                     self._on_deepforest_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._deepforest_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._deepforest_dock
+                )
                 self._deepforest_dock.show()
                 self._deepforest_dock.raise_()
                 return
@@ -613,7 +619,7 @@ class GeoAIPlugin:
                     self._on_water_segmentation_visibility_changed
                 )
                 self.iface.addDockWidget(
-                    Qt.RightDockWidgetArea, self._water_segmentation_dock
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._water_segmentation_dock
                 )
                 self._water_segmentation_dock.show()
                 self._water_segmentation_dock.raise_()
@@ -660,7 +666,8 @@ class GeoAIPlugin:
                     self._on_instance_segmentation_visibility_changed
                 )
                 self.iface.addDockWidget(
-                    Qt.RightDockWidgetArea, self._instance_segmentation_dock
+                    Qt.DockWidgetArea.RightDockWidgetArea,
+                    self._instance_segmentation_dock,
                 )
                 self._instance_segmentation_dock.show()
                 self._instance_segmentation_dock.raise_()

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.2.0
+version=1.2.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -59,6 +59,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.2.1
+        - Fix AttributeError on PyQt6 (#715): qualify remaining short-form Qt enums (DockWidgetArea, ScrollBarPolicy, CursorShape, MouseButton) missed in #707
     1.2.0
         - Qt5/Qt6 dual compatibility for QGIS 4.0
     1.1.0


### PR DESCRIPTION
## Summary

Fixes [#715](https://github.com/opengeos/geoai/issues/715), where the QGIS 4.0
plugin crashes with `AttributeError: type object 'Qt' has no attribute 'LeftDockWidgetArea'`
the moment a user clicks any tool button.

### Root cause

PR #707 (Qt5/Qt6 dual compatibility) qualified `AlignmentFlag`, `Orientation`,
`CheckState`, and `QMessageBox.StandardButton`, but missed four other enum
classes still referenced via short-form attributes:

| Short form | Qualified form | Sites |
| --- | --- | --- |
| `Qt.LeftDockWidgetArea` / `Qt.RightDockWidgetArea` | `Qt.DockWidgetArea.<X>` | 14 |
| `Qt.ScrollBarAlwaysOff` | `Qt.ScrollBarPolicy.ScrollBarAlwaysOff` | 6 |
| `Qt.CrossCursor` | `Qt.CursorShape.CrossCursor` | 2 |
| `Qt.LeftButton` / `Qt.RightButton` | `Qt.MouseButton.<X>` | 5 |

These all live in method bodies (`__init__`, mouse event handlers), so the
PyQt6 import-smoke test added in #707 — which only catches class-body
regressions — passed cleanly while the plugin still crashed at runtime.

### Fix

Qualify all 27 occurrences across 9 files using the same pattern #707
established. PyQt5 5.15+ accepts the qualified form, so dual Qt5/Qt6
compatibility is preserved (no compat shim, no try/except imports).

Plugin version bumped to 1.2.1.

## Test plan

- [x] Static check: `grep -rE 'Qt\.(Left|Right|Top|Bottom)DockWidgetArea|Qt\.ScrollBarAlwaysOff|Qt\.CrossCursor|Qt\.(Left|Right|Mid)Button[^.]' qgis_plugin/geoai/` returns zero hits
- [x] PyQt6 import-smoke tests pass (29/29)
- [x] PyQt6 instantiation: `DepsInstallDockWidget()` constructs without `AttributeError` (the exact crash path from #715)
- [x] PyQt6 instantiation: `PointPromptTool` and `BoxPromptTool` construct without `AttributeError` (exercises `Qt.CursorShape.CrossCursor`)
- [x] All six new qualified enum members resolve under `PyQt6.QtCore.Qt`
- [x] `pre-commit run --all-files` passes (black, codespell, bandit, etc.)
- [ ] Issue #715 reporter to re-test on QGIS 4.0 / Windows once the next plugin release is available

## Follow-ups (not bundled here)

The import-smoke test could be extended to *instantiate* every dock widget,
which would catch this regression class. Worth a follow-up PR; kept out of
this one to keep it a focused bug fix.