### PR TITLE
chore: bump version to 0.39.0 and QGIS plugin to 1.4.0

### DIFF
--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -8,7 +8,7 @@ only when a specific symbol is first accessed.
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.38.0"
+__version__ = "0.39.0"
 
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geoai-py"
-version = "0.38.0"
+version = "0.39.0"
 dynamic = [
     "dependencies",
 ]
@@ -58,7 +58,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.38.0"
+current_version = "0.39.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.3.0
+version=1.4.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -59,6 +59,11 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.4.0
+        - Add QGIS plugin diagnostics report for GitHub issue sharing
+        - Redact user home paths in diagnostics output
+        - Add dedicated diagnostics menu icon
+        - Fix diagnostics dialog close handling after worker cleanup
     1.3.0
         - Fix QGIS plugin reload cleanup (#741)
     1.2.3

--- a/qgis_plugin/tests/test_diagnostics.py
+++ b/qgis_plugin/tests/test_diagnostics.py
@@ -45,8 +45,8 @@ def test_diagnostics_report_is_github_markdown(monkeypatch):
                     "label": "GeoAI",
                     "dist_name": "geoai-py",
                     "module_name": "geoai",
-                    "dist_version": "0.38.0",
-                    "module_version": "0.38.0",
+                    "dist_version": "0.39.0",
+                    "module_version": "0.39.0",
                     "module_file": (
                         "/home/testuser/.qgis_geoai/venv_py3.12/"
                         "lib/python3.12/site-packages/geoai/__init__.py"
@@ -81,7 +81,7 @@ def test_diagnostics_report_is_github_markdown(monkeypatch):
     assert "`~/.qgis_geoai/venv_py3.12/lib/python3.12/site-packages" in report
     assert "## CUDA / Accelerator" in report
     assert "- CUDA available: `Yes`" in report
-    assert "| GeoAI | `geoai-py` | `geoai` | `0.38.0` | `OK` |" in report
+    assert "| GeoAI | `geoai-py` | `geoai` | `0.39.0` | `OK` |" in report
     assert (
         "| Transformers | `transformers` | `transformers` | `4.57.6` | `OK` |" in report
     )


### PR DESCRIPTION
## Summary
- Bump `geoai-py` from 0.38.0 to 0.39.0 in `pyproject.toml`, `geoai/__init__.py`, and bumpversion config
- Bump QGIS plugin from 1.3.0 to 1.4.0 with changelog entries for the diagnostics report dialog, home-path redaction, dedicated icon, and dialog cleanup fix
- Update diagnostics test fixtures to match the new version string

## Test plan
- [x] `pre-commit run --all-files`
- [ ] CI passes on the PR