### PR TITLE
chore: bump versions and decouple plugin check in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,24 @@ jobs:
               with:
                   python-version: "3.13"
 
-            - name: Build plugin zip
-              run: python "qgis_plugin/package_plugin.py" --source "$PLUGIN_DIR" --output "$ZIP_PATH"
-
-            - name: Verify metadata version matches release tag
+            - name: Read plugin version
+              id: plugin_version
               run: |
-                  metadata_version=$(grep '^version=' "$PLUGIN_DIR/metadata.txt" | cut -d'=' -f2 | tr -d '[:space:]')
-                  tag_version="${TAG#v}"
-                  if [ "$metadata_version" != "$tag_version" ]; then
-                      echo "::error::metadata.txt version ($metadata_version) does not match release tag ($tag_version)"
+                  plugin_version=$(grep '^version=' "$PLUGIN_DIR/metadata.txt" | cut -d'=' -f2 | tr -d '[:space:]')
+                  if [ -z "$plugin_version" ]; then
+                      echo "::error::Could not read plugin version from $PLUGIN_DIR/metadata.txt"
                       exit 1
                   fi
+                  if ! echo "$plugin_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-].+)?$'; then
+                      echo "::error::Plugin version '$plugin_version' is not a valid version string"
+                      exit 1
+                  fi
+                  echo "version=$plugin_version" >> "$GITHUB_OUTPUT"
+                  echo "Release tag (package): $TAG"
+                  echo "Plugin version (metadata.txt): $plugin_version"
+
+            - name: Build plugin zip
+              run: python "qgis_plugin/package_plugin.py" --source "$PLUGIN_DIR" --output "$ZIP_PATH"
 
             - name: Attach zip to GitHub release
               env:

--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -8,7 +8,7 @@ only when a specific symbol is first accessed.
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.37.2"
+__version__ = "0.38.0"
 
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geoai-py"
-version = "0.37.2"
+version = "0.38.0"
 dynamic = [
     "dependencies",
 ]
@@ -58,7 +58,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.37.2"
+current_version = "0.38.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.2.3
+version=1.3.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -59,6 +59,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.3.0
+        - Fix QGIS plugin reload cleanup (#741)
     1.2.3
         - Fix macOS QGIS installer dependency installation
     1.2.2


### PR DESCRIPTION
## Summary
- Bump `geoai-py` to 0.38.0 (`pyproject.toml`, `geoai/__init__.py`, bumpversion config).
- Bump QGIS plugin to 1.3.0 in `qgis_plugin/geoai/metadata.txt` and record the plugin reload cleanup fix (#741) in the changelog.
- Drop the strict equality check between the QGIS plugin's `metadata.txt` version and the GitHub release tag in `.github/workflows/publish.yml`. The Python package and the QGIS plugin are versioned independently, so the workflow now only validates the plugin version format and logs both the release tag and the plugin version.

## Test plan
- [ ] CI passes on this branch.
- [ ] On the next tagged release, the Publish workflow reads the plugin version, builds the zip, attaches it to the release, and uploads it to plugins.qgis.org without failing on a tag/plugin version mismatch.