### PR TITLE
feat: preserve ignore_index in semantic segmentation training

### DIFF
--- a/geoai/train.py
+++ b/geoai/train.py
@@ -3167,6 +3167,7 @@ class SemanticSegmentationDataset(Dataset):
         target_size: Optional[Tuple[int, int]] = None,
         resize_mode: str = "resize",
         num_classes: int = 2,
+        ignore_index: Optional[int] = -100,
     ) -> None:
         """
         Initialize dataset for semantic segmentation.
@@ -3183,6 +3184,8 @@ class SemanticSegmentationDataset(Dataset):
                 'resize' - Resize images to target_size (may change aspect ratio)
                 'pad' - Pad images to target_size (preserves aspect ratio)
             num_classes (int): Number of classes for segmentation. Used for mask normalization.
+            ignore_index (int, optional): Label value to preserve as ignored pixels
+                during mask normalization and resizing. Defaults to -100.
         """
         self.image_paths = image_paths
         self.label_paths = label_paths
@@ -3190,6 +3193,7 @@ class SemanticSegmentationDataset(Dataset):
         self.target_size = target_size
         self.resize_mode = resize_mode
         self.num_classes = num_classes
+        self.ignore_index = ignore_index
 
         # Auto-detect the number of channels if not specified
         if num_channels is None:
@@ -3219,6 +3223,41 @@ class SemanticSegmentationDataset(Dataset):
                     # Convert to RGB and return 3 channels
                     return 3
 
+    def _normalize_label_mask(self, label_mask: np.ndarray) -> np.ndarray:
+        """Normalize class labels while preserving ignored pixels."""
+        label_mask = label_mask.astype(np.int64)
+        ignore_mask = None
+        if self.ignore_index is not None:
+            ignore_mask = label_mask == self.ignore_index
+
+        unique_vals = np.unique(label_mask)
+        if self.num_classes == 2:
+            # Binary segmentation: normalize any non-zero value to foreground (1)
+            if unique_vals.max() > 1:
+                label_mask = (label_mask > 0).astype(np.int64)
+        else:
+            # Multi-class segmentation: preserve class IDs and clamp to valid range.
+            label_mask = np.clip(label_mask, 0, self.num_classes - 1)
+
+        if ignore_mask is not None:
+            label_mask[ignore_mask] = self.ignore_index
+
+        return label_mask
+
+    def _clamp_mask_tensor(self, mask: torch.Tensor) -> torch.Tensor:
+        """Clamp resized labels to class range while preserving ignored pixels."""
+        ignore_mask = None
+        if self.ignore_index is not None:
+            ignore_mask = mask == self.ignore_index
+
+        mask = torch.clamp(mask, 0, self.num_classes - 1)
+
+        if ignore_mask is not None:
+            mask = mask.clone()
+            mask[ignore_mask] = self.ignore_index
+
+        return mask
+
     def _resize_image_and_mask(
         self, image: np.ndarray, mask: np.ndarray
     ) -> Tuple[np.ndarray, np.ndarray]:
@@ -3247,15 +3286,15 @@ class SemanticSegmentationDataset(Dataset):
                 .squeeze(0)
                 .long()
             )
-            # Clamp mask values to ensure they're within valid range [0, num_classes-1]
-            mask = torch.clamp(mask, 0, self.num_classes - 1)
+            # Clamp valid mask values without converting ignore_index to a class.
+            mask = self._clamp_mask_tensor(mask)
 
         elif self.resize_mode == "pad":
             # Pad to target size (preserves aspect ratio)
             image = self._pad_to_size(image, (target_h, target_w))
             mask = self._pad_to_size(mask.unsqueeze(0), (target_h, target_w)).squeeze(0)
-            # Clamp mask values to ensure they're within valid range [0, num_classes-1]
-            mask = torch.clamp(mask, 0, self.num_classes - 1)
+            # Clamp valid mask values without converting ignore_index to a class.
+            mask = self._clamp_mask_tensor(mask)
 
         return image, mask
 
@@ -3348,17 +3387,8 @@ class SemanticSegmentationDataset(Dataset):
                     img = img.convert("L")
                 label_mask = np.array(img, dtype=np.int64)
 
-        # Normalize mask values to expected class range [0, num_classes-1]
-        # This handles cases where masks contain pixel values outside the expected range
-        unique_vals = np.unique(label_mask)
-        if self.num_classes == 2:
-            # Binary segmentation: normalize any non-zero value to foreground (1)
-            if unique_vals.max() > 1:
-                label_mask = (label_mask > 0).astype(np.int64)
-        else:
-            # Multi-class segmentation:
-            # Preserve class IDs and only clamp to valid range
-            label_mask = np.clip(label_mask, 0, self.num_classes - 1)
+        # Normalize mask values while preserving ignored/no-data pixels.
+        label_mask = self._normalize_label_mask(label_mask)
 
         # Convert to tensor
         mask = torch.as_tensor(label_mask, dtype=torch.long)
@@ -3645,6 +3675,7 @@ def f1_score(
     target: torch.Tensor,
     smooth: float = 1e-6,
     num_classes: Optional[int] = None,
+    ignore_index: Optional[int] = None,
 ) -> float:
     """
     Calculate F1 score (also known as Dice coefficient) for segmentation (binary or multi-class).
@@ -3654,6 +3685,7 @@ def f1_score(
         target (torch.Tensor): Ground truth mask with shape [H, W].
         smooth (float): Smoothing factor to avoid division by zero.
         num_classes (int, optional): Number of classes. If None, auto-detected.
+        ignore_index (int, optional): Target value to exclude from scoring.
 
     Returns:
         float: Mean F1 score across all classes.
@@ -3667,15 +3699,28 @@ def f1_score(
     else:
         raise ValueError(f"Unexpected prediction dimensions: {pred.shape}")
 
+    if ignore_index is not None:
+        valid_mask = target != ignore_index
+        if not torch.any(valid_mask):
+            return 0.0
+    else:
+        valid_mask = torch.ones_like(target, dtype=torch.bool)
+
     # Auto-detect number of classes if not provided
     if num_classes is None:
-        num_classes = max(pred_classes.max().item(), target.max().item()) + 1
+        num_classes = (
+            max(pred_classes[valid_mask].max().item(), target[valid_mask].max().item())
+            + 1
+        )
 
     # Calculate F1 score for each class and average
     f1_scores = []
     for class_id in range(num_classes):
-        pred_class = (pred_classes == class_id).float()
-        target_class = (target == class_id).float()
+        if ignore_index is not None and class_id == ignore_index:
+            continue
+
+        pred_class = ((pred_classes == class_id) & valid_mask).float()
+        target_class = ((target == class_id) & valid_mask).float()
 
         intersection = (pred_class * target_class).sum()
         union = pred_class.sum() + target_class.sum()
@@ -3692,6 +3737,7 @@ def iou_coefficient(
     target: torch.Tensor,
     smooth: float = 1e-6,
     num_classes: Optional[int] = None,
+    ignore_index: Optional[int] = None,
 ) -> float:
     """
     Calculate IoU coefficient for segmentation (binary or multi-class).
@@ -3701,6 +3747,7 @@ def iou_coefficient(
         target (torch.Tensor): Ground truth mask with shape [H, W].
         smooth (float): Smoothing factor to avoid division by zero.
         num_classes (int, optional): Number of classes. If None, auto-detected.
+        ignore_index (int, optional): Target value to exclude from scoring.
 
     Returns:
         float: Mean IoU coefficient across all classes.
@@ -3714,15 +3761,28 @@ def iou_coefficient(
     else:
         raise ValueError(f"Unexpected prediction dimensions: {pred.shape}")
 
+    if ignore_index is not None:
+        valid_mask = target != ignore_index
+        if not torch.any(valid_mask):
+            return 0.0
+    else:
+        valid_mask = torch.ones_like(target, dtype=torch.bool)
+
     # Auto-detect number of classes if not provided
     if num_classes is None:
-        num_classes = max(pred_classes.max().item(), target.max().item()) + 1
+        num_classes = (
+            max(pred_classes[valid_mask].max().item(), target[valid_mask].max().item())
+            + 1
+        )
 
     # Calculate IoU for each class and average
     iou_scores = []
     for class_id in range(num_classes):
-        pred_class = (pred_classes == class_id).float()
-        target_class = (target == class_id).float()
+        if ignore_index is not None and class_id == ignore_index:
+            continue
+
+        pred_class = ((pred_classes == class_id) & valid_mask).float()
+        target_class = ((target == class_id) & valid_mask).float()
 
         intersection = (pred_class * target_class).sum()
         union = pred_class.sum() + target_class.sum() - intersection
@@ -3739,6 +3799,7 @@ def precision_score(
     target: torch.Tensor,
     smooth: float = 1e-6,
     num_classes: Optional[int] = None,
+    ignore_index: Optional[int] = None,
 ) -> float:
     """
     Calculate precision score for segmentation (binary or multi-class).
@@ -3752,6 +3813,7 @@ def precision_score(
         target (torch.Tensor): Ground truth mask with shape [H, W].
         smooth (float): Smoothing factor to avoid division by zero.
         num_classes (int, optional): Number of classes. If None, auto-detected.
+        ignore_index (int, optional): Target value to exclude from scoring.
 
     Returns:
         float: Mean precision score across all classes.
@@ -3765,15 +3827,28 @@ def precision_score(
     else:
         raise ValueError(f"Unexpected prediction dimensions: {pred.shape}")
 
+    if ignore_index is not None:
+        valid_mask = target != ignore_index
+        if not torch.any(valid_mask):
+            return 0.0
+    else:
+        valid_mask = torch.ones_like(target, dtype=torch.bool)
+
     # Auto-detect number of classes if not provided
     if num_classes is None:
-        num_classes = max(pred_classes.max().item(), target.max().item()) + 1
+        num_classes = (
+            max(pred_classes[valid_mask].max().item(), target[valid_mask].max().item())
+            + 1
+        )
 
     # Calculate precision for each class and average
     precision_scores = []
     for class_id in range(num_classes):
-        pred_class = (pred_classes == class_id).float()
-        target_class = (target == class_id).float()
+        if ignore_index is not None and class_id == ignore_index:
+            continue
+
+        pred_class = ((pred_classes == class_id) & valid_mask).float()
+        target_class = ((target == class_id) & valid_mask).float()
 
         true_positives = (pred_class * target_class).sum()
         predicted_positives = pred_class.sum()
@@ -3790,6 +3865,7 @@ def recall_score(
     target: torch.Tensor,
     smooth: float = 1e-6,
     num_classes: Optional[int] = None,
+    ignore_index: Optional[int] = None,
 ) -> float:
     """
     Calculate recall score (also known as sensitivity) for segmentation (binary or multi-class).
@@ -3803,6 +3879,7 @@ def recall_score(
         target (torch.Tensor): Ground truth mask with shape [H, W].
         smooth (float): Smoothing factor to avoid division by zero.
         num_classes (int, optional): Number of classes. If None, auto-detected.
+        ignore_index (int, optional): Target value to exclude from scoring.
 
     Returns:
         float: Mean recall score across all classes.
@@ -3816,15 +3893,28 @@ def recall_score(
     else:
         raise ValueError(f"Unexpected prediction dimensions: {pred.shape}")
 
+    if ignore_index is not None:
+        valid_mask = target != ignore_index
+        if not torch.any(valid_mask):
+            return 0.0
+    else:
+        valid_mask = torch.ones_like(target, dtype=torch.bool)
+
     # Auto-detect number of classes if not provided
     if num_classes is None:
-        num_classes = max(pred_classes.max().item(), target.max().item()) + 1
+        num_classes = (
+            max(pred_classes[valid_mask].max().item(), target[valid_mask].max().item())
+            + 1
+        )
 
     # Calculate recall for each class and average
     recall_scores = []
     for class_id in range(num_classes):
-        pred_class = (pred_classes == class_id).float()
-        target_class = (target == class_id).float()
+        if ignore_index is not None and class_id == ignore_index:
+            continue
+
+        pred_class = ((pred_classes == class_id) & valid_mask).float()
+        target_class = ((target == class_id) & valid_mask).float()
 
         true_positives = (pred_class * target_class).sum()
         actual_positives = target_class.sum()
@@ -3905,6 +3995,7 @@ def evaluate_semantic(
     device: torch.device,
     criterion: Any,
     num_classes: int = 2,
+    ignore_index: Optional[int] = None,
 ) -> Dict[str, float]:
     """
     Evaluate the semantic segmentation model on the validation set.
@@ -3915,6 +4006,7 @@ def evaluate_semantic(
         device (torch.device): Device to evaluate on.
         criterion: Loss function.
         num_classes (int): Number of classes for evaluation metrics.
+        ignore_index (int, optional): Target value to exclude from scoring.
 
     Returns:
         dict: Evaluation metrics including loss, IoU, F1, precision, and recall.
@@ -3941,10 +4033,30 @@ def evaluate_semantic(
 
             # Calculate metrics for each sample in the batch
             for pred, target in zip(outputs, targets):
-                f1 = f1_score(pred, target, num_classes=num_classes)
-                iou = iou_coefficient(pred, target, num_classes=num_classes)
-                precision = precision_score(pred, target, num_classes=num_classes)
-                recall = recall_score(pred, target, num_classes=num_classes)
+                f1 = f1_score(
+                    pred,
+                    target,
+                    num_classes=num_classes,
+                    ignore_index=ignore_index,
+                )
+                iou = iou_coefficient(
+                    pred,
+                    target,
+                    num_classes=num_classes,
+                    ignore_index=ignore_index,
+                )
+                precision = precision_score(
+                    pred,
+                    target,
+                    num_classes=num_classes,
+                    ignore_index=ignore_index,
+                )
+                recall = recall_score(
+                    pred,
+                    target,
+                    num_classes=num_classes,
+                    ignore_index=ignore_index,
+                )
                 f1_scores.append(f1)
                 iou_scores.append(iou)
                 precision_scores.append(precision)
@@ -3999,7 +4111,7 @@ def train_segmentation_model(
     val_transforms: Optional[Callable] = None,
     loss_fn: Optional[torch.nn.Module] = None,
     class_weights: Optional[List[float]] = None,
-    ignore_index: int = -100,
+    ignore_index: Optional[int] = -100,
     freeze_encoder: bool = False,
     **kwargs: Any,
 ) -> torch.nn.Module:
@@ -4071,9 +4183,10 @@ def train_segmentation_model(
         class_weights (list, optional): Per-class weights for CrossEntropyLoss
             (e.g., ``[0.5, 2.0]`` for a 2-class problem). Ignored when *loss_fn*
             is provided. Defaults to None.
-        ignore_index (int): Target value that is ignored by the default
+        ignore_index (int, optional): Target value that is ignored by the default
             CrossEntropyLoss. Ignored when *loss_fn* is provided.
-            Defaults to -100 (PyTorch default, i.e., no pixels ignored).
+            Set to None to disable ignore-index handling in label normalization,
+            loss, and metrics. Defaults to -100 (PyTorch default).
         freeze_encoder (bool): If True, freeze the encoder parameters so only the
             decoder is trained. Useful for fine-tuning on small datasets to prevent
             overfitting. Defaults to False.
@@ -4250,6 +4363,7 @@ def train_segmentation_model(
         target_size=target_size,
         resize_mode=resize_mode,
         num_classes=num_classes,
+        ignore_index=ignore_index,
     )
     val_dataset = SemanticSegmentationDataset(
         val_imgs,
@@ -4259,6 +4373,7 @@ def train_segmentation_model(
         target_size=target_size,
         resize_mode=resize_mode,
         num_classes=num_classes,
+        ignore_index=ignore_index,
     )
 
     # Create data loaders
@@ -4339,11 +4454,17 @@ def train_segmentation_model(
                 f"num_classes ({num_classes})"
             )
         weight_tensor = torch.tensor(class_weights, dtype=torch.float32).to(device)
-        criterion = torch.nn.CrossEntropyLoss(
-            weight=weight_tensor, ignore_index=ignore_index
-        )
+        if ignore_index is None:
+            criterion = torch.nn.CrossEntropyLoss(weight=weight_tensor)
+        else:
+            criterion = torch.nn.CrossEntropyLoss(
+                weight=weight_tensor, ignore_index=ignore_index
+            )
     else:
-        criterion = torch.nn.CrossEntropyLoss(ignore_index=ignore_index)
+        if ignore_index is None:
+            criterion = torch.nn.CrossEntropyLoss()
+        else:
+            criterion = torch.nn.CrossEntropyLoss(ignore_index=ignore_index)
 
     # Initialize tracking variables
     best_iou = 0
@@ -4480,7 +4601,12 @@ def train_segmentation_model(
 
         # Evaluate on validation set
         eval_metrics = evaluate_semantic(
-            model, val_loader, device, criterion, num_classes=num_classes
+            model,
+            val_loader,
+            device,
+            criterion,
+            num_classes=num_classes,
+            ignore_index=ignore_index,
         )
         val_losses.append(eval_metrics["loss"])
         val_ious.append(eval_metrics["IoU"])

--- a/geoai/train.py
+++ b/geoai/train.py
@@ -3259,13 +3259,14 @@ class SemanticSegmentationDataset(Dataset):
         return mask
 
     def _resize_image_and_mask(
-        self, image: np.ndarray, mask: np.ndarray
-    ) -> Tuple[np.ndarray, np.ndarray]:
+        self, image: torch.Tensor, mask: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Resize image and mask to target size."""
         if self.target_size is None:
             return image, mask
 
         target_h, target_w = self.target_size
+        mask_pad_value = 0 if self.ignore_index is None else self.ignore_index
 
         if self.resize_mode == "resize":
             # Direct resize (may change aspect ratio)
@@ -3290,18 +3291,31 @@ class SemanticSegmentationDataset(Dataset):
             mask = self._clamp_mask_tensor(mask)
 
         elif self.resize_mode == "pad":
-            # Pad to target size (preserves aspect ratio)
+            # Pad to target size (preserves aspect ratio). Pad masks with
+            # ignore_index (when set) so newly introduced padding pixels are
+            # excluded from loss/metrics rather than being learned as class 0.
             image = self._pad_to_size(image, (target_h, target_w))
-            mask = self._pad_to_size(mask.unsqueeze(0), (target_h, target_w)).squeeze(0)
+            mask = self._pad_to_size(
+                mask.unsqueeze(0), (target_h, target_w), pad_value=mask_pad_value
+            ).squeeze(0)
             # Clamp valid mask values without converting ignore_index to a class.
             mask = self._clamp_mask_tensor(mask)
 
         return image, mask
 
     def _pad_to_size(
-        self, tensor: torch.Tensor, target_size: Tuple[int, int]
+        self,
+        tensor: torch.Tensor,
+        target_size: Tuple[int, int],
+        pad_value: float = 0,
     ) -> torch.Tensor:
-        """Pad tensor to target size with zeros."""
+        """Pad tensor to target size.
+
+        Args:
+            tensor: Tensor with shape ``[C, H, W]`` or ``[H, W]``.
+            target_size: Target ``(height, width)``.
+            pad_value: Fill value used for padded pixels. Defaults to ``0``.
+        """
         target_h, target_w = target_size
 
         if tensor.dim() == 3:  # Image [C, H, W]
@@ -3322,7 +3336,9 @@ class SemanticSegmentationDataset(Dataset):
         pad_right = pad_w - pad_left
 
         # Apply padding (left, right, top, bottom)
-        padded = F.pad(tensor, (pad_left, pad_right, pad_top, pad_bottom), value=0)
+        padded = F.pad(
+            tensor, (pad_left, pad_right, pad_top, pad_bottom), value=pad_value
+        )
 
         # Crop if tensor is larger than target
         if tensor.dim() == 3:

--- a/tests/test_train_ignore_index.py
+++ b/tests/test_train_ignore_index.py
@@ -107,12 +107,24 @@ class TestSemanticMetricsIgnoreIndex(unittest.TestCase):
         )
 
     def test_metrics_return_zero_when_all_pixels_ignored(self):
-        """All-ignored targets should produce a defined zero score."""
+        """All-ignored targets should produce a defined zero score for every metric."""
         pred = torch.tensor([[0, 1], [1, 0]])
         target = torch.full((2, 2), -100, dtype=torch.long)
 
         self.assertEqual(
             iou_coefficient(pred, target, num_classes=2, ignore_index=-100),
+            0.0,
+        )
+        self.assertEqual(
+            f1_score(pred, target, num_classes=2, ignore_index=-100),
+            0.0,
+        )
+        self.assertEqual(
+            precision_score(pred, target, num_classes=2, ignore_index=-100),
+            0.0,
+        )
+        self.assertEqual(
+            recall_score(pred, target, num_classes=2, ignore_index=-100),
             0.0,
         )
 

--- a/tests/test_train_ignore_index.py
+++ b/tests/test_train_ignore_index.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+"""Tests for ignore_index handling in `geoai.train` semantic segmentation."""
+
+import unittest
+
+import numpy as np
+import torch
+
+from geoai.train import (
+    SemanticSegmentationDataset,
+    f1_score,
+    iou_coefficient,
+    precision_score,
+    recall_score,
+)
+
+
+class TestSemanticSegmentationDatasetIgnoreIndex(unittest.TestCase):
+    """Tests for preserving ignored pixels in semantic segmentation labels."""
+
+    def test_multiclass_normalization_preserves_negative_ignore_index(self):
+        """Multi-class label clipping should not turn -100 into class 0."""
+        dataset = SemanticSegmentationDataset(
+            [],
+            [],
+            num_channels=3,
+            num_classes=4,
+            ignore_index=-100,
+        )
+        mask = np.array([[0, 1, -100], [5, 2, -100]], dtype=np.int16)
+
+        result = dataset._normalize_label_mask(mask)
+
+        np.testing.assert_array_equal(
+            result,
+            np.array([[0, 1, -100], [3, 2, -100]], dtype=np.int64),
+        )
+
+    def test_binary_normalization_preserves_positive_ignore_index(self):
+        """Binary non-zero normalization should not turn 255 into foreground."""
+        dataset = SemanticSegmentationDataset(
+            [],
+            [],
+            num_channels=3,
+            num_classes=2,
+            ignore_index=255,
+        )
+        mask = np.array([[0, 255], [128, 1]], dtype=np.uint8)
+
+        result = dataset._normalize_label_mask(mask)
+
+        np.testing.assert_array_equal(
+            result,
+            np.array([[0, 255], [1, 1]], dtype=np.int64),
+        )
+
+    def test_resize_preserves_ignore_index(self):
+        """Nearest-neighbor resizing should keep ignored pixels ignored."""
+        dataset = SemanticSegmentationDataset(
+            [],
+            [],
+            num_channels=3,
+            target_size=(4, 4),
+            resize_mode="resize",
+            num_classes=3,
+            ignore_index=-100,
+        )
+        image = torch.zeros((3, 2, 2), dtype=torch.float32)
+        mask = torch.tensor([[0, -100], [2, 5]], dtype=torch.long)
+
+        _, resized = dataset._resize_image_and_mask(image, mask)
+
+        self.assertIn(-100, resized.tolist()[0])
+        valid = resized != -100
+        self.assertTrue(torch.all(resized[valid] >= 0))
+        self.assertTrue(torch.all(resized[valid] <= 2))
+
+
+class TestSemanticMetricsIgnoreIndex(unittest.TestCase):
+    """Tests for excluding ignored pixels from semantic metrics."""
+
+    def test_metrics_exclude_ignore_index_pixels(self):
+        """Wrong predictions on ignored pixels should not reduce metrics."""
+        pred = torch.tensor([[0, 0], [1, 1]])
+        target = torch.tensor([[0, -100], [1, 1]])
+
+        self.assertAlmostEqual(
+            iou_coefficient(pred, target, num_classes=2, ignore_index=-100),
+            1.0,
+            places=6,
+        )
+        self.assertAlmostEqual(
+            f1_score(pred, target, num_classes=2, ignore_index=-100),
+            1.0,
+            places=6,
+        )
+        self.assertAlmostEqual(
+            precision_score(pred, target, num_classes=2, ignore_index=-100),
+            1.0,
+            places=6,
+        )
+        self.assertAlmostEqual(
+            recall_score(pred, target, num_classes=2, ignore_index=-100),
+            1.0,
+            places=6,
+        )
+
+    def test_metrics_return_zero_when_all_pixels_ignored(self):
+        """All-ignored targets should produce a defined zero score."""
+        pred = torch.tensor([[0, 1], [1, 0]])
+        target = torch.full((2, 2), -100, dtype=torch.long)
+
+        self.assertEqual(
+            iou_coefficient(pred, target, num_classes=2, ignore_index=-100),
+            0.0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds an `ignore_index` parameter (default `-100`) to `SemanticSegmentationDataset` and `train_segmentation_model()`, threading it through label normalization, resizing, the default `CrossEntropyLoss`, and the validation metrics (`f1_score`, `iou_coefficient`, `precision_score`, `recall_score`, `evaluate_semantic`).
- Previously, no-data/ignored pixels in multi-class masks were silently clipped to class `0` (or normalized to foreground in the binary case), so PyTorch's default `-100` sentinel — or any custom no-data value — was being trained as a real class. This polluted both training and validation on geospatial datasets with masked-out regions.
- Passing `ignore_index=None` is supported and fully disables the ignore-index path (label normalization, loss, metrics), preserving the prior behavior for users who want it.

Closes #765

## Test plan
- [x] `pytest tests/test_train_ignore_index.py --verbose` (5 new tests, all pass)
  - Multi-class normalization preserves a negative `ignore_index` (`-100`) instead of clipping to class `0`.
  - Binary normalization preserves a positive sentinel (e.g. `255`) instead of mapping it to foreground.
  - Nearest-neighbor resizing keeps ignored pixels ignored.
  - `f1_score` / `iou_coefficient` / `precision_score` / `recall_score` exclude ignored pixels from scoring.
  - Metrics return `0.0` (rather than erroring) when every target pixel is ignored.
- [x] `pre-commit run --files geoai/train.py tests/test_train_ignore_index.py` (black, codespell, bandit, etc. — all pass).