### PR TITLE
fix: stream confusion matrix in val loop to prevent CPU OOM on large datasets

### DIFF
--- a/geoai/landcover_train.py
+++ b/geoai/landcover_train.py
@@ -1663,7 +1663,9 @@ def _train_with_custom_iou(
                 if stream_iou:
                     # Stream confusion matrix on GPU, accumulate on CPU.
                     # bool is a subclass of int; treat bool False as "no ignore".
-                    if isinstance(ignore_index, int) and not isinstance(ignore_index, bool):
+                    if isinstance(ignore_index, int) and not isinstance(
+                        ignore_index, bool
+                    ):
                         valid = targets != ignore_index
                         t_flat = targets[valid].to(torch.int64)
                         p_flat = preds[valid].to(torch.int64)
@@ -1698,9 +1700,7 @@ def _train_with_custom_iou(
             if isinstance(ignore_index, int) and not isinstance(ignore_index, bool):
                 if 0 <= ignore_index < num_classes:
                     present[ignore_index] = False
-            val_iou = (
-                iou_per_class[present].mean().item() if present.any() else 0.0
-            )
+            val_iou = iou_per_class[present].mean().item() if present.any() else 0.0
             iou_display = f"Val IoU: {val_iou:.4f}"
         else:
             # Concatenate all predictions and targets (legacy path for non-mean modes)

--- a/geoai/landcover_train.py
+++ b/geoai/landcover_train.py
@@ -1661,8 +1661,9 @@ def _train_with_custom_iou(
                 preds = torch.argmax(outputs, dim=1)
 
                 if stream_iou:
-                    # Stream confusion matrix on GPU, accumulate on CPU
-                    if isinstance(ignore_index, int):
+                    # Stream confusion matrix on GPU, accumulate on CPU.
+                    # bool is a subclass of int; treat bool False as "no ignore".
+                    if isinstance(ignore_index, int) and not isinstance(ignore_index, bool):
                         valid = targets != ignore_index
                         t_flat = targets[valid].to(torch.int64)
                         p_flat = preds[valid].to(torch.int64)
@@ -1693,6 +1694,10 @@ def _train_with_custom_iou(
                 denom > 0, tp / (denom + 1e-10), torch.zeros_like(tp)
             )
             present = denom > 0
+            # Exclude ignore_index from mean, matching landcover_iou(mode='mean') behaviour.
+            if isinstance(ignore_index, int) and not isinstance(ignore_index, bool):
+                if 0 <= ignore_index < num_classes:
+                    present[ignore_index] = False
             val_iou = (
                 iou_per_class[present].mean().item() if present.any() else 0.0
             )

--- a/geoai/landcover_train.py
+++ b/geoai/landcover_train.py
@@ -1630,8 +1630,21 @@ def _train_with_custom_iou(
         # ===== VALIDATION PHASE WITH CUSTOM IoU =====
         model.eval()
         val_loss = 0.0
-        all_preds = []
-        all_targets = []
+
+        # Map "standard" to "mean" for landcover_iou
+        iou_mode = "mean" if validation_iou_mode == "standard" else validation_iou_mode
+
+        # Streaming confusion matrix for "mean" mode avoids materializing the
+        # full validation set on CPU each epoch (root cause of OOM after epoch 1
+        # when training set grew). Other modes still need full tensors.
+        stream_iou = iou_mode == "mean"
+        conf = (
+            torch.zeros(num_classes, num_classes, dtype=torch.long)
+            if stream_iou
+            else None
+        )
+        all_preds = [] if not stream_iou else None
+        all_targets = [] if not stream_iou else None
 
         with torch.no_grad():
             for images, targets in val_loader:
@@ -1645,33 +1658,52 @@ def _train_with_custom_iou(
                     loss = criterion(outputs, targets)
                 val_loss += loss.item()
 
-                # Collect predictions and targets for custom IoU
-                # Keep argmax on GPU, only move final result to CPU
-                preds = torch.argmax(outputs, dim=1).cpu()
-                all_preds.append(preds)
-                all_targets.append(targets.cpu())
+                preds = torch.argmax(outputs, dim=1)
+
+                if stream_iou:
+                    # Stream confusion matrix on GPU, accumulate on CPU
+                    if isinstance(ignore_index, int):
+                        valid = targets != ignore_index
+                        t_flat = targets[valid].to(torch.int64)
+                        p_flat = preds[valid].to(torch.int64)
+                    else:
+                        t_flat = targets.reshape(-1).to(torch.int64)
+                        p_flat = preds.reshape(-1).to(torch.int64)
+                    # Clamp to valid class range to avoid out-of-bounds bincount
+                    t_flat = t_flat.clamp_(0, num_classes - 1)
+                    p_flat = p_flat.clamp_(0, num_classes - 1)
+                    idx = t_flat * num_classes + p_flat
+                    binc = torch.bincount(
+                        idx, minlength=num_classes * num_classes
+                    ).cpu()
+                    conf += binc.view(num_classes, num_classes).to(torch.long)
+                else:
+                    all_preds.append(preds.cpu())
+                    all_targets.append(targets.cpu())
 
         val_loss = val_loss / len(val_loader)
         val_losses.append(val_loss)
 
-        # Concatenate all predictions and targets
-        all_preds = torch.cat(all_preds, dim=0)
-        all_targets = torch.cat(all_targets, dim=0)
-
-        # Calculate IoU based on validation_iou_mode
-        # Map "standard" to "mean" for landcover_iou
-        iou_mode = "mean" if validation_iou_mode == "standard" else validation_iou_mode
-
-        if iou_mode == "mean":
-            # Standard mean IoU
-            val_iou = landcover_iou(
-                pred=all_preds,
-                target=all_targets,
-                num_classes=num_classes,
-                ignore_index=ignore_index,
-                mode="mean",
+        if stream_iou:
+            tp = conf.diag().to(torch.float64)
+            fp = conf.sum(0).to(torch.float64) - tp
+            fn = conf.sum(1).to(torch.float64) - tp
+            denom = tp + fp + fn
+            iou_per_class = torch.where(
+                denom > 0, tp / (denom + 1e-10), torch.zeros_like(tp)
+            )
+            present = denom > 0
+            val_iou = (
+                iou_per_class[present].mean().item() if present.any() else 0.0
             )
             iou_display = f"Val IoU: {val_iou:.4f}"
+        else:
+            # Concatenate all predictions and targets (legacy path for non-mean modes)
+            all_preds = torch.cat(all_preds, dim=0)
+            all_targets = torch.cat(all_targets, dim=0)
+
+        if stream_iou:
+            pass  # val_iou already computed above
 
         elif iou_mode == "perclass_frequency":
             # Per-class frequency weighted IoU

--- a/geoai/landcover_train.py
+++ b/geoai/landcover_train.py
@@ -1639,7 +1639,7 @@ def _train_with_custom_iou(
         # when training set grew). Other modes still need full tensors.
         stream_iou = iou_mode == "mean"
         conf = (
-            torch.zeros(num_classes, num_classes, dtype=torch.long)
+            torch.zeros(num_classes, num_classes, dtype=torch.long, device=device)
             if stream_iou
             else None
         )
@@ -1672,14 +1672,12 @@ def _train_with_custom_iou(
                     else:
                         t_flat = targets.reshape(-1).to(torch.int64)
                         p_flat = preds.reshape(-1).to(torch.int64)
-                    # Clamp to valid class range to avoid out-of-bounds bincount
+                    # preds (argmax) always in [0, num_classes-1]; clamp targets only
                     t_flat = t_flat.clamp_(0, num_classes - 1)
-                    p_flat = p_flat.clamp_(0, num_classes - 1)
                     idx = t_flat * num_classes + p_flat
-                    binc = torch.bincount(
+                    conf += torch.bincount(
                         idx, minlength=num_classes * num_classes
-                    ).cpu()
-                    conf += binc.view(num_classes, num_classes).to(torch.long)
+                    ).view(num_classes, num_classes)
                 else:
                     all_preds.append(preds.cpu())
                     all_targets.append(targets.cpu())
@@ -1688,6 +1686,7 @@ def _train_with_custom_iou(
         val_losses.append(val_loss)
 
         if stream_iou:
+            conf = conf.cpu()
             tp = conf.diag().to(torch.float64)
             fp = conf.sum(0).to(torch.float64) - tp
             fn = conf.sum(1).to(torch.float64) - tp


### PR DESCRIPTION
Fixes #717

## Summary

- Validation loop in `_train_with_custom_iou` accumulated the entire validation set as `int64` CPU tensors each epoch, causing 30–80 GB peak CPU RAM on large datasets and SIGKILL on HPC nodes at epoch 1 boundary.
- Replace with streaming confusion matrix (`O(num_classes²)` memory) for the default `validation_iou_mode='mean'` path.
- Non-mean modes (`perclass_frequency`, `boundary_weighted`, `sparse_labels`) retain existing behaviour.

## Changes

`geoai/landcover_train.py` — `_train_with_custom_iou` validation block:
- `stream_iou = (iou_mode == "mean")` gates the new path
- Per-batch: compute argmax on GPU, stream into `num_classes×num_classes` confusion matrix on CPU
- mIoU from conf matrix diag: `tp / (tp + fp + fn)`, averaged over present classes
- Guard `isinstance(ignore_index, bool)` — `False` (no-ignore) must not be treated as class 0
- Exclude `ignore_index` from `present` averaging mask to match `landcover_iou(mode='mean')`

## Test plan

- [x] Training on 50k+ tile dataset with `--mem=64G` SLURM node — epoch 1 completes without SIGKILL
- [x] `seff <jobid>` MaxRSS stays < 30 GB regardless of dataset size
- [x] Streaming mIoU matches `landcover_iou(mode='mean')` on small dataset (with and without ignore_index)
- [x] Existing modes (`perclass_frequency`, `boundary_weighted`, `sparse_labels`) unaffected