### PR TITLE
mcp: improve Windows filename handling

### DIFF
--- a/geoai-mcp-server/src/geoai_mcp_server/utils/validation.py
+++ b/geoai-mcp-server/src/geoai_mcp_server/utils/validation.py
@@ -12,6 +12,15 @@ from .error_handling import InputValidationError
 
 logger = logging.getLogger("geoai_mcp.validation")
 
+_WINDOWS_RESERVED_FILENAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+
 
 def validate_bbox(
     bbox: List[float] | Tuple[float, ...],
@@ -231,15 +240,19 @@ def sanitize_filename(filename: str, max_length: int = 255) -> str:
     # Remove leading/trailing dots
     filename = filename.strip(".")
 
+    # Fallback for empty result
+    if not filename:
+        filename = "unnamed_file"
+
+    base, ext = filename.rsplit(".", 1) if "." in filename else (filename, "")
+    if base.upper() in _WINDOWS_RESERVED_FILENAMES:
+        filename = f"_{base}" + (f".{ext}" if ext else "")
+
     # Truncate if too long (preserving extension)
     if len(filename) > max_length:
         base, ext = filename.rsplit(".", 1) if "." in filename else (filename, "")
         max_base = max_length - len(ext) - 1
         filename = base[:max_base] + ("." + ext if ext else "")
-
-    # Fallback for empty result
-    if not filename:
-        filename = "unnamed_file"
 
     return filename
 

--- a/geoai-mcp-server/tests/test_utils.py
+++ b/geoai-mcp-server/tests/test_utils.py
@@ -127,6 +127,14 @@ class TestValidation:
         assert ".." not in result
         assert result.endswith(".tif")
 
+    @pytest.mark.parametrize("filename", ["CON", "aux.tif", "LPT1.geojson"])
+    def test_sanitize_filename_windows_reserved_names(self, filename):
+        """Test Windows reserved device names are avoided."""
+        result = sanitize_filename(filename)
+
+        assert result.startswith("_")
+        assert Path(result).stem.upper() not in {"CON", "AUX", "LPT1"}
+
 
 class TestFileManagement:
     """Tests for file management utilities."""
@@ -175,8 +183,8 @@ class TestConfig:
             max_memory_gb=16,
             device="cuda",
         )
-        assert config.input_dir == Path("/custom/input")
-        assert config.output_dir == Path("/custom/output")
+        assert config.input_dir == Path("/custom/input").resolve()
+        assert config.output_dir == Path("/custom/output").resolve()
         assert config.log_level == "DEBUG"
         assert config.timeout == 600
         assert config.max_memory_gb == 16


### PR DESCRIPTION
## Summary
- Avoid Windows reserved device names when sanitizing output filenames.
- Make the MCP config path test compare resolved paths so it passes on Windows too.
- Add coverage for reserved names such as CON, AUX, and LPT1.

## Checks
- .\.venv\Scripts\python.exe -m pytest geoai-mcp-server/tests -q