### PR TITLE
fix(qgis-plugin): avoid CUDA device mismatch in DeepForest Single Image mode

### DIFF
--- a/qgis_plugin/geoai/dialogs/deepforest_panel.py
+++ b/qgis_plugin/geoai/dialogs/deepforest_panel.py
@@ -481,8 +481,16 @@ class DeepForestPredictWorker(QThread):
             try:
                 self.model.model.to("cpu")
                 moved = True
-            except Exception:
-                moved = False
+            except Exception as exc:
+                # Surface the underlying reason; predict_image would otherwise
+                # crash next with the original device-mismatch error.
+                QgsMessageLog.logMessage(
+                    f"DeepForest: could not move model to CPU for "
+                    f"predict_image ({exc}); leaving model on "
+                    f"{original_device}.",
+                    "GeoAI - Tree Segmentation",
+                    Qgis.Warning,
+                )
 
         try:
             return self.model.predict_image(path=image_path)
@@ -490,8 +498,16 @@ class DeepForestPredictWorker(QThread):
             if moved:
                 try:
                     self.model.model.to(original_device)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    # Restore failed: the model is now stuck on CPU, which
+                    # silently downgrades subsequent CUDA predictions.
+                    QgsMessageLog.logMessage(
+                        f"DeepForest: could not restore model to "
+                        f"{original_device} after predict_image ({exc}); "
+                        f"model remains on CPU.",
+                        "GeoAI - Tree Segmentation",
+                        Qgis.Warning,
+                    )
 
     @staticmethod
     def _is_cuda_oom(exc: Exception) -> bool:

--- a/qgis_plugin/geoai/dialogs/deepforest_panel.py
+++ b/qgis_plugin/geoai/dialogs/deepforest_panel.py
@@ -412,7 +412,7 @@ class DeepForestPredictWorker(QThread):
 
             if self.mode == "Single Image":
                 self.progress.emit("Running prediction on single image...")
-                result = self.model.predict_image(path=image_path)
+                result = self._predict_image_on_cpu(image_path)
                 pred_mode = "single"
             else:
                 # Estimate number of patches for progress info
@@ -459,6 +459,39 @@ class DeepForestPredictWorker(QThread):
 
         except Exception as e:
             self.error.emit(str(e))
+
+    def _predict_image_on_cpu(self, image_path: str):
+        """Run ``predict_image`` with the model temporarily on CPU.
+
+        Workaround for an upstream DeepForest bug: ``_predict_image_`` builds
+        the input tensor on CPU and never moves it to the model's device, so a
+        model on CUDA crashes with "Input type (torch.FloatTensor) and weight
+        type (torch.cuda.FloatTensor)". Single image inference is cheap, so we
+        move the model to CPU for the call and restore the original device
+        afterward. See https://github.com/opengeos/geoai/issues/742.
+        """
+        original_device = None
+        try:
+            original_device = next(self.model.model.parameters()).device
+        except Exception:
+            pass
+
+        moved = False
+        if original_device is not None and original_device.type != "cpu":
+            try:
+                self.model.model.to("cpu")
+                moved = True
+            except Exception:
+                moved = False
+
+        try:
+            return self.model.predict_image(path=image_path)
+        finally:
+            if moved:
+                try:
+                    self.model.model.to(original_device)
+                except Exception:
+                    pass
 
     @staticmethod
     def _is_cuda_oom(exc: Exception) -> bool:

--- a/qgis_plugin/geoai/workers/deepforest_worker.py
+++ b/qgis_plugin/geoai/workers/deepforest_worker.py
@@ -176,6 +176,40 @@ def _prepare_image_for_deepforest(image_path: str) -> tuple[str, str | None]:
     return image_path, None
 
 
+def _predict_image_on_cpu(model, path: str) -> Any:
+    """Run ``predict_image`` with the model temporarily on CPU.
+
+    Workaround for an upstream DeepForest bug: ``deepforest.predict._predict_image_``
+    constructs the input tensor on CPU and never moves it to the model's device,
+    so a model placed on CUDA crashes with "Input type (torch.FloatTensor) and
+    weight type (torch.cuda.FloatTensor)". Single image inference is cheap, so
+    we move the model to CPU for the call and restore the original device after.
+    See https://github.com/opengeos/geoai/issues/742.
+    """
+    original_device = None
+    try:
+        original_device = next(model.model.parameters()).device
+    except Exception:
+        pass
+
+    moved = False
+    if original_device is not None and original_device.type != "cpu":
+        try:
+            _run_quiet_stdout(model.model.to, "cpu")
+            moved = True
+        except Exception:
+            moved = False
+
+    try:
+        return _run_quiet_stdout(model.predict_image, path=path)
+    finally:
+        if moved:
+            try:
+                _run_quiet_stdout(model.model.to, original_device)
+            except Exception:
+                pass
+
+
 def _is_cuda_oom(exc: Exception) -> bool:
     """Check whether *exc* is a CUDA out-of-memory error."""
     try:
@@ -331,7 +365,7 @@ def _handle_predict(req: dict) -> Any:
     pred_path, temp_rgb_path = _prepare_image_for_deepforest(image_path)
     try:
         if mode == "Single Image":
-            result = _run_quiet_stdout(model.predict_image, path=pred_path)
+            result = _predict_image_on_cpu(model, pred_path)
             pred_mode = "single"
         else:
             result = _predict_tile_with_oom_retry(

--- a/qgis_plugin/geoai/workers/deepforest_worker.py
+++ b/qgis_plugin/geoai/workers/deepforest_worker.py
@@ -197,8 +197,14 @@ def _predict_image_on_cpu(model, path: str) -> Any:
         try:
             _run_quiet_stdout(model.model.to, "cpu")
             moved = True
-        except Exception:
-            moved = False
+        except Exception as exc:
+            # Surface the underlying reason; predict_image would otherwise
+            # crash next with the original device-mismatch error.
+            print(
+                f"DeepForest worker: could not move model to CPU for "
+                f"predict_image ({exc}); leaving model on {original_device}.",
+                file=sys.stderr,
+            )
 
     try:
         return _run_quiet_stdout(model.predict_image, path=path)
@@ -206,8 +212,15 @@ def _predict_image_on_cpu(model, path: str) -> Any:
         if moved:
             try:
                 _run_quiet_stdout(model.model.to, original_device)
-            except Exception:
-                pass
+            except Exception as exc:
+                # Restore failed: the singleton model is now stuck on CPU,
+                # which silently downgrades subsequent CUDA predictions.
+                print(
+                    f"DeepForest worker: could not restore model to "
+                    f"{original_device} after predict_image ({exc}); "
+                    f"model remains on CPU.",
+                    file=sys.stderr,
+                )
 
 
 def _is_cuda_oom(exc: Exception) -> bool:


### PR DESCRIPTION
## Summary

Fixes #742 — `Device=cuda` + `Mode=Single Image` in the DeepForest panel crashes with `RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor)`.

Root cause is upstream: `deepforest.predict._predict_image_` (see [predict.py](https://github.com/weecology/DeepForest/blob/main/src/deepforest/predict.py)) builds the input tensor on CPU and never moves it to the model's device:

```python
image = torch.tensor(image).permute(2, 0, 1)
image = image / 255
with torch.no_grad():
    prediction = model(image.unsqueeze(0))   # model on cuda, image on cpu => crash
```

When the user selects `cuda` in our Device dropdown, the worker calls `model.model.to('cuda')`, after which `predict_image` blows up. `Large Tile` mode is unaffected because it goes through the Lightning trainer, which handles device placement for both module and batches.

Workaround applied here: wrap `predict_image` so the model is temporarily moved to CPU for the call and restored to its original device afterward. Single image inference is fast enough that the move cost is negligible. No upstream change is required for this fix to land, but the same bug should ideally be reported / fixed in DeepForest (e.g. have `_predict_image_` move the input to `next(model.parameters()).device`).

## Changes

- [qgis_plugin/geoai/workers/deepforest_worker.py](qgis_plugin/geoai/workers/deepforest_worker.py): add `_predict_image_on_cpu` helper, use it from `_handle_predict` Single Image branch.
- [qgis_plugin/geoai/dialogs/deepforest_panel.py](qgis_plugin/geoai/dialogs/deepforest_panel.py): mirror the same wrapper as a method on `DeepForestPredictWorker`, used from the in-process Single Image branch.

## Test plan

- [ ] In QGIS, open the DeepForest panel, pick `Device=cuda`, `Mode=Single Image`, load `weecology/deepforest-tree`, run on the sample image — should produce detections instead of the device-mismatch error.
- [ ] Repeat with `Device=cpu` and `Device=auto` — still works.
- [ ] Repeat with `Mode=Large Tile` on both `cuda` and `cpu` — still works (path unchanged).