### PR TITLE
feat: add diagnostics report dialog to QGIS plugin

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,16 @@ labels: bug
 -   Python version:
 -   Operating System:
 
+### QGIS Plugin Diagnostics
+
+If this bug is related to the QGIS plugin, open QGIS and go to
+`GeoAI` → `Generate Diagnostics Report...`, click **Copy Markdown**, and paste
+the full report below.
+
+```markdown
+Paste the QGIS plugin diagnostics report here.
+```
+
 ### Description
 
 Describe what you were trying to get done.

--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -546,6 +546,10 @@ Go to `GeoAI` menu → `Check for Updates...` to see if a newer version of the G
 
 ![](https://github.com/user-attachments/assets/cc0dfd38-9b41-4735-9af0-c49b7aa71b72)
 
+### Diagnostics Report
+
+Go to `GeoAI` menu → `Generate Diagnostics Report...` to create a Markdown report that can be copied directly into a GitHub issue. The report includes the plugin version, QGIS/Python runtime, operating system, managed virtual environment path, CUDA availability, GPU details, and versions/import status for key packages such as `geoai-py`, PyTorch, SAM3, Transformers, and `segment-geospatial`.
+
 ## Supported Model Architectures (Segmentation)
 
 The QGIS plugin supports any models supported by [Pytorch Segmentation Models](https://smp.readthedocs.io/en/latest/models.html), including:
@@ -578,6 +582,7 @@ The QGIS plugin supports any models supported by [Pytorch Segmentation Models](h
 
 ## Troubleshooting
 
+- If you report a plugin issue on GitHub, include the Markdown from `GeoAI` menu → `Generate Diagnostics Report...`.
 - Plugin missing after install: confirm the plugin folder exists in your QGIS profile path and that you restarted QGIS.
 - CUDA OOM: use the **GPU** button to clear cache, lower batch sizes, or switch to CPU for smaller runs.
 - Model download failures: check network/firewall, then retry loading models from the panel.

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -380,6 +380,10 @@ Go to `GeoAI` menu → `Check for Updates...` to see if a newer version of the G
 
 ![](https://github.com/user-attachments/assets/cc0dfd38-9b41-4735-9af0-c49b7aa71b72)
 
+### Diagnostics Report
+
+Go to `GeoAI` menu → `Generate Diagnostics Report...` to create a Markdown report that can be copied directly into a GitHub issue. The report includes the plugin version, QGIS/Python runtime, operating system, managed virtual environment path, CUDA availability, GPU details, and versions/import status for key packages such as `geoai-py`, PyTorch, SAM3, Transformers, and `segment-geospatial`.
+
 ## Supported Model Architectures (Segmentation)
 
 The QGIS plugin supports any models supported by [Pytorch Segmentation Models](https://smp.readthedocs.io/en/latest/models.html), including:
@@ -412,6 +416,7 @@ The QGIS plugin supports any models supported by [Pytorch Segmentation Models](h
 
 ## Troubleshooting
 
+-   If you report a plugin issue on GitHub, include the Markdown from `GeoAI` menu → `Generate Diagnostics Report...`.
 -   Plugin missing after install: confirm the plugin folder exists in your QGIS profile path and that you restarted QGIS.
 -   CUDA OOM: use the **GPU** button to clear cache, lower batch sizes, or switch to CPU for smaller runs.
 -   Model download failures: check network/firewall, then retry loading models from the panel.

--- a/qgis_plugin/geoai/core/diagnostics.py
+++ b/qgis_plugin/geoai/core/diagnostics.py
@@ -380,7 +380,8 @@ def _format_packages(packages: Iterable[Dict[str, Any]]) -> List[str]:
         if package.get("module_file"):
             detail_lines.append(f"- module file: `{_value(package['module_file'])}`")
         if package.get("import_error"):
-            detail_lines.append(f"- import error: `{_value(package['import_error'])}`")
+            detail_lines.append("- import error:")
+            detail_lines.extend(_fenced_block(_value(package["import_error"])))
         if detail_lines:
             details.append("")
             details.append(f"<details><summary>{label} details</summary>")
@@ -406,6 +407,26 @@ def _value(value: Any, missing: str = "Unknown") -> str:
 
 def _escape_table(value: Any) -> str:
     return _value(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _fenced_block(value: str) -> List[str]:
+    """Render arbitrary text as a Markdown fenced code block.
+
+    The fence length is chosen so that any internal backtick run cannot close
+    the block, which keeps multi-line tracebacks and backtick characters from
+    breaking the surrounding Markdown rendering.
+    """
+    text = "" if value is None else str(value)
+    longest_run = 0
+    current_run = 0
+    for char in text:
+        if char == "`":
+            current_run += 1
+            longest_run = max(longest_run, current_run)
+        else:
+            current_run = 0
+    fence = "`" * max(3, longest_run + 1)
+    return [fence] + text.splitlines() + [fence]
 
 
 def _redact_home(value: str) -> str:

--- a/qgis_plugin/geoai/core/diagnostics.py
+++ b/qgis_plugin/geoai/core/diagnostics.py
@@ -3,6 +3,7 @@
 import json
 import os
 import platform
+import re
 import subprocess
 import sys
 import textwrap
@@ -52,33 +53,33 @@ def generate_diagnostics_report() -> str:
         "",
         "## Plugin",
         "",
-        f"- GeoAI plugin version: `{plugin_info.get('version', 'Unknown')}`",
-        f"- Plugin path: `{plugin_info.get('path', 'Unknown')}`",
+        f"- GeoAI plugin version: `{_value(plugin_info.get('version'))}`",
+        f"- Plugin path: `{_value(plugin_info.get('path'))}`",
         "",
         "## QGIS Process",
         "",
-        f"- QGIS version: `{qgis_info.get('qgis_version', 'Unknown')}`",
-        f"- Python version: `{qgis_info.get('python_version', 'Unknown')}`",
-        f"- Python executable: `{qgis_info.get('python_executable', 'Unknown')}`",
-        f"- Python prefix: `{qgis_info.get('python_prefix', 'Unknown')}`",
+        f"- QGIS version: `{_value(qgis_info.get('qgis_version'))}`",
+        f"- Python version: `{_value(qgis_info.get('python_version'))}`",
+        f"- Python executable: `{_value(qgis_info.get('python_executable'))}`",
+        f"- Python prefix: `{_value(qgis_info.get('python_prefix'))}`",
         "",
         "## Operating System",
         "",
-        f"- OS: `{system_info.get('platform', 'Unknown')}`",
-        f"- System: `{system_info.get('system', 'Unknown')}`",
-        f"- Release: `{system_info.get('release', 'Unknown')}`",
-        f"- Machine: `{system_info.get('machine', 'Unknown')}`",
-        f"- Processor: `{system_info.get('processor', 'Unknown')}`",
+        f"- OS: `{_value(system_info.get('platform'))}`",
+        f"- System: `{_value(system_info.get('system'))}`",
+        f"- Release: `{_value(system_info.get('release'))}`",
+        f"- Machine: `{_value(system_info.get('machine'))}`",
+        f"- Processor: `{_value(system_info.get('processor'))}`",
         "",
         "## Managed Environment",
         "",
-        f"- Cache directory: `{venv_info['cache_dir']}`",
-        f"- Virtual environment path: `{venv_info['venv_dir']}`",
+        f"- Cache directory: `{_value(venv_info['cache_dir'])}`",
+        f"- Virtual environment path: `{_value(venv_info['venv_dir'])}`",
         f"- Virtual environment exists: `{_yes_no(venv_info['exists'])}`",
-        f"- Virtual environment Python: `{venv_info['python_path']}`",
-        f"- Virtual environment site-packages: `{venv_info['site_packages']}`",
-        f"- GEOAI_CACHE_DIR: `{os.environ.get('GEOAI_CACHE_DIR', '<unset>')}`",
-        f"- GEOAI_VENV_DIR: `{os.environ.get('GEOAI_VENV_DIR', '<unset>')}`",
+        f"- Virtual environment Python: `{_value(venv_info['python_path'])}`",
+        f"- Virtual environment site-packages: `{_value(venv_info['site_packages'])}`",
+        f"- GEOAI_CACHE_DIR: `{_value(os.environ.get('GEOAI_CACHE_DIR'), '<unset>')}`",
+        f"- GEOAI_VENV_DIR: `{_value(os.environ.get('GEOAI_VENV_DIR'), '<unset>')}`",
         "",
         "## GPU Detection",
         "",
@@ -88,13 +89,13 @@ def generate_diagnostics_report() -> str:
 
     if gpu_detect_info["details"]:
         for key, value in gpu_detect_info["details"].items():
-            lines.append(f"- NVIDIA {key}: `{value}`")
+            lines.append(f"- NVIDIA {key}: `{_value(value)}`")
     if gpu_detect_info["error"]:
-        lines.append(f"- NVIDIA detection error: `{gpu_detect_info['error']}`")
+        lines.append(f"- NVIDIA detection error: `{_value(gpu_detect_info['error'])}`")
 
     lines.extend(["", "## Venv Runtime", ""])
     if venv_runtime.get("error"):
-        lines.append(f"- Error: `{venv_runtime['error']}`")
+        lines.append(f"- Error: `{_value(venv_runtime['error'])}`")
     else:
         lines.extend(_format_venv_runtime(venv_runtime))
 
@@ -308,10 +309,10 @@ def _venv_probe_script() -> str:
 def _format_venv_runtime(runtime: Dict[str, Any]) -> List[str]:
     torch_runtime = runtime.get("torch_runtime", {})
     lines = [
-        f"- Python version: `{runtime.get('python_version', 'Unknown')}`",
-        f"- Python executable: `{runtime.get('python_executable', 'Unknown')}`",
-        f"- Python prefix: `{runtime.get('python_prefix', 'Unknown')}`",
-        f"- Platform: `{runtime.get('platform', 'Unknown')}`",
+        f"- Python version: `{_value(runtime.get('python_version'))}`",
+        f"- Python executable: `{_value(runtime.get('python_executable'))}`",
+        f"- Python prefix: `{_value(runtime.get('python_prefix'))}`",
+        f"- Platform: `{_value(runtime.get('platform'))}`",
         "",
         "## CUDA / Accelerator",
         "",
@@ -324,10 +325,10 @@ def _format_venv_runtime(runtime: Dict[str, Any]) -> List[str]:
 
     cuda_devices = torch_runtime.get("cuda_devices") or []
     for index, name in enumerate(cuda_devices):
-        lines.append(f"- CUDA device {index}: `{name}`")
+        lines.append(f"- CUDA device {index}: `{_value(name)}`")
 
     if torch_runtime.get("cuda_error"):
-        lines.append(f"- CUDA error: `{torch_runtime['cuda_error']}`")
+        lines.append(f"- CUDA error: `{_value(torch_runtime['cuda_error'])}`")
     lines.extend(
         [
             f"- cuDNN version: `{_value(torch_runtime.get('cudnn_version'))}`",
@@ -336,9 +337,11 @@ def _format_venv_runtime(runtime: Dict[str, Any]) -> List[str]:
         ]
     )
     if torch_runtime.get("mps_error"):
-        lines.append(f"- MPS error: `{torch_runtime['mps_error']}`")
+        lines.append(f"- MPS error: `{_value(torch_runtime['mps_error'])}`")
     if torch_runtime.get("torch_import_error"):
-        lines.append(f"- PyTorch import error: `{torch_runtime['torch_import_error']}`")
+        lines.append(
+            f"- PyTorch import error: `{_value(torch_runtime['torch_import_error'])}`"
+        )
 
     lines.extend(["", "## Package Versions", ""])
     lines.extend(_format_packages(runtime.get("packages", [])))
@@ -372,12 +375,12 @@ def _format_packages(packages: Iterable[Dict[str, Any]]) -> List[str]:
         detail_lines = []
         if package.get("module_version") and package.get("module_version") != version:
             detail_lines.append(
-                f"- module `__version__`: `{package['module_version']}`"
+                f"- module `__version__`: `{_value(package['module_version'])}`"
             )
         if package.get("module_file"):
-            detail_lines.append(f"- module file: `{package['module_file']}`")
+            detail_lines.append(f"- module file: `{_value(package['module_file'])}`")
         if package.get("import_error"):
-            detail_lines.append(f"- import error: `{package['import_error']}`")
+            detail_lines.append(f"- import error: `{_value(package['import_error'])}`")
         if detail_lines:
             details.append("")
             details.append(f"<details><summary>{label} details</summary>")
@@ -398,8 +401,30 @@ def _yes_no(value: Optional[bool]) -> str:
 def _value(value: Any, missing: str = "Unknown") -> str:
     if value is None or value == "":
         return missing
-    return str(value)
+    return _redact_home(str(value))
 
 
 def _escape_table(value: Any) -> str:
-    return str(value).replace("|", "\\|").replace("\n", " ")
+    return _value(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _redact_home(value: str) -> str:
+    """Replace the current user's home directory with ``~`` in report output."""
+    home = os.path.expanduser("~")
+    if not home or home == "~":
+        return value
+
+    redacted = value
+    candidates = {home, os.path.abspath(home)}
+    candidates.update(path.replace("\\", "/") for path in list(candidates))
+
+    for candidate in sorted(candidates, key=len, reverse=True):
+        if not candidate or candidate == os.path.sep:
+            continue
+        redacted = re.sub(
+            re.escape(candidate) + r"(?=$|[/\\\s`'\"),;:])",
+            "~",
+            redacted,
+        )
+
+    return redacted

--- a/qgis_plugin/geoai/core/diagnostics.py
+++ b/qgis_plugin/geoai/core/diagnostics.py
@@ -1,0 +1,405 @@
+"""Diagnostics report generation for the GeoAI QGIS plugin."""
+
+import json
+import os
+import platform
+import subprocess
+import sys
+import textwrap
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+from .venv_manager import (
+    CACHE_DIR,
+    VENV_DIR,
+    _get_clean_env_for_venv,
+    _get_subprocess_kwargs,
+    detect_nvidia_gpu,
+    get_venv_python_path,
+    get_venv_site_packages,
+    venv_exists,
+)
+
+PACKAGE_SPECS = [
+    ("geoai-py", "geoai", "GeoAI"),
+    ("torch", "torch", "PyTorch"),
+    ("torchvision", "torchvision", "TorchVision"),
+    ("sam3", "sam3", "SAM3"),
+    ("transformers", "transformers", "Transformers"),
+    ("segment-geospatial", "samgeo", "Segment Geospatial"),
+    ("segmentation-models-pytorch", "segmentation_models_pytorch", "SMP"),
+    ("deepforest", "deepforest", "DeepForest"),
+    ("omniwatermask", "omniwatermask", "OmniWaterMask"),
+    ("rasterio", "rasterio", "Rasterio"),
+    ("geopandas", "geopandas", "GeoPandas"),
+    ("numpy", "numpy", "NumPy"),
+]
+
+
+def generate_diagnostics_report() -> str:
+    """Generate a Markdown diagnostics report for support and bug reports."""
+    plugin_info = _get_plugin_info()
+    qgis_info = _get_qgis_info()
+    system_info = _get_system_info()
+    gpu_detect_info = _get_nvidia_gpu_detection()
+    venv_info = _get_venv_info()
+    venv_runtime = _collect_venv_runtime_info(venv_info)
+
+    lines = [
+        "# GeoAI QGIS Diagnostics Report",
+        "",
+        f"Generated: {datetime.now(timezone.utc).isoformat()}",
+        "",
+        "## Plugin",
+        "",
+        f"- GeoAI plugin version: `{plugin_info.get('version', 'Unknown')}`",
+        f"- Plugin path: `{plugin_info.get('path', 'Unknown')}`",
+        "",
+        "## QGIS Process",
+        "",
+        f"- QGIS version: `{qgis_info.get('qgis_version', 'Unknown')}`",
+        f"- Python version: `{qgis_info.get('python_version', 'Unknown')}`",
+        f"- Python executable: `{qgis_info.get('python_executable', 'Unknown')}`",
+        f"- Python prefix: `{qgis_info.get('python_prefix', 'Unknown')}`",
+        "",
+        "## Operating System",
+        "",
+        f"- OS: `{system_info.get('platform', 'Unknown')}`",
+        f"- System: `{system_info.get('system', 'Unknown')}`",
+        f"- Release: `{system_info.get('release', 'Unknown')}`",
+        f"- Machine: `{system_info.get('machine', 'Unknown')}`",
+        f"- Processor: `{system_info.get('processor', 'Unknown')}`",
+        "",
+        "## Managed Environment",
+        "",
+        f"- Cache directory: `{venv_info['cache_dir']}`",
+        f"- Virtual environment path: `{venv_info['venv_dir']}`",
+        f"- Virtual environment exists: `{_yes_no(venv_info['exists'])}`",
+        f"- Virtual environment Python: `{venv_info['python_path']}`",
+        f"- Virtual environment site-packages: `{venv_info['site_packages']}`",
+        f"- GEOAI_CACHE_DIR: `{os.environ.get('GEOAI_CACHE_DIR', '<unset>')}`",
+        f"- GEOAI_VENV_DIR: `{os.environ.get('GEOAI_VENV_DIR', '<unset>')}`",
+        "",
+        "## GPU Detection",
+        "",
+        "- NVIDIA GPU detected by `nvidia-smi`: "
+        f"`{_yes_no(gpu_detect_info['detected'])}`",
+    ]
+
+    if gpu_detect_info["details"]:
+        for key, value in gpu_detect_info["details"].items():
+            lines.append(f"- NVIDIA {key}: `{value}`")
+    if gpu_detect_info["error"]:
+        lines.append(f"- NVIDIA detection error: `{gpu_detect_info['error']}`")
+
+    lines.extend(["", "## Venv Runtime", ""])
+    if venv_runtime.get("error"):
+        lines.append(f"- Error: `{venv_runtime['error']}`")
+    else:
+        lines.extend(_format_venv_runtime(venv_runtime))
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _get_plugin_info() -> Dict[str, str]:
+    plugin_dir = os.path.dirname(os.path.dirname(__file__))
+    metadata_path = os.path.join(plugin_dir, "metadata.txt")
+    version = "Unknown"
+    try:
+        with open(metadata_path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("version="):
+                    version = line.split("=", 1)[1].strip()
+                    break
+    except OSError:
+        pass
+    return {"path": plugin_dir, "version": version}
+
+
+def _get_qgis_info() -> Dict[str, str]:
+    try:
+        from qgis.core import Qgis
+
+        qgis_version = str(getattr(Qgis, "QGIS_VERSION", "Unknown"))
+    except Exception:
+        qgis_version = "Unknown"
+
+    return {
+        "qgis_version": qgis_version,
+        "python_version": sys.version.replace("\n", " "),
+        "python_executable": sys.executable,
+        "python_prefix": sys.prefix,
+    }
+
+
+def _get_system_info() -> Dict[str, str]:
+    return {
+        "platform": platform.platform(),
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "processor": platform.processor() or "Unknown",
+    }
+
+
+def _get_nvidia_gpu_detection() -> Dict[str, Any]:
+    try:
+        detected, details = detect_nvidia_gpu()
+        return {"detected": bool(detected), "details": details, "error": None}
+    except Exception as exc:
+        return {"detected": False, "details": {}, "error": str(exc)}
+
+
+def _get_venv_info() -> Dict[str, Any]:
+    return {
+        "cache_dir": CACHE_DIR,
+        "venv_dir": VENV_DIR,
+        "exists": venv_exists(),
+        "python_path": get_venv_python_path(),
+        "site_packages": get_venv_site_packages(),
+    }
+
+
+def _collect_venv_runtime_info(venv_info: Dict[str, Any]) -> Dict[str, Any]:
+    if not venv_info["exists"]:
+        return {"error": "Virtual environment does not exist."}
+
+    python_path = venv_info["python_path"]
+    if not os.path.exists(python_path):
+        return {"error": f"Virtual environment Python not found: {python_path}"}
+
+    script = _venv_probe_script()
+    env = _get_clean_env_for_venv()
+    env.setdefault("TRANSFORMERS_VERBOSITY", "error")
+    env.setdefault("HF_HUB_DISABLE_TELEMETRY", "1")
+
+    try:
+        result = subprocess.run(
+            [python_path, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=90,
+            env=env,
+            **_get_subprocess_kwargs(),
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": "Timed out while collecting venv runtime diagnostics."}
+    except Exception as exc:
+        return {"error": f"Failed to run venv diagnostics: {exc}"}
+
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout or "").strip()
+        return {
+            "error": "Venv diagnostics subprocess failed with code {}: {}".format(
+                result.returncode, output[:2000]
+            )
+        }
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "error": "Could not parse venv diagnostics output: {}\n{}".format(
+                exc, result.stdout[:2000]
+            )
+        }
+
+
+def _venv_probe_script() -> str:
+    specs_json = json.dumps(PACKAGE_SPECS)
+    return textwrap.dedent(f"""
+        import importlib
+        import importlib.metadata as metadata
+        import json
+        import platform
+        import sys
+        import traceback
+
+        PACKAGE_SPECS = {specs_json}
+
+        def dist_version(dist_name):
+            try:
+                return metadata.version(dist_name)
+            except metadata.PackageNotFoundError:
+                return None
+            except Exception as exc:
+                return "error: " + str(exc)
+
+        def package_info(dist_name, module_name, label):
+            info = {{
+                "label": label,
+                "dist_name": dist_name,
+                "module_name": module_name,
+                "dist_version": dist_version(dist_name),
+                "module_version": None,
+                "module_file": None,
+                "import_ok": False,
+                "import_error": None,
+            }}
+            try:
+                module = importlib.import_module(module_name)
+                info["import_ok"] = True
+                info["module_version"] = getattr(module, "__version__", None)
+                info["module_file"] = getattr(module, "__file__", None)
+            except Exception as exc:
+                info["import_error"] = "".join(
+                    traceback.format_exception_only(type(exc), exc)
+                ).strip()
+            return info
+
+        def torch_runtime():
+            runtime = {{
+                "torch_import_ok": False,
+                "torch_import_error": None,
+                "torch_version": None,
+                "cuda_available": None,
+                "cuda_version": None,
+                "cuda_device_count": None,
+                "cuda_devices": [],
+                "cudnn_version": None,
+                "mps_available": None,
+                "mps_built": None,
+            }}
+            try:
+                import torch
+                runtime["torch_import_ok"] = True
+                runtime["torch_version"] = getattr(torch, "__version__", None)
+                runtime["cuda_version"] = getattr(torch.version, "cuda", None)
+                try:
+                    runtime["cuda_available"] = bool(torch.cuda.is_available())
+                    runtime["cuda_device_count"] = int(torch.cuda.device_count())
+                    for idx in range(runtime["cuda_device_count"]):
+                        runtime["cuda_devices"].append(torch.cuda.get_device_name(idx))
+                except Exception as exc:
+                    runtime["cuda_available"] = False
+                    runtime["cuda_error"] = str(exc)
+                try:
+                    runtime["cudnn_version"] = torch.backends.cudnn.version()
+                except Exception:
+                    pass
+                try:
+                    mps = getattr(torch.backends, "mps", None)
+                    if mps is not None:
+                        runtime["mps_available"] = bool(mps.is_available())
+                        runtime["mps_built"] = bool(mps.is_built())
+                except Exception as exc:
+                    runtime["mps_error"] = str(exc)
+            except Exception as exc:
+                runtime["torch_import_error"] = "".join(
+                    traceback.format_exception_only(type(exc), exc)
+                ).strip()
+            return runtime
+
+        payload = {{
+            "python_version": sys.version.replace("\\n", " "),
+            "python_executable": sys.executable,
+            "python_prefix": sys.prefix,
+            "platform": platform.platform(),
+            "packages": [
+                package_info(dist_name, module_name, label)
+                for dist_name, module_name, label in PACKAGE_SPECS
+            ],
+            "torch_runtime": torch_runtime(),
+        }}
+        print(json.dumps(payload, sort_keys=True))
+        """)
+
+
+def _format_venv_runtime(runtime: Dict[str, Any]) -> List[str]:
+    torch_runtime = runtime.get("torch_runtime", {})
+    lines = [
+        f"- Python version: `{runtime.get('python_version', 'Unknown')}`",
+        f"- Python executable: `{runtime.get('python_executable', 'Unknown')}`",
+        f"- Python prefix: `{runtime.get('python_prefix', 'Unknown')}`",
+        f"- Platform: `{runtime.get('platform', 'Unknown')}`",
+        "",
+        "## CUDA / Accelerator",
+        "",
+        f"- PyTorch import OK: `{_yes_no(torch_runtime.get('torch_import_ok'))}`",
+        f"- PyTorch version: `{_value(torch_runtime.get('torch_version'))}`",
+        f"- PyTorch CUDA build: `{_value(torch_runtime.get('cuda_version'))}`",
+        f"- CUDA available: `{_yes_no(torch_runtime.get('cuda_available'))}`",
+        f"- CUDA device count: `{_value(torch_runtime.get('cuda_device_count'))}`",
+    ]
+
+    cuda_devices = torch_runtime.get("cuda_devices") or []
+    for index, name in enumerate(cuda_devices):
+        lines.append(f"- CUDA device {index}: `{name}`")
+
+    if torch_runtime.get("cuda_error"):
+        lines.append(f"- CUDA error: `{torch_runtime['cuda_error']}`")
+    lines.extend(
+        [
+            f"- cuDNN version: `{_value(torch_runtime.get('cudnn_version'))}`",
+            f"- MPS available: `{_yes_no(torch_runtime.get('mps_available'))}`",
+            f"- MPS built: `{_yes_no(torch_runtime.get('mps_built'))}`",
+        ]
+    )
+    if torch_runtime.get("mps_error"):
+        lines.append(f"- MPS error: `{torch_runtime['mps_error']}`")
+    if torch_runtime.get("torch_import_error"):
+        lines.append(f"- PyTorch import error: `{torch_runtime['torch_import_error']}`")
+
+    lines.extend(["", "## Package Versions", ""])
+    lines.extend(_format_packages(runtime.get("packages", [])))
+    return lines
+
+
+def _format_packages(packages: Iterable[Dict[str, Any]]) -> List[str]:
+    lines = [
+        "| Package | Distribution | Import | Version | Import status |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    details = []
+    for package in packages:
+        label = package.get("label") or package.get("dist_name") or "Unknown"
+        dist_name = package.get("dist_name") or "Unknown"
+        module_name = package.get("module_name") or "Unknown"
+        version = _value(
+            package.get("dist_version") or package.get("module_version"),
+            missing="not installed",
+        )
+        import_status = "OK" if package.get("import_ok") else "FAILED"
+        lines.append(
+            "| {} | `{}` | `{}` | `{}` | `{}` |".format(
+                _escape_table(label),
+                _escape_table(dist_name),
+                _escape_table(module_name),
+                _escape_table(version),
+                import_status,
+            )
+        )
+        detail_lines = []
+        if package.get("module_version") and package.get("module_version") != version:
+            detail_lines.append(
+                f"- module `__version__`: `{package['module_version']}`"
+            )
+        if package.get("module_file"):
+            detail_lines.append(f"- module file: `{package['module_file']}`")
+        if package.get("import_error"):
+            detail_lines.append(f"- import error: `{package['import_error']}`")
+        if detail_lines:
+            details.append("")
+            details.append(f"<details><summary>{label} details</summary>")
+            details.append("")
+            details.extend(detail_lines)
+            details.append("")
+            details.append("</details>")
+    lines.extend(details)
+    return lines
+
+
+def _yes_no(value: Optional[bool]) -> str:
+    if value is None:
+        return "Unknown"
+    return "Yes" if bool(value) else "No"
+
+
+def _value(value: Any, missing: str = "Unknown") -> str:
+    if value is None or value == "":
+        return missing
+    return str(value)
+
+
+def _escape_table(value: Any) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ")

--- a/qgis_plugin/geoai/dialogs/diagnostics.py
+++ b/qgis_plugin/geoai/dialogs/diagnostics.py
@@ -75,7 +75,7 @@ class DiagnosticsDialog(QDialog):
 
     def refresh_report(self):
         """Regenerate the diagnostics report on a background thread."""
-        if self._worker is not None and self._worker.isRunning():
+        if self._worker_is_running():
             return
 
         self.refresh_button.setEnabled(False)
@@ -89,6 +89,7 @@ class DiagnosticsDialog(QDialog):
 
         worker = _DiagnosticsWorker()
         worker.finished_report.connect(self._on_report_ready)
+        worker.finished.connect(self._on_worker_finished)
         worker.finished.connect(worker.deleteLater)
         self._worker = worker
         worker.start()
@@ -100,13 +101,28 @@ class DiagnosticsDialog(QDialog):
         self.copy_button.setEnabled(True)
         self.save_button.setEnabled(True)
 
+    def _on_worker_finished(self):
+        """Clear the worker reference before Qt deletes the C++ object."""
+        self._worker = None
+
+    def _worker_is_running(self):
+        """Return whether the current worker is running, tolerating Qt deletion."""
+        if self._worker is None:
+            return False
+        try:
+            return self._worker.isRunning()
+        except RuntimeError:
+            self._worker = None
+            return False
+
     def closeEvent(self, event):
         """Detach from the worker so a late report does not touch a dead dialog."""
-        if self._worker is not None and self._worker.isRunning():
+        if self._worker is not None:
             try:
                 self._worker.finished_report.disconnect(self._on_report_ready)
-            except (TypeError, RuntimeError):
+            except (AttributeError, TypeError, RuntimeError):
                 pass
+        self._worker_is_running()
         super().closeEvent(event)
 
     def copy_report(self):

--- a/qgis_plugin/geoai/dialogs/diagnostics.py
+++ b/qgis_plugin/geoai/dialogs/diagnostics.py
@@ -1,0 +1,111 @@
+"""Diagnostics report dialog for the GeoAI QGIS plugin."""
+
+import os
+from datetime import datetime
+
+from qgis.PyQt.QtCore import QTimer
+from qgis.PyQt.QtWidgets import (
+    QApplication,
+    QDialog,
+    QFileDialog,
+    QHBoxLayout,
+    QMessageBox,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+)
+
+
+class DiagnosticsDialog(QDialog):
+    """Dialog that displays and exports a GeoAI diagnostics report."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("GeoAI Diagnostics Report")
+        self.resize(900, 650)
+
+        layout = QVBoxLayout(self)
+
+        self.report_text = QTextEdit()
+        self.report_text.setReadOnly(True)
+        try:
+            no_wrap = QTextEdit.LineWrapMode.NoWrap
+        except AttributeError:
+            no_wrap = QTextEdit.NoWrap
+        self.report_text.setLineWrapMode(no_wrap)
+        self.report_text.setPlainText("Generating diagnostics report...")
+        layout.addWidget(self.report_text)
+
+        button_layout = QHBoxLayout()
+        self.refresh_button = QPushButton("Refresh")
+        self.copy_button = QPushButton("Copy Markdown")
+        self.save_button = QPushButton("Save Markdown...")
+        self.close_button = QPushButton("Close")
+
+        self.refresh_button.clicked.connect(self.refresh_report)
+        self.copy_button.clicked.connect(self.copy_report)
+        self.save_button.clicked.connect(self.save_report)
+        self.close_button.clicked.connect(self.close)
+
+        button_layout.addWidget(self.refresh_button)
+        button_layout.addStretch()
+        button_layout.addWidget(self.copy_button)
+        button_layout.addWidget(self.save_button)
+        button_layout.addWidget(self.close_button)
+        layout.addLayout(button_layout)
+
+        QTimer.singleShot(0, self.refresh_report)
+
+    def refresh_report(self):
+        """Regenerate the diagnostics report."""
+        self.refresh_button.setEnabled(False)
+        self.report_text.setPlainText("Generating diagnostics report...")
+        QApplication.processEvents()
+        try:
+            from ..core.diagnostics import generate_diagnostics_report
+
+            report = generate_diagnostics_report()
+        except Exception as exc:
+            report = f"Failed to generate diagnostics report:\n{exc}"
+        self.report_text.setPlainText(report)
+        self.refresh_button.setEnabled(True)
+
+    def copy_report(self):
+        """Copy the diagnostics report to the clipboard."""
+        QApplication.clipboard().setText(self.report_text.toPlainText())
+
+    def save_report(self):
+        """Save the diagnostics report to a text file."""
+        try:
+            from ..core.venv_manager import CACHE_DIR
+
+            default_dir = CACHE_DIR
+        except Exception:
+            default_dir = os.path.expanduser("~")
+
+        default_name = "geoai_diagnostics_{}.md".format(
+            datetime.now().strftime("%Y%m%d_%H%M%S")
+        )
+        default_path = os.path.join(default_dir, default_name)
+
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save GeoAI Diagnostics Report",
+            default_path,
+            "Markdown Files (*.md);;Text Files (*.txt);;All Files (*)",
+        )
+        if not path:
+            return
+
+        try:
+            parent_dir = os.path.dirname(path)
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(self.report_text.toPlainText())
+        except OSError as exc:
+            QMessageBox.critical(
+                self,
+                "Save Diagnostics Report",
+                f"Could not save diagnostics report:\n{exc}",
+            )

--- a/qgis_plugin/geoai/dialogs/diagnostics.py
+++ b/qgis_plugin/geoai/dialogs/diagnostics.py
@@ -3,7 +3,7 @@
 import os
 from datetime import datetime
 
-from qgis.PyQt.QtCore import QTimer
+from qgis.PyQt.QtCore import QThread, QTimer, pyqtSignal
 from qgis.PyQt.QtWidgets import (
     QApplication,
     QDialog,
@@ -16,6 +16,21 @@ from qgis.PyQt.QtWidgets import (
 )
 
 
+class _DiagnosticsWorker(QThread):
+    """Background worker that builds the diagnostics report off the UI thread."""
+
+    finished_report = pyqtSignal(str)
+
+    def run(self):
+        try:
+            from ..core.diagnostics import generate_diagnostics_report
+
+            report = generate_diagnostics_report()
+        except Exception as exc:
+            report = f"Failed to generate diagnostics report:\n{exc}"
+        self.finished_report.emit(report)
+
+
 class DiagnosticsDialog(QDialog):
     """Dialog that displays and exports a GeoAI diagnostics report."""
 
@@ -23,6 +38,8 @@ class DiagnosticsDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("GeoAI Diagnostics Report")
         self.resize(900, 650)
+
+        self._worker = None
 
         layout = QVBoxLayout(self)
 
@@ -57,18 +74,40 @@ class DiagnosticsDialog(QDialog):
         QTimer.singleShot(0, self.refresh_report)
 
     def refresh_report(self):
-        """Regenerate the diagnostics report."""
-        self.refresh_button.setEnabled(False)
-        self.report_text.setPlainText("Generating diagnostics report...")
-        QApplication.processEvents()
-        try:
-            from ..core.diagnostics import generate_diagnostics_report
+        """Regenerate the diagnostics report on a background thread."""
+        if self._worker is not None and self._worker.isRunning():
+            return
 
-            report = generate_diagnostics_report()
-        except Exception as exc:
-            report = f"Failed to generate diagnostics report:\n{exc}"
+        self.refresh_button.setEnabled(False)
+        self.copy_button.setEnabled(False)
+        self.save_button.setEnabled(False)
+        self.report_text.setPlainText(
+            "Generating diagnostics report... this may take up to 90 seconds while "
+            "the managed environment is probed."
+        )
+        QApplication.processEvents()
+
+        worker = _DiagnosticsWorker()
+        worker.finished_report.connect(self._on_report_ready)
+        worker.finished.connect(worker.deleteLater)
+        self._worker = worker
+        worker.start()
+
+    def _on_report_ready(self, report):
+        """Handle the completed diagnostics report."""
         self.report_text.setPlainText(report)
         self.refresh_button.setEnabled(True)
+        self.copy_button.setEnabled(True)
+        self.save_button.setEnabled(True)
+
+    def closeEvent(self, event):
+        """Detach from the worker so a late report does not touch a dead dialog."""
+        if self._worker is not None and self._worker.isRunning():
+            try:
+                self._worker.finished_report.disconnect(self._on_report_ready)
+            except (TypeError, RuntimeError):
+                pass
+        super().closeEvent(event)
 
     def copy_report(self):
         """Copy the diagnostics report to the clipboard."""

--- a/qgis_plugin/geoai/geoai_plugin.py
+++ b/qgis_plugin/geoai/geoai_plugin.py
@@ -146,6 +146,10 @@ class GeoAIPlugin:
         if not os.path.exists(about_icon):
             about_icon = ":/images/themes/default/mActionHelpContents.svg"
 
+        diagnostics_icon = os.path.join(icon_base, "diagnostics.svg")
+        if not os.path.exists(diagnostics_icon):
+            diagnostics_icon = ":/images/themes/default/mActionIdentify.svg"
+
         # Add Tree Segmentation action (checkable for dock toggle)
         self.deepforest_action = self.add_action(
             deepforest_icon,
@@ -241,7 +245,7 @@ class GeoAIPlugin:
 
         # Add Diagnostics Report action (menu only)
         self.add_action(
-            about_icon,
+            diagnostics_icon,
             "Generate Diagnostics Report...",
             self.show_diagnostics_report,
             add_to_toolbar=False,

--- a/qgis_plugin/geoai/geoai_plugin.py
+++ b/qgis_plugin/geoai/geoai_plugin.py
@@ -239,6 +239,16 @@ class GeoAIPlugin:
             parent=self.iface.mainWindow(),
         )
 
+        # Add Diagnostics Report action (menu only)
+        self.add_action(
+            about_icon,
+            "Generate Diagnostics Report...",
+            self.show_diagnostics_report,
+            add_to_toolbar=False,
+            status_tip="Generate a Markdown diagnostics report for GitHub issues",
+            parent=self.iface.mainWindow(),
+        )
+
         # Add About action (menu only)
         self.add_action(
             about_icon,
@@ -1136,6 +1146,28 @@ class GeoAIPlugin:
             "About GeoAI Plugin",
             about_text,
         )
+
+    def show_diagnostics_report(self):
+        """Display a Markdown diagnostics report dialog."""
+        try:
+            from .dialogs.diagnostics import DiagnosticsDialog
+        except ImportError as e:
+            QMessageBox.critical(
+                self.iface.mainWindow(),
+                "Error",
+                f"Failed to import diagnostics dialog:\n{str(e)}",
+            )
+            return
+
+        try:
+            dialog = DiagnosticsDialog(self.iface.mainWindow())
+            dialog.exec()
+        except Exception as e:
+            QMessageBox.critical(
+                self.iface.mainWindow(),
+                "Error",
+                f"Failed to generate diagnostics report:\n{str(e)}",
+            )
 
     def show_update_checker(self):
         """Display the update checker dialog."""

--- a/qgis_plugin/geoai/icons/diagnostics.svg
+++ b/qgis_plugin/geoai/icons/diagnostics.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <rect x="5" y="3" width="14" height="18" rx="2" fill="#3498db" stroke="#2471a3" stroke-width="1"/>
+  <path d="M8 8h8M8 12h5M8 16h8" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+  <circle cx="16.5" cy="12" r="3.2" fill="#ffffff" stroke="#2471a3" stroke-width="1"/>
+  <path d="M18.8 14.3l2.2 2.2" stroke="#2471a3" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M15.2 12l1 1 1.7-2" fill="none" stroke="#27ae60" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/qgis_plugin/tests/test_diagnostics.py
+++ b/qgis_plugin/tests/test_diagnostics.py
@@ -1,0 +1,108 @@
+from geoai.core import diagnostics
+
+
+def test_diagnostics_report_is_github_markdown(monkeypatch):
+    monkeypatch.setattr(
+        diagnostics,
+        "_get_nvidia_gpu_detection",
+        lambda: {"detected": True, "details": {"name": "Test GPU"}, "error": None},
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "_get_venv_info",
+        lambda: {
+            "cache_dir": "/tmp/geoai-cache",
+            "venv_dir": "/tmp/geoai-cache/venv_py3.12",
+            "exists": True,
+            "python_path": "/tmp/geoai-cache/venv_py3.12/bin/python3",
+            "site_packages": (
+                "/tmp/geoai-cache/venv_py3.12/lib/python3.12/site-packages"
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "_collect_venv_runtime_info",
+        lambda _venv_info: {
+            "python_version": "3.12.8",
+            "python_executable": "/tmp/geoai-cache/venv_py3.12/bin/python3",
+            "python_prefix": "/tmp/geoai-cache/venv_py3.12",
+            "platform": "Linux-test",
+            "torch_runtime": {
+                "torch_import_ok": True,
+                "torch_version": "2.7.0",
+                "cuda_version": "12.8",
+                "cuda_available": True,
+                "cuda_device_count": 1,
+                "cuda_devices": ["Test GPU"],
+                "cudnn_version": 91002,
+                "mps_available": False,
+                "mps_built": False,
+            },
+            "packages": [
+                {
+                    "label": "GeoAI",
+                    "dist_name": "geoai-py",
+                    "module_name": "geoai",
+                    "dist_version": "0.38.0",
+                    "module_version": "0.38.0",
+                    "module_file": "/tmp/site-packages/geoai/__init__.py",
+                    "import_ok": True,
+                    "import_error": None,
+                },
+                {
+                    "label": "Transformers",
+                    "dist_name": "transformers",
+                    "module_name": "transformers",
+                    "dist_version": "4.57.6",
+                    "module_version": "4.57.6",
+                    "module_file": "/tmp/site-packages/transformers/__init__.py",
+                    "import_ok": True,
+                    "import_error": None,
+                },
+            ],
+        },
+    )
+
+    report = diagnostics.generate_diagnostics_report()
+
+    assert report.startswith("# GeoAI QGIS Diagnostics Report")
+    assert "## Managed Environment" in report
+    assert "- Virtual environment path: `/tmp/geoai-cache/venv_py3.12`" in report
+    assert "## CUDA / Accelerator" in report
+    assert "- CUDA available: `Yes`" in report
+    assert "| GeoAI | `geoai-py` | `geoai` | `0.38.0` | `OK` |" in report
+    assert (
+        "| Transformers | `transformers` | `transformers` | `4.57.6` | `OK` |" in report
+    )
+
+
+def test_diagnostics_report_handles_missing_venv(monkeypatch):
+    monkeypatch.setattr(
+        diagnostics,
+        "_get_nvidia_gpu_detection",
+        lambda: {"detected": False, "details": {}, "error": None},
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "_get_venv_info",
+        lambda: {
+            "cache_dir": "/tmp/geoai-cache",
+            "venv_dir": "/tmp/geoai-cache/venv_py3.12",
+            "exists": False,
+            "python_path": "/tmp/geoai-cache/venv_py3.12/bin/python3",
+            "site_packages": (
+                "/tmp/geoai-cache/venv_py3.12/lib/python3.12/site-packages"
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "_collect_venv_runtime_info",
+        lambda _venv_info: {"error": "Virtual environment does not exist."},
+    )
+
+    report = diagnostics.generate_diagnostics_report()
+
+    assert "- Virtual environment exists: `No`" in report
+    assert "- Error: `Virtual environment does not exist.`" in report

--- a/qgis_plugin/tests/test_diagnostics.py
+++ b/qgis_plugin/tests/test_diagnostics.py
@@ -2,6 +2,7 @@ from geoai.core import diagnostics
 
 
 def test_diagnostics_report_is_github_markdown(monkeypatch):
+    monkeypatch.setenv("HOME", "/home/testuser")
     monkeypatch.setattr(
         diagnostics,
         "_get_nvidia_gpu_detection",
@@ -11,12 +12,12 @@ def test_diagnostics_report_is_github_markdown(monkeypatch):
         diagnostics,
         "_get_venv_info",
         lambda: {
-            "cache_dir": "/tmp/geoai-cache",
-            "venv_dir": "/tmp/geoai-cache/venv_py3.12",
+            "cache_dir": "/home/testuser/.qgis_geoai",
+            "venv_dir": "/home/testuser/.qgis_geoai/venv_py3.12",
             "exists": True,
-            "python_path": "/tmp/geoai-cache/venv_py3.12/bin/python3",
+            "python_path": "/home/testuser/.qgis_geoai/venv_py3.12/bin/python3",
             "site_packages": (
-                "/tmp/geoai-cache/venv_py3.12/lib/python3.12/site-packages"
+                "/home/testuser/.qgis_geoai/venv_py3.12/lib/python3.12/site-packages"
             ),
         },
     )
@@ -25,8 +26,8 @@ def test_diagnostics_report_is_github_markdown(monkeypatch):
         "_collect_venv_runtime_info",
         lambda _venv_info: {
             "python_version": "3.12.8",
-            "python_executable": "/tmp/geoai-cache/venv_py3.12/bin/python3",
-            "python_prefix": "/tmp/geoai-cache/venv_py3.12",
+            "python_executable": "/home/testuser/.qgis_geoai/venv_py3.12/bin/python3",
+            "python_prefix": "/home/testuser/.qgis_geoai/venv_py3.12",
             "platform": "Linux-test",
             "torch_runtime": {
                 "torch_import_ok": True,
@@ -46,7 +47,10 @@ def test_diagnostics_report_is_github_markdown(monkeypatch):
                     "module_name": "geoai",
                     "dist_version": "0.38.0",
                     "module_version": "0.38.0",
-                    "module_file": "/tmp/site-packages/geoai/__init__.py",
+                    "module_file": (
+                        "/home/testuser/.qgis_geoai/venv_py3.12/"
+                        "lib/python3.12/site-packages/geoai/__init__.py"
+                    ),
                     "import_ok": True,
                     "import_error": None,
                 },
@@ -56,7 +60,10 @@ def test_diagnostics_report_is_github_markdown(monkeypatch):
                     "module_name": "transformers",
                     "dist_version": "4.57.6",
                     "module_version": "4.57.6",
-                    "module_file": "/tmp/site-packages/transformers/__init__.py",
+                    "module_file": (
+                        "/home/testuser/.qgis_geoai/venv_py3.12/"
+                        "lib/python3.12/site-packages/transformers/__init__.py"
+                    ),
                     "import_ok": True,
                     "import_error": None,
                 },
@@ -68,7 +75,10 @@ def test_diagnostics_report_is_github_markdown(monkeypatch):
 
     assert report.startswith("# GeoAI QGIS Diagnostics Report")
     assert "## Managed Environment" in report
-    assert "- Virtual environment path: `/tmp/geoai-cache/venv_py3.12`" in report
+    assert "- Virtual environment path: `~/.qgis_geoai/venv_py3.12`" in report
+    assert "/home/testuser" not in report
+    assert "`~/.qgis_geoai/venv_py3.12/bin/python3`" in report
+    assert "`~/.qgis_geoai/venv_py3.12/lib/python3.12/site-packages" in report
     assert "## CUDA / Accelerator" in report
     assert "- CUDA available: `Yes`" in report
     assert "| GeoAI | `geoai-py` | `geoai` | `0.38.0` | `OK` |" in report

--- a/qgis_plugin/tests/test_diagnostics.py
+++ b/qgis_plugin/tests/test_diagnostics.py
@@ -87,6 +87,63 @@ def test_diagnostics_report_is_github_markdown(monkeypatch):
     )
 
 
+def test_diagnostics_report_renders_import_errors_in_fenced_block(monkeypatch):
+    """Multi-line tracebacks with backticks must not break Markdown rendering."""
+    monkeypatch.setattr(
+        diagnostics,
+        "_get_nvidia_gpu_detection",
+        lambda: {"detected": False, "details": {}, "error": None},
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "_get_venv_info",
+        lambda: {
+            "cache_dir": "/tmp/geoai-cache",
+            "venv_dir": "/tmp/geoai-cache/venv_py3.12",
+            "exists": True,
+            "python_path": "/tmp/geoai-cache/venv_py3.12/bin/python3",
+            "site_packages": (
+                "/tmp/geoai-cache/venv_py3.12/lib/python3.12/site-packages"
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "_collect_venv_runtime_info",
+        lambda _venv_info: {
+            "python_version": "3.12.8",
+            "python_executable": "/tmp/geoai-cache/venv_py3.12/bin/python3",
+            "python_prefix": "/tmp/geoai-cache/venv_py3.12",
+            "platform": "Linux-test",
+            "torch_runtime": {"torch_import_ok": True, "torch_version": "2.7.0"},
+            "packages": [
+                {
+                    "label": "Broken",
+                    "dist_name": "broken-pkg",
+                    "module_name": "broken_pkg",
+                    "dist_version": "1.0.0",
+                    "module_version": None,
+                    "module_file": None,
+                    "import_ok": False,
+                    "import_error": (
+                        "SyntaxError: invalid syntax\n" "  File '`/tmp/foo.py`', line 1"
+                    ),
+                }
+            ],
+        },
+    )
+
+    report = diagnostics.generate_diagnostics_report()
+
+    assert "- import error:" in report
+    assert "SyntaxError: invalid syntax" in report
+    assert "  File '`/tmp/foo.py`', line 1" in report
+    # Fenced block must use a fence longer than any backtick run in the body.
+    assert "\n```\nSyntaxError" in report
+    # No inline-code wrapper around the raw multi-line error.
+    assert "`SyntaxError: invalid syntax" not in report
+
+
 def test_diagnostics_report_handles_missing_venv(monkeypatch):
     monkeypatch.setattr(
         diagnostics,

--- a/qgis_plugin/tests/test_diagnostics_dialog.py
+++ b/qgis_plugin/tests/test_diagnostics_dialog.py
@@ -1,0 +1,16 @@
+from geoai.dialogs.diagnostics import DiagnosticsDialog
+
+
+class DeletedWorker:
+    def isRunning(self):
+        raise RuntimeError(
+            "wrapped C/C++ object of type _DiagnosticsWorker has been deleted"
+        )
+
+
+def test_diagnostics_dialog_worker_check_tolerates_deleted_worker():
+    dialog = DiagnosticsDialog.__new__(DiagnosticsDialog)
+    dialog._worker = DeletedWorker()
+
+    assert dialog._worker_is_running() is False
+    assert dialog._worker is None

--- a/qgis_plugin/tests/test_plugin_menu.py
+++ b/qgis_plugin/tests/test_plugin_menu.py
@@ -45,6 +45,10 @@ def test_plugin_actions_stay_out_of_application_menu():
         ]
         assert len(about_actions) == 1
         assert len(diagnostics_actions) == 1
+        assert (
+            diagnostics_actions[0].icon().cacheKey()
+            != about_actions[0].icon().cacheKey()
+        )
         assert about_actions[0].menuRole() == _no_menu_role()
         assert diagnostics_actions[0].menuRole() == _no_menu_role()
         assert all(action.menuRole() == _no_menu_role() for action in plugin.actions)

--- a/qgis_plugin/tests/test_plugin_menu.py
+++ b/qgis_plugin/tests/test_plugin_menu.py
@@ -38,8 +38,15 @@ def test_plugin_actions_stay_out_of_application_menu():
         about_actions = [
             action for action in plugin.actions if action.text() == "About GeoAI"
         ]
+        diagnostics_actions = [
+            action
+            for action in plugin.actions
+            if action.text() == "Generate Diagnostics Report..."
+        ]
         assert len(about_actions) == 1
+        assert len(diagnostics_actions) == 1
         assert about_actions[0].menuRole() == _no_menu_role()
+        assert diagnostics_actions[0].menuRole() == _no_menu_role()
         assert all(action.menuRole() == _no_menu_role() for action in plugin.actions)
     finally:
         plugin.unload()


### PR DESCRIPTION
## Summary
- Adds a "Generate Diagnostics Report..." menu entry to the QGIS plugin that opens a dialog showing a Markdown diagnostics report with copy and save actions.
- The report covers plugin version, QGIS/Python runtime, OS, managed venv path/state, NVIDIA detection, CUDA availability, and import status/versions for key packages (geoai-py, PyTorch, SAM3, Transformers, segment-geospatial, etc.).
- Updates the bug report issue template and plugin docs/README to point users at the new dialog when filing plugin issues.

## Test plan
- [x] pre-commit run --all-files
- [ ] In QGIS, open GeoAI menu and confirm "Generate Diagnostics Report..." launches the dialog.
- [ ] Click Refresh, Copy Markdown, and Save Markdown... and verify each works.
- [ ] Verify the report renders correctly when pasted into a GitHub issue.
- [ ] pytest qgis_plugin/tests/test_diagnostics.py qgis_plugin/tests/test_plugin_menu.py