### PR TITLE
fix(qgis-plugin): surface real cause of Moondream worker import failures

### DIFF
--- a/qgis_plugin/geoai/workers/moondream_worker.py
+++ b/qgis_plugin/geoai/workers/moondream_worker.py
@@ -128,7 +128,13 @@ def _run_quiet_stdout(fn, *args, **kwargs):
 
 
 def _handle_init(req: dict) -> Any:
-    from geoai import MoondreamGeo
+    # Import the submodule directly. `from geoai import MoondreamGeo` would
+    # go through the package's lazy ``__getattr__``, which converts any
+    # underlying ImportError (missing torch / transformers / etc.) into an
+    # AttributeError; Python's ``from X import Y`` machinery then strips
+    # the chained cause and leaves users with a misleading
+    # "cannot import name 'MoondreamGeo'" error.
+    from geoai.moondream import MoondreamGeo
 
     _STATE["moondream"] = _run_quiet_stdout(
         MoondreamGeo,


### PR DESCRIPTION
## Summary
- Closes #750
- Import `MoondreamGeo` directly from `geoai.moondream` instead of `from geoai import MoondreamGeo`, so any underlying `ImportError` (missing torch / transformers / etc.) propagates with its full chained traceback instead of being swallowed by the package's lazy `__getattr__`.

## Why
The worker did `from geoai import MoondreamGeo`. Since `geoai` uses PEP 562 lazy loading, `MoondreamGeo` is resolved via `__getattr__`, which catches `ImportError`/`OSError` from importing `geoai.moondream` and re-raises as `AttributeError`. Python's `from X import Y` machinery then converts that into `ImportError: cannot import name 'MoondreamGeo' from 'geoai'` and discards the chained cause. The reporter only saw:

```
ImportError: cannot import name 'MoondreamGeo' from 'geoai' (...). Did you mean: 'moondream_gui'?
```

The actual reason `geoai.moondream` failed to import (missing/broken transformers, torch DLL, geopandas, etc.) was hidden. Verified by reproduction in a sandbox: `from geoai import X` style produces only the "did you mean" hint, while `from geoai.moondream import X` style shows the real `ModuleNotFoundError` / `ImportError`.

This is a diagnostic improvement: once the reporter upgrades to this fix, the dialog and worker stderr will show the actual missing dependency so they (or we) can address the underlying root cause.

## Test plan
- [ ] Reinstall QGIS plugin, trigger Moondream load with a deliberately broken dep in the venv, confirm the error dialog shows the underlying `ImportError` instead of "Did you mean: 'moondream_gui'?".
- [ ] Confirm normal Moondream model load still works on a healthy venv.