### PR TITLE
fix: keep GeoAI plugin actions in plugin menu on macOS

### DIFF
--- a/qgis_plugin/geoai/geoai_plugin.py
+++ b/qgis_plugin/geoai/geoai_plugin.py
@@ -71,6 +71,7 @@ class GeoAIPlugin:
         """
         icon = QIcon(icon_path)
         action = QAction(icon, text, parent)
+        self._disable_application_menu_role(action)
         action.triggered.connect(callback)
         action.setEnabled(enabled_flag)
         action.setCheckable(checkable)
@@ -87,6 +88,15 @@ class GeoAIPlugin:
         self.actions.append(action)
 
         return action
+
+    @staticmethod
+    def _disable_application_menu_role(action):
+        """Keep plugin actions in the GeoAI menu on macOS."""
+        try:
+            no_role = QAction.MenuRole.NoRole
+        except AttributeError:
+            no_role = QAction.NoRole
+        action.setMenuRole(no_role)
 
     def initGui(self):
         """Create the menu entries and toolbar icons inside the QGIS GUI."""

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.2.1
+version=1.2.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -59,6 +59,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.2.2
+        - Fix macOS About QGIS menu collision by keeping GeoAI actions out of the application menu (#723)
     1.2.1
         - Fix AttributeError on PyQt6 (#715): qualify remaining short-form Qt enums (DockWidgetArea, ScrollBarPolicy, CursorShape, MouseButton) missed in #707
     1.2.0

--- a/qgis_plugin/tests/conftest.py
+++ b/qgis_plugin/tests/conftest.py
@@ -12,10 +12,13 @@ to the plugin package (``qgis_plugin/geoai``) instead of the unrelated
 top-level library package at the repo root.
 """
 
+import os
 import pathlib
 import sys
 import types
 from unittest.mock import MagicMock
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 PLUGIN_PARENT = pathlib.Path(__file__).resolve().parent.parent
 if str(PLUGIN_PARENT) in sys.path:

--- a/qgis_plugin/tests/test_plugin_menu.py
+++ b/qgis_plugin/tests/test_plugin_menu.py
@@ -1,0 +1,47 @@
+from qgis.PyQt.QtWidgets import QApplication, QMainWindow, QAction
+
+from geoai.geoai_plugin import GeoAIPlugin
+
+
+class FakeIface:
+    def __init__(self):
+        self._main_window = QMainWindow()
+
+    def mainWindow(self):
+        return self._main_window
+
+    def addToolBar(self, toolbar):
+        self._main_window.addToolBar(toolbar)
+
+    def removePluginMenu(self, _menu, _action):
+        pass
+
+    def removeDockWidget(self, dock_widget):
+        self._main_window.removeDockWidget(dock_widget)
+
+
+def _no_menu_role():
+    try:
+        return QAction.MenuRole.NoRole
+    except AttributeError:
+        return QAction.NoRole
+
+
+def test_plugin_actions_stay_out_of_application_menu():
+    app = QApplication.instance() or QApplication([])
+    iface = FakeIface()
+    plugin = GeoAIPlugin(iface)
+
+    try:
+        plugin.initGui()
+
+        about_actions = [
+            action for action in plugin.actions if action.text() == "About GeoAI"
+        ]
+        assert len(about_actions) == 1
+        assert about_actions[0].menuRole() == _no_menu_role()
+        assert all(action.menuRole() == _no_menu_role() for action in plugin.actions)
+    finally:
+        plugin.unload()
+        iface.mainWindow().close()
+        app.processEvents()


### PR DESCRIPTION
## Summary
- Force `MenuRole.NoRole` on every QAction created by the plugin so macOS does not relocate entries like "About GeoAI" into the application menu.
- Add a headless Qt test that exercises `initGui()` and asserts every plugin action keeps `NoRole`.
- Default `QT_QPA_PLATFORM=offscreen` in the test conftest so the suite runs without a display.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] Load the plugin in QGIS on macOS and confirm "About GeoAI" stays under the GeoAI menu instead of moving to the application menu.
- [ ] `pytest qgis_plugin/tests/test_plugin_menu.py` in an environment with PyQt available.