### PR TITLE
fix(mcp-server): use correct GroundedSAM API for text-prompted segmentation

### DIFF
--- a/geoai-mcp-server/src/geoai_mcp_server/schemas/tool_schemas.py
+++ b/geoai-mcp-server/src/geoai_mcp_server/schemas/tool_schemas.py
@@ -141,7 +141,7 @@ class SegmentObjectsInput(BaseModel):
         default=1024,
         description="Size of tiles for processing large images. Larger tiles use more memory but "
         "may produce better results.",
-        ge=256,
+        ge=512,
         le=4096,
     )
     output_filename: Optional[str] = Field(

--- a/geoai-mcp-server/src/geoai_mcp_server/server.py
+++ b/geoai-mcp-server/src/geoai_mcp_server/server.py
@@ -194,64 +194,45 @@ async def segment_objects_with_prompts(
         logger.info(f"Segmenting objects in {full_input_path} with prompts: {prompts}")
 
         # Import GeoAI modules
-        sam_module = _get_geoai_module("sam")
+        segment_module = _get_geoai_module("segment")
 
         # Initialize model based on selection
-        if model in ("grounded_sam", "auto"):
-            # Try GroundedSAM first for text prompts
-            try:
-                segmenter = sam_module.SamGeo(
-                    model_type="vit_h",
-                    checkpoint=None,  # Uses default
-                )
-                # Use text prompts for segmentation
-                segmenter.set_image(str(full_input_path))
-                masks = segmenter.predict_with_text(
-                    text_prompts=prompts,
-                    box_threshold=confidence_threshold,
-                    text_threshold=confidence_threshold,
-                )
-            except Exception as e:
-                logger.warning(f"GroundedSAM failed, falling back to CLIPSeg: {e}")
-                # Fallback to CLIPSeg
-                segment_module = _get_geoai_module("segment")
-                masks = segment_module.segment_with_text(
-                    str(full_input_path),
-                    prompts,
-                    threshold=confidence_threshold,
-                )
-        elif model == "clipseg":
-            segment_module = _get_geoai_module("segment")
-            masks = segment_module.segment_with_text(
-                str(full_input_path),
-                prompts,
+        if model in ("grounded_sam", "auto", "clipseg"):
+            # GroundedSAM: detector + SAM segmenter driven by text prompts
+            segmenter = segment_module.GroundedSAM(
                 threshold=confidence_threshold,
+                tile_size=input_data.tile_size,
             )
+            result = segmenter.segment_image(
+                input_path=str(full_input_path),
+                output_path=str(output_path),
+                text_prompts=prompts,
+                export_polygons=(input_data.output_format == OutputFormat.GEOJSON),
+                export_boxes=(input_data.output_format != OutputFormat.GEOJSON),
+            )
+            masks = result
         else:
-            # SAM with automatic prompt generation
+            # SAM without text prompts — automatic segmentation
+            sam_module = _get_geoai_module("sam")
             segmenter = sam_module.SamGeo(model_type="vit_h")
             segmenter.set_image(str(full_input_path))
 
-            # Always generate a raster mask first, then convert to vector if needed.
-            # Use a raster-friendly extension when the requested output is vector (e.g., GEOJSON).
             if input_data.output_format == OutputFormat.GEOJSON:
                 raster_output_path = output_path.with_suffix(".tif")
             else:
                 raster_output_path = output_path
 
             masks = segmenter.generate(output=str(raster_output_path))
-        # Save results
-        if input_data.output_format == OutputFormat.GEOJSON:
-            # Convert masks to vector
-            utils_module = _get_geoai_module("utils")
-            utils_module.raster_to_vector(
-                masks if isinstance(masks, str) else str(output_path),
-                str(output_path),
-            )
+
+            if input_data.output_format == OutputFormat.GEOJSON:
+                utils_module = _get_geoai_module("utils")
+                utils_module.raster_to_vector(str(raster_output_path), str(output_path))
 
         # Calculate statistics
         num_objects = 0
-        if hasattr(masks, "__len__"):
+        if isinstance(masks, dict):
+            num_objects = sum(len(v) if hasattr(v, "__len__") else 1 for v in masks.values())
+        elif hasattr(masks, "__len__"):
             num_objects = len(masks) if not isinstance(masks, str) else 1
 
         processing_time = time.time() - start_time

--- a/geoai-mcp-server/src/geoai_mcp_server/server.py
+++ b/geoai-mcp-server/src/geoai_mcp_server/server.py
@@ -231,7 +231,9 @@ async def segment_objects_with_prompts(
         # Calculate statistics
         num_objects = 0
         if isinstance(masks, dict):
-            num_objects = sum(len(v) if hasattr(v, "__len__") else 1 for v in masks.values())
+            num_objects = sum(
+                len(v) if hasattr(v, "__len__") else 1 for v in masks.values()
+            )
         elif hasattr(masks, "__len__"):
             num_objects = len(masks) if not isinstance(masks, str) else 1
 

--- a/geoai-mcp-server/src/geoai_mcp_server/server.py
+++ b/geoai-mcp-server/src/geoai_mcp_server/server.py
@@ -154,7 +154,7 @@ async def segment_objects_with_prompts(
         output_format: Output format - "geojson", "geotiff", "shapefile", "geopackage".
         model: Model to use - "sam", "sam2", "grounded_sam", "clipseg", "auto".
         confidence_threshold: Minimum confidence (0-1). Lower = more detections.
-        tile_size: Tile size for large images (256-4096 pixels).
+        tile_size: Tile size for large images (512-4096 pixels).
         output_filename: Custom output filename (optional).
 
     Returns:

--- a/geoai-mcp-server/src/geoai_mcp_server/server.py
+++ b/geoai-mcp-server/src/geoai_mcp_server/server.py
@@ -265,10 +265,18 @@ async def segment_objects_with_prompts(
 
         processing_time = time.time() - start_time
 
+        if isinstance(masks, dict):
+            output_files = list(masks.values())
+        elif isinstance(masks, str):
+            # CLIPSeg returns the path it actually wrote; use it directly.
+            output_files = [masks]
+        else:
+            output_files = [str(output_path)]
+
         return SegmentationResult(
             success=True,
             message=f"Successfully segmented objects matching {prompts}",
-            output_files=[str(output_path)],
+            output_files=output_files,
             processing_time_seconds=processing_time,
             num_objects=num_objects,
             classes_found=prompts,

--- a/geoai-mcp-server/src/geoai_mcp_server/server.py
+++ b/geoai-mcp-server/src/geoai_mcp_server/server.py
@@ -196,14 +196,17 @@ async def segment_objects_with_prompts(
         # Initialize model based on selection
         if model in ("grounded_sam", "auto"):
             # GroundedSAM: detector + SAM segmenter driven by text prompts
+            # segment_image() always writes a GeoTIFF and derives vector sidecars
+            # by replacing ".tif" in the path, so the raster path must end in .tif.
             segment_module = _get_geoai_module("segment")
+            raster_path = output_path.with_suffix(".tif")
             segmenter = segment_module.GroundedSAM(
                 threshold=confidence_threshold,
                 tile_size=input_data.tile_size,
             )
             result = segmenter.segment_image(
                 input_path=str(full_input_path),
-                output_path=str(output_path),
+                output_path=str(raster_path),
                 text_prompts=prompts,
                 export_polygons=(input_data.output_format == OutputFormat.GEOJSON),
                 export_boxes=(input_data.output_format != OutputFormat.GEOJSON),

--- a/geoai-mcp-server/src/geoai_mcp_server/server.py
+++ b/geoai-mcp-server/src/geoai_mcp_server/server.py
@@ -193,12 +193,10 @@ async def segment_objects_with_prompts(
 
         logger.info(f"Segmenting objects in {full_input_path} with prompts: {prompts}")
 
-        # Import GeoAI modules
-        segment_module = _get_geoai_module("segment")
-
         # Initialize model based on selection
-        if model in ("grounded_sam", "auto", "clipseg"):
+        if model in ("grounded_sam", "auto"):
             # GroundedSAM: detector + SAM segmenter driven by text prompts
+            segment_module = _get_geoai_module("segment")
             segmenter = segment_module.GroundedSAM(
                 threshold=confidence_threshold,
                 tile_size=input_data.tile_size,
@@ -211,6 +209,24 @@ async def segment_objects_with_prompts(
                 export_boxes=(input_data.output_format != OutputFormat.GEOJSON),
             )
             masks = result
+        elif model == "clipseg":
+            # CLIPSegmentation accepts a single text prompt; join multiple prompts
+            segment_module = _get_geoai_module("segment")
+            segmenter = segment_module.CLIPSegmentation(
+                tile_size=input_data.tile_size,
+            )
+            text_prompt = ", ".join(prompts)
+            raster_path = output_path.with_suffix(".tif")
+            masks = segmenter.segment_image(
+                input_path=str(full_input_path),
+                output_path=str(raster_path),
+                text_prompt=text_prompt,
+                threshold=confidence_threshold,
+            )
+            if input_data.output_format == OutputFormat.GEOJSON:
+                utils_module = _get_geoai_module("utils")
+                utils_module.raster_to_vector(str(raster_path), str(output_path))
+                masks = str(output_path)
         else:
             # SAM without text prompts — automatic segmentation
             sam_module = _get_geoai_module("sam")

--- a/geoai-mcp-server/src/geoai_mcp_server/server.py
+++ b/geoai-mcp-server/src/geoai_mcp_server/server.py
@@ -250,11 +250,18 @@ async def segment_objects_with_prompts(
         # Calculate statistics
         num_objects = 0
         if isinstance(masks, dict):
-            num_objects = sum(
-                len(v) if hasattr(v, "__len__") else 1 for v in masks.values()
-            )
-        elif hasattr(masks, "__len__"):
-            num_objects = len(masks) if not isinstance(masks, str) else 1
+            # GroundedSAM returns a dict of output file paths, not mask arrays.
+            # Count actual detected objects from the vector sidecar if present.
+            import geopandas as gpd
+
+            count_file = masks.get("polygons") or masks.get("boxes")
+            if count_file:
+                try:
+                    num_objects = len(gpd.read_file(count_file))
+                except Exception:
+                    pass
+        elif hasattr(masks, "__len__") and not isinstance(masks, str):
+            num_objects = len(masks)
 
         processing_time = time.time() - start_time
 

--- a/geoai-mcp-server/tests/test_server.py
+++ b/geoai-mcp-server/tests/test_server.py
@@ -46,6 +46,93 @@ class TestSegmentationTools:
             assert "not found" in result["message"].lower()
 
 
+    @pytest.mark.asyncio
+    async def test_segment_objects_grounded_sam_success(
+        self, sample_geotiff, temp_output_dir
+    ):
+        """GroundedSAM path: output_files lists all result files; num_objects reflects detected count."""
+        from geoai_mcp_server.server import segment_objects_with_prompts
+
+        raster_path = temp_output_dir / "sample_segmented.tif"
+        polygons_path = temp_output_dir / "sample_segmented_polygons.geojson"
+
+        fake_result = {
+            "segmentation": str(raster_path),
+            "polygons": str(polygons_path),
+        }
+
+        mock_segmenter = MagicMock()
+        mock_segmenter.segment_image.return_value = fake_result
+        mock_segment = MagicMock()
+        mock_segment.GroundedSAM.return_value = mock_segmenter
+
+        mock_gdf = MagicMock()
+        mock_gdf.__len__ = MagicMock(return_value=3)
+
+        with (
+            patch("geoai_mcp_server.server.config") as mock_config,
+            patch(
+                "geoai_mcp_server.server._get_geoai_module",
+                return_value=mock_segment,
+            ),
+            patch("geopandas.read_file", return_value=mock_gdf),
+        ):
+            mock_config.input_dir = sample_geotiff.parent
+            mock_config.output_dir = temp_output_dir
+
+            result = await segment_objects_with_prompts(
+                image_path=sample_geotiff.name,
+                prompts=["building"],
+                model="grounded_sam",
+                output_format="geojson",
+            )
+
+        assert result["success"] is True
+        assert str(raster_path) in result["output_files"]
+        assert str(polygons_path) in result["output_files"]
+        assert result["num_objects"] == 3
+
+    @pytest.mark.asyncio
+    async def test_segment_objects_clipseg_uses_clipsegmentation(
+        self, sample_geotiff, temp_output_dir
+    ):
+        """model='clipseg' routes to CLIPSegmentation, not GroundedSAM."""
+        from geoai_mcp_server.server import segment_objects_with_prompts
+
+        raster_path = temp_output_dir / "sample_segmented.tif"
+
+        mock_segmenter = MagicMock()
+        mock_segmenter.segment_image.return_value = str(raster_path)
+        mock_segment = MagicMock()
+        mock_segment.CLIPSegmentation.return_value = mock_segmenter
+
+        mock_utils = MagicMock()
+
+        def get_module(name):
+            return mock_segment if name == "segment" else mock_utils
+
+        with (
+            patch("geoai_mcp_server.server.config") as mock_config,
+            patch("geoai_mcp_server.server._get_geoai_module", side_effect=get_module),
+        ):
+            mock_config.input_dir = sample_geotiff.parent
+            mock_config.output_dir = temp_output_dir
+
+            result = await segment_objects_with_prompts(
+                image_path=sample_geotiff.name,
+                prompts=["building"],
+                model="clipseg",
+                output_format="geotiff",
+            )
+
+        assert result["success"] is True
+        mock_segment.CLIPSegmentation.assert_called_once()
+        mock_segment.GroundedSAM.assert_not_called()
+        # CLIPSeg writes to raster_path (.tif), not to the user-facing output_path
+        # (.geotiff). output_files must point to the file that was actually written.
+        assert result["output_files"] == [str(raster_path)]
+
+
 class TestDetectionTools:
     """Tests for detection-related tools."""
 

--- a/geoai-mcp-server/tests/test_server.py
+++ b/geoai-mcp-server/tests/test_server.py
@@ -45,7 +45,6 @@ class TestSegmentationTools:
             assert result["success"] is False
             assert "not found" in result["message"].lower()
 
-
     @pytest.mark.asyncio
     async def test_segment_objects_grounded_sam_success(
         self, sample_geotiff, temp_output_dir


### PR DESCRIPTION
Replace non-existent SamGeo.predict_with_text() and segment_with_text() with GroundedSAM(threshold=...).segment_image() from geoai.segment. SAM fallback for prompt-free segmentation is preserved.