### PR TITLE
feat: add RF-DETR-Seg instance segmentation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ docs/examples/ndvi_regression_output/
 docs/examples/timm_regression_output/
 docs/examples/ndvi_model/
 *.pth
+*.pt
 *.ckpt
 docs/examples/cache/
 docs/examples/*_cache/
@@ -59,6 +60,7 @@ wheels/
 *.egg
 docs/examples/**/*.txt
 docs/examples/**/*.pth
+docs/examples/**/*.pt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/docs/examples/rfdetr_segmentation.ipynb
+++ b/docs/examples/rfdetr_segmentation.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# RF-DETR-Seg - Instance Segmentation on Geospatial Imagery\n",
+    "\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/geoai/blob/main/docs/examples/rfdetr_segmentation.ipynb)\n",
+    "\n",
+    "This notebook demonstrates GeoAI's RF-DETR-Seg integration for instance segmentation on GeoTIFF imagery.\n",
+    "\n",
+    "`rfdetr_segment()` runs tiled inference with RF-DETR-Seg, preserves the predicted instance masks, and returns a georeferenced GeoDataFrame with mask polygons. You can also call `rfdetr_detect()` with a `seg-*` model variant; mask geometry is enabled automatically for segmentation variants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U \"geoai-py[rfdetr]\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geoai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## List RF-DETR-Seg Models\n",
+    "\n",
+    "GeoAI registers the RF-DETR detection and segmentation variants. The segmentation variants are named with the `seg-` prefix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoai import RFDETR_MODELS, list_rfdetr_models\n",
+    "\n",
+    "for name, desc in list_rfdetr_models().items():\n",
+    "    if name.startswith(\"seg-\"):\n",
+    "        resolution = RFDETR_MODELS[name][\"resolution\"]\n",
+    "        print(f\"{name:12s} [{resolution:4d}px] {desc}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## Download a Sample GeoTIFF\n",
+    "\n",
+    "This example uses a public GeoTIFF from the GeoAI sample data collection. The default RF-DETR-Seg weights are trained on general COCO objects, so for domain-specific classes such as buildings, ships, tree crowns, or wetlands, use a fine-tuned RF-DETR-Seg checkpoint with `pretrain_weights=`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raster_url = (\n",
+    "    \"https://huggingface.co/datasets/giswqs/geospatial/resolve/main/parking_spots.tif\"\n",
+    ")\n",
+    "raster_path = geoai.download_file(raster_url)\n",
+    "raster_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## View the Input Image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geoai.view_raster(raster_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "## Run RF-DETR-Seg\n",
+    "\n",
+    "`rfdetr_segment()` returns georeferenced mask polygons. The `area_pixels` column records the pixel area of each predicted mask before vectorization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf = geoai.rfdetr_segment(\n",
+    "    raster_path,\n",
+    "    output_path=\"rfdetr_segmentation.geojson\",\n",
+    "    model_variant=\"seg-medium\",\n",
+    "    confidence_threshold=0.35,\n",
+    "    nms_threshold=0.3,\n",
+    "    batch_size=2,\n",
+    ")\n",
+    "\n",
+    "print(f\"Segmented {len(gdf)} objects\")\n",
+    "gdf.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Inspect the Segmentation Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(gdf.geom_type.value_counts().to_string())\n",
+    "print(gdf[\"class_name\"].value_counts().head(10).to_string())\n",
+    "print(f\"Mean mask area: {gdf['area_pixels'].mean():.1f} pixels\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "## Visualize Mask Polygons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geoai.view_vector_interactive(gdf, column=\"class_name\", tiles=raster_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "## Compare with Bounding Boxes\n",
+    "\n",
+    "For segmentation variants, `rfdetr_detect()` uses mask polygons by default. Set `use_mask_geometry=False` when you want bounding box rectangles from the same RF-DETR-Seg predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "boxes = geoai.rfdetr_detect(\n",
+    "    raster_path,\n",
+    "    model_variant=\"seg-medium\",\n",
+    "    confidence_threshold=0.35,\n",
+    "    nms_threshold=0.3,\n",
+    "    batch_size=2,\n",
+    "    use_mask_geometry=False,\n",
+    ")\n",
+    "\n",
+    "print(f\"Bounding boxes: {len(boxes)}\")\n",
+    "geoai.view_vector_interactive(boxes, column=\"class_name\", tiles=raster_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "## Use Custom Weights\n",
+    "\n",
+    "Pass a fine-tuned RF-DETR-Seg checkpoint through `pretrain_weights` to segment custom geospatial classes.\n",
+    "\n",
+    "```python\n",
+    "custom_gdf = geoai.rfdetr_segment(\n",
+    "    raster_path,\n",
+    "    model_variant=\"seg-medium\",\n",
+    "    pretrain_weights=\"path/to/checkpoint_best_total.pth\",\n",
+    "    class_names=[\"building\", \"tree\", \"vehicle\"],\n",
+    "    confidence_threshold=0.3,\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "## Save Results\n",
+    "\n",
+    "The earlier `output_path` argument already saved the segmentation output to GeoJSON. You can also write the GeoDataFrame to any vector format supported by GeoPandas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf.to_file(\"rfdetr_segmentation.gpkg\", driver=\"GPKG\")\n",
+    "print(\"Saved RF-DETR-Seg mask polygons to rfdetr_segmentation.gpkg\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -436,6 +436,7 @@ _LAZY_SYMBOL_MAP = {
     "check_rfdetr_available": ("rfdetr", None),
     "list_rfdetr_models": ("rfdetr", None),
     "rfdetr_detect": ("rfdetr", None),
+    "rfdetr_segment": ("rfdetr", None),
     "rfdetr_detect_batch": ("rfdetr", None),
     "rfdetr_train": ("rfdetr", None),
     "push_rfdetr_to_hub": ("rfdetr", None),

--- a/geoai/rfdetr.py
+++ b/geoai/rfdetr.py
@@ -40,6 +40,7 @@ __all__ = [
     "check_rfdetr_available",
     "list_rfdetr_models",
     "rfdetr_detect",
+    "rfdetr_segment",
     "rfdetr_detect_batch",
     "rfdetr_train",
     "push_rfdetr_to_hub",
@@ -82,35 +83,102 @@ RFDETR_MODELS: Dict[str, Dict[str, Any]] = {
     # Segmentation models
     "seg-nano": {
         "class_name": "RFDETRSegNano",
-        "resolution": 384,
-        "description": "RF-DETR Seg Nano (instance segmentation, 384px)",
+        "resolution": 312,
+        "description": "RF-DETR Seg Nano (instance segmentation, 312px)",
     },
     "seg-small": {
         "class_name": "RFDETRSegSmall",
-        "resolution": 512,
-        "description": "RF-DETR Seg Small (instance segmentation, 512px)",
+        "resolution": 384,
+        "description": "RF-DETR Seg Small (instance segmentation, 384px)",
     },
     "seg-medium": {
         "class_name": "RFDETRSegMedium",
-        "resolution": 576,
-        "description": "RF-DETR Seg Medium (instance segmentation, 576px)",
+        "resolution": 432,
+        "description": "RF-DETR Seg Medium (instance segmentation, 432px)",
     },
     "seg-large": {
         "class_name": "RFDETRSegLarge",
-        "resolution": 704,
-        "description": "RF-DETR Seg Large (instance segmentation, 704px)",
+        "resolution": 504,
+        "description": "RF-DETR Seg Large (instance segmentation, 504px)",
     },
     "seg-xlarge": {
         "class_name": "RFDETRSegXLarge",
-        "resolution": 700,
-        "description": "RF-DETR Seg XLarge (instance segmentation, 700px)",
+        "resolution": 624,
+        "description": "RF-DETR Seg XLarge (instance segmentation, 624px)",
     },
     "seg-2xlarge": {
         "class_name": "RFDETRSeg2XLarge",
-        "resolution": 880,
-        "description": "RF-DETR Seg 2XLarge (instance segmentation, 880px)",
+        "resolution": 768,
+        "description": "RF-DETR Seg 2XLarge (instance segmentation, 768px)",
     },
 }
+
+
+def _is_rfdetr_segmentation_variant(model_variant: str) -> bool:
+    """Return True if the RF-DETR variant is an instance segmentation model."""
+    return model_variant.startswith("seg-")
+
+
+def _normalize_detection_masks(
+    masks: Optional[Any], expected_count: int
+) -> Optional[np.ndarray]:
+    """Normalize Supervision detection masks to ``(N, H, W)`` boolean arrays."""
+    if masks is None:
+        return None
+
+    masks_array = np.asarray(masks)
+    if masks_array.ndim == 4 and masks_array.shape[-1] == 1:
+        masks_array = masks_array[..., 0]
+    if masks_array.ndim == 2 and expected_count == 1:
+        masks_array = masks_array[np.newaxis, ...]
+    if masks_array.ndim != 3 or masks_array.shape[0] != expected_count:
+        logger.warning(
+            "Skipping RF-DETR masks with unexpected shape %s for %d detections.",
+            masks_array.shape,
+            expected_count,
+        )
+        return None
+    return masks_array.astype(bool)
+
+
+def _mask_to_georeferenced_geometry(
+    mask: np.ndarray,
+    x_offset: int,
+    y_offset: int,
+    transform: Any,
+    simplify_tolerance: float = 0.0,
+) -> Optional[Any]:
+    """Vectorize a tile-local mask into georeferenced polygon geometry."""
+    if mask is None or not np.any(mask):
+        return None
+
+    from rasterio.features import shapes as rasterio_shapes
+    from rasterio.transform import Affine
+    from shapely.geometry import shape
+    from shapely.ops import unary_union
+
+    mask_uint8 = mask.astype(np.uint8)
+    tile_transform = transform * Affine.translation(x_offset, y_offset)
+
+    parts = []
+    for geom_dict, value in rasterio_shapes(
+        mask_uint8, mask=mask_uint8.astype(bool), transform=tile_transform
+    ):
+        if value == 0:
+            continue
+        candidate = shape(geom_dict)
+        if candidate.is_valid and not candidate.is_empty:
+            parts.append(candidate)
+
+    if not parts:
+        return None
+
+    geom = unary_union(parts) if len(parts) > 1 else parts[0]
+    if simplify_tolerance > 0:
+        simplified = geom.simplify(simplify_tolerance, preserve_topology=True)
+        if simplified.is_valid and not simplified.is_empty:
+            geom = simplified
+    return geom
 
 
 def check_rfdetr_available() -> None:
@@ -211,6 +279,8 @@ def rfdetr_detect(
     overlap: Optional[int] = None,
     batch_size: int = 4,
     class_names: Optional[List[str]] = None,
+    use_mask_geometry: Optional[bool] = None,
+    simplify_tolerance: float = 0.0,
     device: Optional[str] = None,
     **kwargs: Any,
 ) -> Any:
@@ -243,13 +313,21 @@ def rfdetr_detect(
         class_names: Optional list of class names for labeling detections.
             If None and using COCO pretrained weights, COCO class names
             are used.
+        use_mask_geometry: If True, use RF-DETR-Seg instance masks as output
+            geometries when masks are available. If None, this is enabled
+            automatically for ``seg-*`` model variants and disabled for
+            detection variants. Defaults to None.
+        simplify_tolerance: Optional polygon simplification tolerance in
+            georeferenced units for mask geometries. Defaults to 0.0.
         device: Device to use ("cpu", "cuda", "mps"). If None, auto-detected.
         **kwargs: Additional keyword arguments passed to the model constructor.
 
     Returns:
         geopandas.GeoDataFrame: GeoDataFrame with columns: geometry,
         class_id, class_name, confidence. The geometry column contains
-        georeferenced bounding box polygons.
+        georeferenced bounding box polygons for detection variants and
+        georeferenced mask polygons for segmentation variants when masks
+        are available.
     """
     import geopandas as gpd
     import rasterio
@@ -261,6 +339,9 @@ def rfdetr_detect(
     from tqdm import tqdm
 
     check_rfdetr_available()
+
+    if use_mask_geometry is None:
+        use_mask_geometry = _is_rfdetr_segmentation_variant(model_variant)
 
     model = _create_rfdetr_model(
         model_variant=model_variant,
@@ -289,6 +370,8 @@ def rfdetr_detect(
         all_boxes = []
         all_scores = []
         all_class_ids = []
+        all_masks = []
+        all_mask_offsets = []
 
         stride = window_size - overlap
         if stride <= 0:
@@ -386,6 +469,14 @@ def rfdetr_detect(
                                 valid = (boxes[:, 2] > boxes[:, 0]) & (
                                     boxes[:, 3] > boxes[:, 1]
                                 )
+                                masks = None
+                                if use_mask_geometry:
+                                    masks = _normalize_detection_masks(
+                                        getattr(det, "mask", None), len(det.xyxy)
+                                    )
+                                    if masks is not None:
+                                        masks = masks[valid]
+
                                 boxes = boxes[valid]
                                 scores = det.confidence[valid]
                                 class_ids = det.class_id[valid]
@@ -399,6 +490,16 @@ def rfdetr_detect(
                                 all_boxes.append(boxes)
                                 all_scores.append(scores)
                                 all_class_ids.append(class_ids)
+                                if use_mask_geometry:
+                                    if masks is None:
+                                        all_masks.extend([None] * len(boxes))
+                                        all_mask_offsets.extend(
+                                            [(x_pos, y_pos)] * len(boxes)
+                                        )
+                                    else:
+                                        for mask in masks:
+                                            all_masks.append(mask[:h, :w])
+                                            all_mask_offsets.append((x_pos, y_pos))
 
                         pbar.update(len(batch_images))
                         batch_images = []
@@ -423,16 +524,25 @@ def rfdetr_detect(
         keep_indices = torchvision.ops.batched_nms(
             boxes_tensor, scores_tensor, labels_tensor, nms_threshold
         )
+        keep_indices_np = keep_indices.numpy()
 
-        final_boxes = all_boxes[keep_indices.numpy()]
-        final_scores = all_scores[keep_indices.numpy()]
-        final_class_ids = all_class_ids[keep_indices.numpy()]
+        final_boxes = all_boxes[keep_indices_np]
+        final_scores = all_scores[keep_indices_np]
+        final_class_ids = all_class_ids[keep_indices_np]
+        if use_mask_geometry:
+            final_masks = [all_masks[int(idx)] for idx in keep_indices_np]
+            final_mask_offsets = [all_mask_offsets[int(idx)] for idx in keep_indices_np]
+        else:
+            final_masks = []
+            final_mask_offsets = []
 
         logger.info("After NMS: %d detections", len(final_boxes))
     else:
         final_boxes = np.empty((0, 4))
         final_scores = np.empty((0,))
         final_class_ids = np.empty((0,), dtype=int)
+        final_masks = []
+        final_mask_offsets = []
 
     # Convert pixel coordinates to georeferenced polygons
     records = []
@@ -441,12 +551,28 @@ def rfdetr_detect(
         class_id = int(final_class_ids[idx])
         score = float(final_scores[idx])
 
-        # Convert pixel corners to georeferenced coordinates
-        pts = []
-        for c, r in [(c0, r0), (c1, r0), (c1, r1), (c0, r1)]:
-            geo_x, geo_y = transform * (float(c), float(r))
-            pts.append((geo_x, geo_y))
-        geom = Polygon(pts)
+        geom = None
+        area_pixels = 0
+        if use_mask_geometry and idx < len(final_masks):
+            mask = final_masks[idx]
+            if mask is not None:
+                x_offset, y_offset = final_mask_offsets[idx]
+                area_pixels = int(np.sum(mask))
+                geom = _mask_to_georeferenced_geometry(
+                    mask,
+                    x_offset=x_offset,
+                    y_offset=y_offset,
+                    transform=transform,
+                    simplify_tolerance=simplify_tolerance,
+                )
+
+        if geom is None:
+            # Convert pixel corners to georeferenced coordinates
+            pts = []
+            for c, r in [(c0, r0), (c1, r0), (c1, r1), (c0, r1)]:
+                geo_x, geo_y = transform * (float(c), float(r))
+                pts.append((geo_x, geo_y))
+            geom = Polygon(pts)
 
         # Resolve class name
         if class_names and class_id < len(class_names):
@@ -454,20 +580,24 @@ def rfdetr_detect(
         else:
             name = f"class_{class_id}"
 
-        records.append(
-            {
-                "geometry": geom,
-                "class_id": class_id,
-                "class_name": name,
-                "confidence": score,
-            }
-        )
+        record = {
+            "geometry": geom,
+            "class_id": class_id,
+            "class_name": name,
+            "confidence": score,
+        }
+        if use_mask_geometry:
+            record["area_pixels"] = area_pixels
+        records.append(record)
 
     if records:
         gdf = gpd.GeoDataFrame(records, crs=crs)
     else:
+        columns = ["geometry", "class_id", "class_name", "confidence"]
+        if use_mask_geometry:
+            columns.append("area_pixels")
         gdf = gpd.GeoDataFrame(
-            columns=["geometry", "class_id", "class_name", "confidence"],
+            columns=columns,
             geometry="geometry",
             crs=crs,
         )
@@ -478,6 +608,80 @@ def rfdetr_detect(
         logger.info("Saved %d detections to %s", len(gdf), output_path)
 
     return gdf
+
+
+def rfdetr_segment(
+    input_path: str,
+    output_path: Optional[str] = None,
+    model_variant: str = "seg-medium",
+    pretrain_weights: Optional[str] = None,
+    confidence_threshold: float = 0.5,
+    nms_threshold: float = 0.3,
+    window_size: Optional[int] = None,
+    overlap: Optional[int] = None,
+    batch_size: int = 4,
+    class_names: Optional[List[str]] = None,
+    simplify_tolerance: float = 0.0,
+    device: Optional[str] = None,
+    **kwargs: Any,
+) -> Any:
+    """Perform RF-DETR-Seg instance segmentation on a GeoTIFF.
+
+    This is a convenience wrapper around :func:`rfdetr_detect` that requires
+    a ``seg-*`` model variant and returns georeferenced mask polygons when
+    RF-DETR provides masks.
+
+    Args:
+        input_path: Path to input GeoTIFF image.
+        output_path: Optional path to save the output GeoDataFrame.
+        model_variant: RF-DETR-Seg model variant to use. Defaults to
+            ``"seg-medium"``.
+        pretrain_weights: Path to custom pretrained weights file. If None,
+            uses RF-DETR's default pretrained weights.
+        confidence_threshold: Minimum confidence score for detections.
+        nms_threshold: IoU threshold for Non-Maximum Suppression across
+            tiles.
+        window_size: Size of the sliding window in pixels. Defaults to the
+            model's native resolution.
+        overlap: Overlap between adjacent windows in pixels. Defaults to
+            ``window_size // 4``.
+        batch_size: Number of tiles to process in each batch.
+        class_names: Optional list of class names for labeling detections.
+        simplify_tolerance: Optional polygon simplification tolerance in
+            georeferenced units. Defaults to 0.0.
+        device: Device to use ("cpu", "cuda", "mps"). If None, auto-detected.
+        **kwargs: Additional keyword arguments passed to the model constructor.
+
+    Returns:
+        geopandas.GeoDataFrame: GeoDataFrame with georeferenced mask polygons.
+    """
+    if not _is_rfdetr_segmentation_variant(model_variant):
+        available = ", ".join(
+            sorted(
+                name for name in RFDETR_MODELS if _is_rfdetr_segmentation_variant(name)
+            )
+        )
+        raise ValueError(
+            f"rfdetr_segment requires a segmentation variant. "
+            f"Available segmentation variants: {available}"
+        )
+
+    return rfdetr_detect(
+        input_path=input_path,
+        output_path=output_path,
+        model_variant=model_variant,
+        pretrain_weights=pretrain_weights,
+        confidence_threshold=confidence_threshold,
+        nms_threshold=nms_threshold,
+        window_size=window_size,
+        overlap=overlap,
+        batch_size=batch_size,
+        class_names=class_names,
+        use_mask_geometry=True,
+        simplify_tolerance=simplify_tolerance,
+        device=device,
+        **kwargs,
+    )
 
 
 def rfdetr_detect_batch(
@@ -491,6 +695,8 @@ def rfdetr_detect_batch(
     overlap: Optional[int] = None,
     batch_size: int = 4,
     class_names: Optional[List[str]] = None,
+    use_mask_geometry: Optional[bool] = None,
+    simplify_tolerance: float = 0.0,
     device: Optional[str] = None,
     **kwargs: Any,
 ) -> Any:
@@ -513,6 +719,11 @@ def rfdetr_detect_batch(
         overlap: Overlap between adjacent windows in pixels.
         batch_size: Number of tiles per inference batch. Defaults to 4.
         class_names: Optional list of class names.
+        use_mask_geometry: If True, use RF-DETR-Seg instance masks as output
+            geometries when masks are available. If None, this is enabled
+            automatically for ``seg-*`` model variants.
+        simplify_tolerance: Optional polygon simplification tolerance in
+            georeferenced units for mask geometries. Defaults to 0.0.
         device: Device to use. If None, auto-detected.
         **kwargs: Additional keyword arguments passed to the model constructor.
 
@@ -566,6 +777,8 @@ def rfdetr_detect_batch(
             overlap=overlap,
             batch_size=batch_size,
             class_names=class_names,
+            use_mask_geometry=use_mask_geometry,
+            simplify_tolerance=simplify_tolerance,
             device=device,
             **kwargs,
         )

--- a/geoai/rfdetr.py
+++ b/geoai/rfdetr.py
@@ -370,8 +370,8 @@ def rfdetr_detect(
         all_boxes = []
         all_scores = []
         all_class_ids = []
-        all_masks = []
-        all_mask_offsets = []
+        all_mask_geoms = []
+        all_mask_areas = []
 
         stride = window_size - overlap
         if stride <= 0:
@@ -492,14 +492,26 @@ def rfdetr_detect(
                                 all_class_ids.append(class_ids)
                                 if use_mask_geometry:
                                     if masks is None:
-                                        all_masks.extend([None] * len(boxes))
-                                        all_mask_offsets.extend(
-                                            [(x_pos, y_pos)] * len(boxes)
-                                        )
+                                        all_mask_geoms.extend([None] * len(boxes))
+                                        all_mask_areas.extend([0] * len(boxes))
                                     else:
+                                        # Vectorize masks immediately so we
+                                        # don't hold (N x window_size^2) bool
+                                        # arrays in memory until after NMS.
                                         for mask in masks:
-                                            all_masks.append(mask[:h, :w])
-                                            all_mask_offsets.append((x_pos, y_pos))
+                                            cropped = mask[:h, :w]
+                                            all_mask_areas.append(int(np.sum(cropped)))
+                                            all_mask_geoms.append(
+                                                _mask_to_georeferenced_geometry(
+                                                    cropped,
+                                                    x_offset=x_pos,
+                                                    y_offset=y_pos,
+                                                    transform=transform,
+                                                    simplify_tolerance=(
+                                                        simplify_tolerance
+                                                    ),
+                                                )
+                                            )
 
                         pbar.update(len(batch_images))
                         batch_images = []
@@ -530,19 +542,19 @@ def rfdetr_detect(
         final_scores = all_scores[keep_indices_np]
         final_class_ids = all_class_ids[keep_indices_np]
         if use_mask_geometry:
-            final_masks = [all_masks[int(idx)] for idx in keep_indices_np]
-            final_mask_offsets = [all_mask_offsets[int(idx)] for idx in keep_indices_np]
+            final_mask_geoms = [all_mask_geoms[int(idx)] for idx in keep_indices_np]
+            final_mask_areas = [all_mask_areas[int(idx)] for idx in keep_indices_np]
         else:
-            final_masks = []
-            final_mask_offsets = []
+            final_mask_geoms = []
+            final_mask_areas = []
 
         logger.info("After NMS: %d detections", len(final_boxes))
     else:
         final_boxes = np.empty((0, 4))
         final_scores = np.empty((0,))
         final_class_ids = np.empty((0,), dtype=int)
-        final_masks = []
-        final_mask_offsets = []
+        final_mask_geoms = []
+        final_mask_areas = []
 
     # Convert pixel coordinates to georeferenced polygons
     records = []
@@ -553,18 +565,9 @@ def rfdetr_detect(
 
         geom = None
         area_pixels = 0
-        if use_mask_geometry and idx < len(final_masks):
-            mask = final_masks[idx]
-            if mask is not None:
-                x_offset, y_offset = final_mask_offsets[idx]
-                area_pixels = int(np.sum(mask))
-                geom = _mask_to_georeferenced_geometry(
-                    mask,
-                    x_offset=x_offset,
-                    y_offset=y_offset,
-                    transform=transform,
-                    simplify_tolerance=simplify_tolerance,
-                )
+        if use_mask_geometry and idx < len(final_mask_geoms):
+            geom = final_mask_geoms[idx]
+            area_pixels = final_mask_areas[idx]
 
         if geom is None:
             # Convert pixel corners to georeferenced coordinates

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -202,6 +202,7 @@ nav:
           - examples/field_boundary_detection.ipynb
           - examples/super_resolution.ipynb
           - examples/rfdetr_detection.ipynb
+          - examples/rfdetr_segmentation.ipynb
           - examples/image_captioning.ipynb
     - Workshops:
           - workshops/GeoAI_Workshop_2025.ipynb

--- a/tests/test_rfdetr.py
+++ b/tests/test_rfdetr.py
@@ -4,6 +4,10 @@
 
 import inspect
 import unittest
+from unittest.mock import patch
+
+import numpy as np
+import pytest
 
 
 class TestRFDETRImport(unittest.TestCase):
@@ -33,6 +37,12 @@ class TestRFDETRImport(unittest.TestCase):
         from geoai.rfdetr import rfdetr_detect
 
         self.assertTrue(callable(rfdetr_detect))
+
+    def test_rfdetr_segment_function_exists(self):
+        """Test that rfdetr_segment convenience function exists."""
+        from geoai.rfdetr import rfdetr_segment
+
+        self.assertTrue(callable(rfdetr_segment))
 
     def test_rfdetr_detect_batch_function_exists(self):
         """Test that rfdetr_detect_batch convenience function exists."""
@@ -77,6 +87,7 @@ class TestRFDETRAllExports(unittest.TestCase):
             "check_rfdetr_available",
             "list_rfdetr_models",
             "rfdetr_detect",
+            "rfdetr_segment",
             "rfdetr_detect_batch",
             "rfdetr_train",
             "push_rfdetr_to_hub",
@@ -154,6 +165,21 @@ class TestRFDETRModels(unittest.TestCase):
         seg_count = sum(1 for name in RFDETR_MODELS if name.startswith("seg-"))
         self.assertEqual(seg_count, 6)
 
+    def test_segmentation_model_resolutions_match_current_rfdetr(self):
+        """Test RF-DETR-Seg native resolutions."""
+        from geoai.rfdetr import RFDETR_MODELS
+
+        expected = {
+            "seg-nano": 312,
+            "seg-small": 384,
+            "seg-medium": 432,
+            "seg-large": 504,
+            "seg-xlarge": 624,
+            "seg-2xlarge": 768,
+        }
+        for model_id, resolution in expected.items():
+            self.assertEqual(RFDETR_MODELS[model_id]["resolution"], resolution)
+
     def test_list_rfdetr_models_returns_descriptions(self):
         """Test that list_rfdetr_models returns model descriptions."""
         from geoai.rfdetr import RFDETR_MODELS, list_rfdetr_models
@@ -185,6 +211,30 @@ class TestRFDETRSignatures(unittest.TestCase):
             "overlap",
             "batch_size",
             "class_names",
+            "use_mask_geometry",
+            "simplify_tolerance",
+            "device",
+        ]
+        for param in expected_params:
+            self.assertIn(param, sig.parameters)
+
+    def test_rfdetr_segment_params(self):
+        """Test rfdetr_segment has expected parameters."""
+        from geoai.rfdetr import rfdetr_segment
+
+        sig = inspect.signature(rfdetr_segment)
+        expected_params = [
+            "input_path",
+            "output_path",
+            "model_variant",
+            "pretrain_weights",
+            "confidence_threshold",
+            "nms_threshold",
+            "window_size",
+            "overlap",
+            "batch_size",
+            "class_names",
+            "simplify_tolerance",
             "device",
         ]
         for param in expected_params:
@@ -265,6 +315,13 @@ class TestRFDETRValidation(unittest.TestCase):
         with self.assertRaises((ValueError, ImportError)):
             _get_rfdetr_model_class("nonexistent_variant")
 
+    def test_rfdetr_segment_rejects_detection_variant(self):
+        """Test rfdetr_segment requires a segmentation model variant."""
+        from geoai.rfdetr import rfdetr_segment
+
+        with self.assertRaises(ValueError):
+            rfdetr_segment("dummy.tif", model_variant="base")
+
 
 class TestRFDETRLazyImport(unittest.TestCase):
     """Tests for lazy import from the top-level geoai package."""
@@ -274,6 +331,12 @@ class TestRFDETRLazyImport(unittest.TestCase):
         from geoai import rfdetr_detect
 
         self.assertTrue(callable(rfdetr_detect))
+
+    def test_lazy_import_rfdetr_segment(self):
+        """Test rfdetr_segment can be imported from geoai via lazy loading."""
+        from geoai import rfdetr_segment
+
+        self.assertTrue(callable(rfdetr_segment))
 
     def test_lazy_import_list_rfdetr_models(self):
         """Test list_rfdetr_models can be imported from geoai."""
@@ -295,11 +358,13 @@ class TestRFDETRLazyImport(unittest.TestCase):
         from geoai import (
             rfdetr_detect,
             rfdetr_detect_batch,
+            rfdetr_segment,
             rfdetr_train,
         )
 
         self.assertTrue(callable(rfdetr_detect))
         self.assertTrue(callable(rfdetr_detect_batch))
+        self.assertTrue(callable(rfdetr_segment))
         self.assertTrue(callable(rfdetr_train))
 
     def test_lazy_import_hub_functions(self):
@@ -308,6 +373,73 @@ class TestRFDETRLazyImport(unittest.TestCase):
 
         self.assertTrue(callable(push_rfdetr_to_hub))
         self.assertTrue(callable(rfdetr_detect_from_hub))
+
+
+class _FakeRFDETRDetections:
+    """Small Supervision-style detections object for RF-DETR tests."""
+
+    def __init__(self):
+        self.xyxy = np.array([[8.0, 8.0, 28.0, 28.0]], dtype=float)
+        self.confidence = np.array([0.92], dtype=float)
+        self.class_id = np.array([0], dtype=int)
+        mask = np.zeros((64, 64), dtype=bool)
+        mask[8:28, 8:18] = True
+        mask[18:28, 18:28] = True
+        self.mask = mask[np.newaxis, ...]
+
+
+class _FakeRFDETRModel:
+    """Small RF-DETR model double returning deterministic masks."""
+
+    class_names = ["building"]
+
+    def predict(self, images, threshold=0.5):
+        return [_FakeRFDETRDetections() for _ in images]
+
+
+def test_rfdetr_segment_vectorizes_masks(tmp_path):
+    """RF-DETR-Seg masks are returned as georeferenced mask polygons."""
+    pytest.importorskip("geopandas")
+    rasterio = pytest.importorskip("rasterio")
+    pytest.importorskip("torch")
+    pytest.importorskip("torchvision")
+
+    from rasterio.transform import from_origin
+
+    from geoai.rfdetr import rfdetr_segment
+
+    image_path = tmp_path / "image.tif"
+    transform = from_origin(0, 64, 1, 1)
+    with rasterio.open(
+        image_path,
+        "w",
+        driver="GTiff",
+        height=64,
+        width=64,
+        count=3,
+        dtype="uint8",
+        crs="EPSG:3857",
+        transform=transform,
+    ) as dst:
+        dst.write(np.zeros((3, 64, 64), dtype=np.uint8))
+
+    with (
+        patch("geoai.rfdetr.RFDETR_AVAILABLE", True),
+        patch("geoai.rfdetr._create_rfdetr_model", return_value=_FakeRFDETRModel()),
+    ):
+        gdf = rfdetr_segment(
+            str(image_path),
+            model_variant="seg-medium",
+            window_size=64,
+            overlap=0,
+            batch_size=1,
+        )
+
+    assert len(gdf) == 1
+    assert gdf.iloc[0]["class_name"] == "building"
+    assert gdf.iloc[0]["area_pixels"] == 300
+    assert gdf.geometry.iloc[0].area == 300
+    assert gdf.geometry.iloc[0].area < 400
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolve #760

## Summary
- Add `rfdetr_segment()` convenience wrapper and `use_mask_geometry`/`simplify_tolerance` options on `rfdetr_detect()` so `seg-*` variants return georeferenced mask polygons instead of bounding boxes
- Update `seg-*` native resolutions (nano 312, small 384, medium 432, large 504, xlarge 624, 2xlarge 768) to match current RF-DETR-Seg releases
- Add tutorial notebook `docs/examples/rfdetr_segmentation.ipynb` and wire it into the mkdocs nav
- Extend `tests/test_rfdetr.py` with API, signature, validation, and end-to-end mask-vectorization tests; ignore `*.pt` weights in `.gitignore`

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/test_rfdetr.py -v`
- [ ] Run `rfdetr_segment()` on a sample GeoTIFF and confirm the output GeoDataFrame contains mask polygons with `area_pixels`