### PR TITLE
feat: add inference range drawing to QGIS segmentation panels

### DIFF
--- a/qgis_plugin/geoai/dialogs/inference_range.py
+++ b/qgis_plugin/geoai/dialogs/inference_range.py
@@ -1,0 +1,143 @@
+"""Shared inference-range helpers for segmentation dock widgets."""
+
+from qgis.core import QgsCoordinateTransform, QgsProject
+from qgis.PyQt.QtWidgets import QMessageBox
+
+from .map_tools import RectangleRangeTool
+
+
+class InferenceRangeMixin:
+    """Mixin providing the inference-range drawing/state behavior.
+
+    Dock widgets that mix this in are expected to initialize these
+    attributes in their ``__init__``: ``inference_range_tool``,
+    ``previous_map_tool``, ``inference_bbox``, ``inference_bbox_crs``,
+    ``inference_range_layer_source``. They must also expose
+    ``self.iface``, the ``inf_raster_layer_combo`` raster combo box,
+    and the ``draw_range_btn``/``range_status_label`` widgets.
+    """
+
+    @staticmethod
+    def _bbox_from_rect(rect):
+        return [
+            float(rect.xMinimum()),
+            float(rect.yMinimum()),
+            float(rect.xMaximum()),
+            float(rect.yMaximum()),
+        ]
+
+    @staticmethod
+    def _intersect_bboxes(first, second):
+        minx = max(first[0], second[0])
+        miny = max(first[1], second[1])
+        maxx = min(first[2], second[2])
+        maxy = min(first[3], second[3])
+        if minx >= maxx or miny >= maxy:
+            return None
+        return [minx, miny, maxx, maxy]
+
+    def _current_inference_layer(self):
+        return self.inf_raster_layer_combo.currentLayer()
+
+    def _layer_crs_authid(self, layer):
+        crs = layer.crs()
+        authid = getattr(crs, "authid", None)
+        return authid() if callable(authid) else None
+
+    def _range_bbox_for_layer(self, rect, layer):
+        canvas_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
+        layer_crs = layer.crs()
+        if canvas_crs != layer_crs:
+            transform = QgsCoordinateTransform(
+                canvas_crs, layer_crs, QgsProject.instance()
+            )
+            rect = transform.transformBoundingBox(rect)
+
+        rect_bbox = self._bbox_from_rect(rect)
+        extent_bbox = self._bbox_from_rect(layer.extent())
+        return self._intersect_bboxes(rect_bbox, extent_bbox)
+
+    def start_inference_range_tool(self):
+        """Start drawing the inference range on the map canvas."""
+        layer = self._current_inference_layer()
+        if layer is None:
+            QMessageBox.warning(
+                self,
+                "Warning",
+                "Please select a raster layer before drawing an inference range.",
+            )
+            self.draw_range_btn.setChecked(False)
+            return
+
+        if self.inference_range_tool is None:
+            self.inference_range_tool = RectangleRangeTool(self.iface.mapCanvas())
+            self.inference_range_tool.range_drawn.connect(self.set_inference_range)
+            self.inference_range_tool.range_canceled.connect(
+                self.cancel_inference_range_tool
+            )
+
+        self.previous_map_tool = self.iface.mapCanvas().mapTool()
+        self.iface.mapCanvas().setMapTool(self.inference_range_tool)
+
+    def cancel_inference_range_tool(self):
+        """Handle range drawing cancellation without clearing the saved range."""
+        self.draw_range_btn.setChecked(False)
+        if self.previous_map_tool:
+            self.iface.mapCanvas().setMapTool(self.previous_map_tool)
+
+    def set_inference_range(self, rect):
+        """Store the drawn inference range as a layer-CRS bbox."""
+        layer = self._current_inference_layer()
+        if layer is None:
+            self.clear_inference_range()
+            QMessageBox.warning(
+                self, "Warning", "Selected raster layer is no longer available."
+            )
+            return
+
+        bbox = self._range_bbox_for_layer(rect, layer)
+        if bbox is None:
+            self.clear_inference_range()
+            QMessageBox.warning(
+                self,
+                "Warning",
+                "The drawn range does not intersect the selected raster layer.",
+            )
+            return
+
+        self.inference_bbox = bbox
+        self.inference_bbox_crs = self._layer_crs_authid(layer)
+        self.inference_range_layer_source = layer.source()
+        self.range_status_label.setText(
+            f"{bbox[0]:.3f}, {bbox[1]:.3f}, {bbox[2]:.3f}, {bbox[3]:.3f}"
+        )
+        self.draw_range_btn.setChecked(False)
+        if self.previous_map_tool:
+            self.iface.mapCanvas().setMapTool(self.previous_map_tool)
+
+    def clear_inference_range(self, *args):
+        """Clear the selected inference range."""
+        self.inference_bbox = None
+        self.inference_bbox_crs = None
+        self.inference_range_layer_source = None
+        if "range_status_label" in self.__dict__:
+            self.range_status_label.setText("Full raster")
+        if "draw_range_btn" in self.__dict__:
+            self.draw_range_btn.setChecked(False)
+        if self.inference_range_tool is not None:
+            self.inference_range_tool.clear_rubber_band()
+
+    def _validated_inference_bbox(self, input_path):
+        if self.inference_bbox is None:
+            return None, None, None
+        if (
+            self.inference_range_layer_source
+            and input_path != self.inference_range_layer_source
+        ):
+            return (
+                None,
+                None,
+                "The selected inference range belongs to a different raster layer. "
+                "Clear the range or select the matching raster layer.",
+            )
+        return self.inference_bbox, self.inference_bbox_crs, None

--- a/qgis_plugin/geoai/dialogs/instance_segmentation.py
+++ b/qgis_plugin/geoai/dialogs/instance_segmentation.py
@@ -6,6 +6,7 @@ segmentation models and running inference, combined in a single dockable panel.
 """
 
 import os
+import shutil
 import tempfile
 from typing import Optional
 
@@ -33,16 +34,11 @@ from qgis.PyQt.QtWidgets import (
     QSplitter,
 )
 
-from qgis.core import (
-    QgsCoordinateTransform,
-    QgsProject,
-    QgsVectorLayer,
-    QgsRasterLayer,
-)
+from qgis.core import QgsProject, QgsVectorLayer, QgsRasterLayer
 from qgis.gui import QgsMapLayerComboBox
 from qgis.core import QgsMapLayerProxyModel
 
-from .map_tools import RectangleRangeTool
+from .inference_range import InferenceRangeMixin
 
 
 class OutputCapture:
@@ -251,7 +247,7 @@ class InstanceInferenceWorker(QThread):
 
     def run(self):
         """Execute the inference."""
-        clipped_input_path = None
+        temp_dir = None
         try:
             from ..core.geoai_task_subprocess import run_geoai_task
 
@@ -259,11 +255,8 @@ class InstanceInferenceWorker(QThread):
             input_path = self.input_path
 
             if self.inference_bbox is not None:
-                temp_file = tempfile.NamedTemporaryFile(
-                    suffix=".tif", prefix="geoai_inference_range_", delete=False
-                )
-                clipped_input_path = temp_file.name
-                temp_file.close()
+                temp_dir = tempfile.mkdtemp(prefix="geoai_inference_range_")
+                clipped_input_path = os.path.join(temp_dir, "clip.tif")
                 self.progress.emit("Clipping raster to selected range...")
                 run_geoai_task(
                     "clip_raster_by_bbox",
@@ -301,11 +294,8 @@ class InstanceInferenceWorker(QThread):
 
             self.error.emit(f"{str(e)}\n\n{traceback.format_exc()}")
         finally:
-            if clipped_input_path and os.path.exists(clipped_input_path):
-                try:
-                    os.remove(clipped_input_path)
-                except OSError:
-                    pass
+            if temp_dir:
+                shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 class VectorizeWorker(QThread):
@@ -400,7 +390,7 @@ class SmoothVectorWorker(QThread):
             self.error.emit(f"{str(e)}\n\n{traceback.format_exc()}")
 
 
-class InstanceSegmentationDockWidget(QDockWidget):
+class InstanceSegmentationDockWidget(InferenceRangeMixin, QDockWidget):
     """Dockable widget for instance segmentation training and inference."""
 
     def __init__(self, iface, parent=None):
@@ -1114,131 +1104,6 @@ class InstanceSegmentationDockWidget(QDockWidget):
         )
         if file_path:
             self.inf_raster_path_edit.setText(file_path)
-
-    @staticmethod
-    def _bbox_from_rect(rect):
-        return [
-            float(rect.xMinimum()),
-            float(rect.yMinimum()),
-            float(rect.xMaximum()),
-            float(rect.yMaximum()),
-        ]
-
-    @staticmethod
-    def _intersect_bboxes(first, second):
-        minx = max(first[0], second[0])
-        miny = max(first[1], second[1])
-        maxx = min(first[2], second[2])
-        maxy = min(first[3], second[3])
-        if minx >= maxx or miny >= maxy:
-            return None
-        return [minx, miny, maxx, maxy]
-
-    def _current_inference_layer(self):
-        return self.inf_raster_layer_combo.currentLayer()
-
-    def _layer_crs_authid(self, layer):
-        crs = layer.crs()
-        authid = getattr(crs, "authid", None)
-        return authid() if callable(authid) else None
-
-    def _range_bbox_for_layer(self, rect, layer):
-        canvas_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
-        layer_crs = layer.crs()
-        if canvas_crs != layer_crs:
-            transform = QgsCoordinateTransform(
-                canvas_crs, layer_crs, QgsProject.instance()
-            )
-            rect = transform.transformBoundingBox(rect)
-
-        rect_bbox = self._bbox_from_rect(rect)
-        extent_bbox = self._bbox_from_rect(layer.extent())
-        return self._intersect_bboxes(rect_bbox, extent_bbox)
-
-    def start_inference_range_tool(self):
-        """Start drawing the inference range on the map canvas."""
-        layer = self._current_inference_layer()
-        if layer is None:
-            QMessageBox.warning(
-                self,
-                "Warning",
-                "Please select a raster layer before drawing an inference range.",
-            )
-            self.draw_range_btn.setChecked(False)
-            return
-
-        if self.inference_range_tool is None:
-            self.inference_range_tool = RectangleRangeTool(self.iface.mapCanvas())
-            self.inference_range_tool.range_drawn.connect(self.set_inference_range)
-            self.inference_range_tool.range_canceled.connect(
-                self.cancel_inference_range_tool
-            )
-
-        self.previous_map_tool = self.iface.mapCanvas().mapTool()
-        self.iface.mapCanvas().setMapTool(self.inference_range_tool)
-
-    def cancel_inference_range_tool(self):
-        """Handle range drawing cancellation without clearing the saved range."""
-        self.draw_range_btn.setChecked(False)
-        if self.previous_map_tool:
-            self.iface.mapCanvas().setMapTool(self.previous_map_tool)
-
-    def set_inference_range(self, rect):
-        """Store the drawn inference range as a layer-CRS bbox."""
-        layer = self._current_inference_layer()
-        if layer is None:
-            self.clear_inference_range()
-            QMessageBox.warning(
-                self, "Warning", "Selected raster layer is no longer available."
-            )
-            return
-
-        bbox = self._range_bbox_for_layer(rect, layer)
-        if bbox is None:
-            self.clear_inference_range()
-            QMessageBox.warning(
-                self,
-                "Warning",
-                "The drawn range does not intersect the selected raster layer.",
-            )
-            return
-
-        self.inference_bbox = bbox
-        self.inference_bbox_crs = self._layer_crs_authid(layer)
-        self.inference_range_layer_source = layer.source()
-        self.range_status_label.setText(
-            f"{bbox[0]:.3f}, {bbox[1]:.3f}, {bbox[2]:.3f}, {bbox[3]:.3f}"
-        )
-        self.draw_range_btn.setChecked(False)
-        if self.previous_map_tool:
-            self.iface.mapCanvas().setMapTool(self.previous_map_tool)
-
-    def clear_inference_range(self, *args):
-        """Clear the selected inference range."""
-        self.inference_bbox = None
-        self.inference_bbox_crs = None
-        self.inference_range_layer_source = None
-        if "range_status_label" in self.__dict__:
-            self.range_status_label.setText("Full raster")
-        if "draw_range_btn" in self.__dict__:
-            self.draw_range_btn.setChecked(False)
-        if self.inference_range_tool is not None:
-            self.inference_range_tool.clear_rubber_band()
-
-    def _validated_inference_bbox(self, input_path):
-        if self.inference_bbox is None:
-            return None, None, None
-        if (
-            self.inference_range_layer_source
-            and input_path != self.inference_range_layer_source
-        ):
-            return (
-                None,
-                None,
-                "The selected inference range belongs to a different raster layer. "
-                "Clear the range or select the matching raster layer.",
-            )
-        return self.inference_bbox, self.inference_bbox_crs, None
 
     def browse_model(self):
         """Browse for a trained model file."""

--- a/qgis_plugin/geoai/dialogs/instance_segmentation.py
+++ b/qgis_plugin/geoai/dialogs/instance_segmentation.py
@@ -6,6 +6,7 @@ segmentation models and running inference, combined in a single dockable panel.
 """
 
 import os
+import tempfile
 from typing import Optional
 
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
@@ -32,9 +33,16 @@ from qgis.PyQt.QtWidgets import (
     QSplitter,
 )
 
-from qgis.core import QgsProject, QgsVectorLayer, QgsRasterLayer
+from qgis.core import (
+    QgsCoordinateTransform,
+    QgsProject,
+    QgsVectorLayer,
+    QgsRasterLayer,
+)
 from qgis.gui import QgsMapLayerComboBox
 from qgis.core import QgsMapLayerProxyModel
+
+from .map_tools import RectangleRangeTool
 
 
 class OutputCapture:
@@ -221,6 +229,8 @@ class InstanceInferenceWorker(QThread):
         overlap: int,
         confidence_threshold: float,
         batch_size: int,
+        inference_bbox: Optional[list] = None,
+        inference_bbox_crs: Optional[str] = None,
     ):
         super().__init__()
         self.input_path = input_path
@@ -232,6 +242,8 @@ class InstanceInferenceWorker(QThread):
         self.overlap = overlap
         self.confidence_threshold = confidence_threshold
         self.batch_size = batch_size
+        self.inference_bbox = inference_bbox
+        self.inference_bbox_crs = inference_bbox_crs
 
     def _forward_line(self, line: str):
         """Forward stdout lines as progress messages."""
@@ -239,14 +251,37 @@ class InstanceInferenceWorker(QThread):
 
     def run(self):
         """Execute the inference."""
+        clipped_input_path = None
         try:
             from ..core.geoai_task_subprocess import run_geoai_task
 
             self.progress.emit("Running instance segmentation inference...")
+            input_path = self.input_path
+
+            if self.inference_bbox is not None:
+                temp_file = tempfile.NamedTemporaryFile(
+                    suffix=".tif", prefix="geoai_inference_range_", delete=False
+                )
+                clipped_input_path = temp_file.name
+                temp_file.close()
+                self.progress.emit("Clipping raster to selected range...")
+                run_geoai_task(
+                    "clip_raster_by_bbox",
+                    {
+                        "input_raster": self.input_path,
+                        "output_raster": clipped_input_path,
+                        "bbox": self.inference_bbox,
+                        "bbox_type": "geo",
+                        "bbox_crs": self.inference_bbox_crs,
+                    },
+                    progress_callback=self._forward_line,
+                )
+                input_path = clipped_input_path
+
             run_geoai_task(
                 "instance_segmentation",
                 {
-                    "input_path": self.input_path,
+                    "input_path": input_path,
                     "output_path": self.output_path,
                     "model_path": self.model_path,
                     "num_channels": self.num_channels,
@@ -265,6 +300,12 @@ class InstanceInferenceWorker(QThread):
             import traceback
 
             self.error.emit(f"{str(e)}\n\n{traceback.format_exc()}")
+        finally:
+            if clipped_input_path and os.path.exists(clipped_input_path):
+                try:
+                    os.remove(clipped_input_path)
+                except OSError:
+                    pass
 
 
 class VectorizeWorker(QThread):
@@ -377,6 +418,11 @@ class InstanceSegmentationDockWidget(QDockWidget):
         self.vectorize_worker = None
         self.smooth_worker = None
         self.last_output_path = None
+        self.inference_range_tool = None
+        self.previous_map_tool = None
+        self.inference_bbox = None
+        self.inference_bbox_crs = None
+        self.inference_range_layer_source = None
 
         self.setAllowedAreas(
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
@@ -726,6 +772,28 @@ class InstanceSegmentationDockWidget(QDockWidget):
         input_group.setLayout(input_layout)
         layout.addWidget(input_group)
 
+        # Inference Range Group
+        range_group = QGroupBox("Inference Range")
+        range_layout = QFormLayout()
+        range_layout.setSpacing(5)
+
+        range_button_layout = QHBoxLayout()
+        self.draw_range_btn = QPushButton("Draw Range")
+        self.draw_range_btn.setCheckable(True)
+        self.draw_range_btn.setStyleSheet(self.btn_style)
+        range_button_layout.addWidget(self.draw_range_btn)
+
+        self.clear_range_btn = QPushButton("Clear")
+        self.clear_range_btn.setStyleSheet(self.btn_style)
+        range_button_layout.addWidget(self.clear_range_btn)
+        range_layout.addRow("Range:", range_button_layout)
+
+        self.range_status_label = QLabel("Full raster")
+        range_layout.addRow("", self.range_status_label)
+
+        range_group.setLayout(range_layout)
+        layout.addWidget(range_group)
+
         # Model Group
         model_group = QGroupBox("Model")
         model_layout = QFormLayout()
@@ -918,7 +986,11 @@ class InstanceSegmentationDockWidget(QDockWidget):
             self.on_inf_raster_layer_changed
         )
         self.inf_raster_path_edit.textChanged.connect(self.on_inf_raster_path_changed)
+        self.inf_raster_layer_combo.layerChanged.connect(self.clear_inference_range)
+        self.inf_raster_path_edit.textChanged.connect(self.clear_inference_range)
         self.inf_raster_browse_btn.clicked.connect(self.browse_inf_raster)
+        self.draw_range_btn.clicked.connect(self.start_inference_range_tool)
+        self.clear_range_btn.clicked.connect(self.clear_inference_range)
         self.model_browse_btn.clicked.connect(self.browse_model)
         self.output_browse_btn.clicked.connect(self.browse_output)
         self.vector_output_browse_btn.clicked.connect(self.browse_vector_output)
@@ -1042,6 +1114,131 @@ class InstanceSegmentationDockWidget(QDockWidget):
         )
         if file_path:
             self.inf_raster_path_edit.setText(file_path)
+
+    @staticmethod
+    def _bbox_from_rect(rect):
+        return [
+            float(rect.xMinimum()),
+            float(rect.yMinimum()),
+            float(rect.xMaximum()),
+            float(rect.yMaximum()),
+        ]
+
+    @staticmethod
+    def _intersect_bboxes(first, second):
+        minx = max(first[0], second[0])
+        miny = max(first[1], second[1])
+        maxx = min(first[2], second[2])
+        maxy = min(first[3], second[3])
+        if minx >= maxx or miny >= maxy:
+            return None
+        return [minx, miny, maxx, maxy]
+
+    def _current_inference_layer(self):
+        return self.inf_raster_layer_combo.currentLayer()
+
+    def _layer_crs_authid(self, layer):
+        crs = layer.crs()
+        authid = getattr(crs, "authid", None)
+        return authid() if callable(authid) else None
+
+    def _range_bbox_for_layer(self, rect, layer):
+        canvas_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
+        layer_crs = layer.crs()
+        if canvas_crs != layer_crs:
+            transform = QgsCoordinateTransform(
+                canvas_crs, layer_crs, QgsProject.instance()
+            )
+            rect = transform.transformBoundingBox(rect)
+
+        rect_bbox = self._bbox_from_rect(rect)
+        extent_bbox = self._bbox_from_rect(layer.extent())
+        return self._intersect_bboxes(rect_bbox, extent_bbox)
+
+    def start_inference_range_tool(self):
+        """Start drawing the inference range on the map canvas."""
+        layer = self._current_inference_layer()
+        if layer is None:
+            QMessageBox.warning(
+                self,
+                "Warning",
+                "Please select a raster layer before drawing an inference range.",
+            )
+            self.draw_range_btn.setChecked(False)
+            return
+
+        if self.inference_range_tool is None:
+            self.inference_range_tool = RectangleRangeTool(self.iface.mapCanvas())
+            self.inference_range_tool.range_drawn.connect(self.set_inference_range)
+            self.inference_range_tool.range_canceled.connect(
+                self.cancel_inference_range_tool
+            )
+
+        self.previous_map_tool = self.iface.mapCanvas().mapTool()
+        self.iface.mapCanvas().setMapTool(self.inference_range_tool)
+
+    def cancel_inference_range_tool(self):
+        """Handle range drawing cancellation without clearing the saved range."""
+        self.draw_range_btn.setChecked(False)
+        if self.previous_map_tool:
+            self.iface.mapCanvas().setMapTool(self.previous_map_tool)
+
+    def set_inference_range(self, rect):
+        """Store the drawn inference range as a layer-CRS bbox."""
+        layer = self._current_inference_layer()
+        if layer is None:
+            self.clear_inference_range()
+            QMessageBox.warning(
+                self, "Warning", "Selected raster layer is no longer available."
+            )
+            return
+
+        bbox = self._range_bbox_for_layer(rect, layer)
+        if bbox is None:
+            self.clear_inference_range()
+            QMessageBox.warning(
+                self,
+                "Warning",
+                "The drawn range does not intersect the selected raster layer.",
+            )
+            return
+
+        self.inference_bbox = bbox
+        self.inference_bbox_crs = self._layer_crs_authid(layer)
+        self.inference_range_layer_source = layer.source()
+        self.range_status_label.setText(
+            f"{bbox[0]:.3f}, {bbox[1]:.3f}, {bbox[2]:.3f}, {bbox[3]:.3f}"
+        )
+        self.draw_range_btn.setChecked(False)
+        if self.previous_map_tool:
+            self.iface.mapCanvas().setMapTool(self.previous_map_tool)
+
+    def clear_inference_range(self, *args):
+        """Clear the selected inference range."""
+        self.inference_bbox = None
+        self.inference_bbox_crs = None
+        self.inference_range_layer_source = None
+        if "range_status_label" in self.__dict__:
+            self.range_status_label.setText("Full raster")
+        if "draw_range_btn" in self.__dict__:
+            self.draw_range_btn.setChecked(False)
+        if self.inference_range_tool is not None:
+            self.inference_range_tool.clear_rubber_band()
+
+    def _validated_inference_bbox(self, input_path):
+        if self.inference_bbox is None:
+            return None, None, None
+        if (
+            self.inference_range_layer_source
+            and input_path != self.inference_range_layer_source
+        ):
+            return (
+                None,
+                None,
+                "The selected inference range belongs to a different raster layer. "
+                "Clear the range or select the matching raster layer.",
+            )
+        return self.inference_bbox, self.inference_bbox_crs, None
 
     def browse_model(self):
         """Browse for a trained model file."""
@@ -1350,9 +1547,19 @@ class InstanceSegmentationDockWidget(QDockWidget):
             QMessageBox.warning(self, "Warning", "Please fill in all fields.")
             return
 
+        inference_bbox, inference_bbox_crs, range_error = (
+            self._validated_inference_bbox(input_path)
+        )
+        if range_error:
+            QMessageBox.warning(self, "Warning", range_error)
+            return
+
         self.run_inference_btn.setEnabled(False)
         self.inference_progress.setRange(0, 0)
-        self.log("Starting instance segmentation inference...")
+        if inference_bbox is not None:
+            self.log("Starting instance segmentation inference on selected range...")
+        else:
+            self.log("Starting instance segmentation inference...")
 
         self.inference_worker = InstanceInferenceWorker(
             input_path,
@@ -1364,6 +1571,8 @@ class InstanceSegmentationDockWidget(QDockWidget):
             self.overlap_spin.value(),
             self.confidence_spin.value(),
             self.inf_batch_size_spin.value(),
+            inference_bbox=inference_bbox,
+            inference_bbox_crs=inference_bbox_crs,
         )
         self.inference_worker.finished.connect(self.on_inference_finished)
         self.inference_worker.error.connect(self.on_inference_error)

--- a/qgis_plugin/geoai/dialogs/map_tools.py
+++ b/qgis_plugin/geoai/dialogs/map_tools.py
@@ -170,3 +170,66 @@ class BoxPromptTool(QgsMapTool):
         """Deactivate the tool."""
         self.is_drawing = False
         super().deactivate()
+
+
+class RectangleRangeTool(QgsMapTool):
+    """Map tool for drawing a reusable rectangular map range."""
+
+    range_drawn = pyqtSignal(object)  # QgsRectangle
+    range_canceled = pyqtSignal()
+
+    def __init__(self, canvas):
+        super().__init__(canvas)
+        self.canvas = canvas
+        self.rubber_band = QgsRubberBand(canvas, QgsWkbTypes.PolygonGeometry)
+        self.rubber_band.setColor(QColor(255, 170, 0, 70))
+        self.rubber_band.setStrokeColor(QColor(255, 140, 0))
+        self.rubber_band.setWidth(2)
+        self.start_point = None
+        self.is_drawing = False
+        self.setCursor(Qt.CursorShape.CrossCursor)
+
+    def canvasPressEvent(self, event):
+        """Start drawing a rectangular range."""
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.start_point = self.toMapCoordinates(event.pos())
+            self.is_drawing = True
+            self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+
+    def canvasMoveEvent(self, event):
+        """Update range preview while dragging."""
+        if self.is_drawing and self.start_point is not None:
+            self.update_rubber_band(
+                self.start_point, self.toMapCoordinates(event.pos())
+            )
+
+    def canvasReleaseEvent(self, event):
+        """Finish drawing and emit the selected range."""
+        if event.button() == Qt.MouseButton.LeftButton and self.is_drawing:
+            end_point = self.toMapCoordinates(event.pos())
+            self.is_drawing = False
+            self.update_rubber_band(self.start_point, end_point)
+            self.range_drawn.emit(QgsRectangle(self.start_point, end_point))
+            self.deactivate()
+        elif event.button() == Qt.MouseButton.RightButton:
+            self.is_drawing = False
+            self.clear_rubber_band()
+            self.range_canceled.emit()
+            self.deactivate()
+
+    def update_rubber_band(self, start_point, end_point):
+        """Update the rubber band rectangle."""
+        self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+        self.rubber_band.addPoint(QgsPointXY(start_point.x(), start_point.y()), False)
+        self.rubber_band.addPoint(QgsPointXY(end_point.x(), start_point.y()), False)
+        self.rubber_band.addPoint(QgsPointXY(end_point.x(), end_point.y()), False)
+        self.rubber_band.addPoint(QgsPointXY(start_point.x(), end_point.y()), True)
+
+    def clear_rubber_band(self):
+        """Clear the drawn range preview."""
+        self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+
+    def deactivate(self):
+        """Deactivate the tool."""
+        self.is_drawing = False
+        super().deactivate()

--- a/qgis_plugin/geoai/dialogs/segmentation.py
+++ b/qgis_plugin/geoai/dialogs/segmentation.py
@@ -6,6 +6,7 @@ and running inference, combined in a single dockable panel.
 """
 
 import os
+import tempfile
 from typing import Optional
 
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
@@ -31,9 +32,16 @@ from qgis.PyQt.QtWidgets import (
     QScrollArea,
 )
 
-from qgis.core import QgsProject, QgsVectorLayer, QgsRasterLayer
+from qgis.core import (
+    QgsCoordinateTransform,
+    QgsProject,
+    QgsVectorLayer,
+    QgsRasterLayer,
+)
 from qgis.gui import QgsMapLayerComboBox
 from qgis.core import QgsMapLayerProxyModel
+
+from .map_tools import RectangleRangeTool
 
 
 class OutputCapture:
@@ -245,6 +253,8 @@ class InferenceWorker(QThread):
         batch_size: int,
         probability_path: Optional[str] = None,
         probability_threshold: Optional[float] = None,
+        inference_bbox: Optional[list] = None,
+        inference_bbox_crs: Optional[str] = None,
     ):
         super().__init__()
         self.input_path = input_path
@@ -259,13 +269,37 @@ class InferenceWorker(QThread):
         self.batch_size = batch_size
         self.probability_path = probability_path
         self.probability_threshold = probability_threshold
+        self.inference_bbox = inference_bbox
+        self.inference_bbox_crs = inference_bbox_crs
 
     def run(self):
         """Execute the inference."""
+        clipped_input_path = None
         try:
             from ..core.geoai_task_subprocess import run_geoai_task
 
             self.progress.emit("Running inference...")
+            input_path = self.input_path
+
+            if self.inference_bbox is not None:
+                temp_file = tempfile.NamedTemporaryFile(
+                    suffix=".tif", prefix="geoai_inference_range_", delete=False
+                )
+                clipped_input_path = temp_file.name
+                temp_file.close()
+                self.progress.emit("Clipping raster to selected range...")
+                run_geoai_task(
+                    "clip_raster_by_bbox",
+                    {
+                        "input_raster": self.input_path,
+                        "output_raster": clipped_input_path,
+                        "bbox": self.inference_bbox,
+                        "bbox_type": "geo",
+                        "bbox_crs": self.inference_bbox_crs,
+                    },
+                    progress_callback=self.progress.emit,
+                )
+                input_path = clipped_input_path
 
             kwargs = {}
             if self.probability_path:
@@ -274,7 +308,7 @@ class InferenceWorker(QThread):
                 kwargs["probability_threshold"] = self.probability_threshold
 
             params = {
-                "input_path": self.input_path,
+                "input_path": input_path,
                 "output_path": self.output_path,
                 "model_path": self.model_path,
                 "architecture": self.architecture,
@@ -298,6 +332,12 @@ class InferenceWorker(QThread):
             import traceback
 
             self.error.emit(f"{str(e)}\n\n{traceback.format_exc()}")
+        finally:
+            if clipped_input_path and os.path.exists(clipped_input_path):
+                try:
+                    os.remove(clipped_input_path)
+                except OSError:
+                    pass
 
 
 class VectorizeWorker(QThread):
@@ -410,6 +450,11 @@ class SegmentationDockWidget(QDockWidget):
         self.vectorize_worker = None
         self.smooth_worker = None
         self.last_output_path = None
+        self.inference_range_tool = None
+        self.previous_map_tool = None
+        self.inference_bbox = None
+        self.inference_bbox_crs = None
+        self.inference_range_layer_source = None
 
         self.setAllowedAreas(
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
@@ -834,6 +879,28 @@ class SegmentationDockWidget(QDockWidget):
         input_group.setLayout(input_layout)
         layout.addWidget(input_group)
 
+        # Inference Range Group
+        range_group = QGroupBox("Inference Range")
+        range_layout = QFormLayout()
+        range_layout.setSpacing(5)
+
+        range_button_layout = QHBoxLayout()
+        self.draw_range_btn = QPushButton("Draw Range")
+        self.draw_range_btn.setCheckable(True)
+        self.draw_range_btn.setStyleSheet(self.btn_style)
+        range_button_layout.addWidget(self.draw_range_btn)
+
+        self.clear_range_btn = QPushButton("Clear")
+        self.clear_range_btn.setStyleSheet(self.btn_style)
+        range_button_layout.addWidget(self.clear_range_btn)
+        range_layout.addRow("Range:", range_button_layout)
+
+        self.range_status_label = QLabel("Full raster")
+        range_layout.addRow("", self.range_status_label)
+
+        range_group.setLayout(range_layout)
+        layout.addWidget(range_group)
+
         # Model Group
         model_group = QGroupBox("Model")
         model_layout = QFormLayout()
@@ -1094,6 +1161,10 @@ class SegmentationDockWidget(QDockWidget):
 
         # Inference tab
         self.inf_raster_browse_btn.clicked.connect(self.browse_inf_raster)
+        self.inf_raster_layer_combo.layerChanged.connect(self.clear_inference_range)
+        self.inf_raster_path_edit.textChanged.connect(self.clear_inference_range)
+        self.draw_range_btn.clicked.connect(self.start_inference_range_tool)
+        self.clear_range_btn.clicked.connect(self.clear_inference_range)
         self.model_browse_btn.clicked.connect(self.browse_model)
         self.output_browse_btn.clicked.connect(self.browse_output)
         self.vector_output_browse_btn.clicked.connect(self.browse_vector_output)
@@ -1228,6 +1299,131 @@ class SegmentationDockWidget(QDockWidget):
         )
         if file_path:
             self.inf_raster_path_edit.setText(file_path)
+
+    @staticmethod
+    def _bbox_from_rect(rect):
+        return [
+            float(rect.xMinimum()),
+            float(rect.yMinimum()),
+            float(rect.xMaximum()),
+            float(rect.yMaximum()),
+        ]
+
+    @staticmethod
+    def _intersect_bboxes(first, second):
+        minx = max(first[0], second[0])
+        miny = max(first[1], second[1])
+        maxx = min(first[2], second[2])
+        maxy = min(first[3], second[3])
+        if minx >= maxx or miny >= maxy:
+            return None
+        return [minx, miny, maxx, maxy]
+
+    def _current_inference_layer(self):
+        return self.inf_raster_layer_combo.currentLayer()
+
+    def _layer_crs_authid(self, layer):
+        crs = layer.crs()
+        authid = getattr(crs, "authid", None)
+        return authid() if callable(authid) else None
+
+    def _range_bbox_for_layer(self, rect, layer):
+        canvas_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
+        layer_crs = layer.crs()
+        if canvas_crs != layer_crs:
+            transform = QgsCoordinateTransform(
+                canvas_crs, layer_crs, QgsProject.instance()
+            )
+            rect = transform.transformBoundingBox(rect)
+
+        rect_bbox = self._bbox_from_rect(rect)
+        extent_bbox = self._bbox_from_rect(layer.extent())
+        return self._intersect_bboxes(rect_bbox, extent_bbox)
+
+    def start_inference_range_tool(self):
+        """Start drawing the inference range on the map canvas."""
+        layer = self._current_inference_layer()
+        if layer is None:
+            QMessageBox.warning(
+                self,
+                "Warning",
+                "Please select a raster layer before drawing an inference range.",
+            )
+            self.draw_range_btn.setChecked(False)
+            return
+
+        if self.inference_range_tool is None:
+            self.inference_range_tool = RectangleRangeTool(self.iface.mapCanvas())
+            self.inference_range_tool.range_drawn.connect(self.set_inference_range)
+            self.inference_range_tool.range_canceled.connect(
+                self.cancel_inference_range_tool
+            )
+
+        self.previous_map_tool = self.iface.mapCanvas().mapTool()
+        self.iface.mapCanvas().setMapTool(self.inference_range_tool)
+
+    def cancel_inference_range_tool(self):
+        """Handle range drawing cancellation without clearing the saved range."""
+        self.draw_range_btn.setChecked(False)
+        if self.previous_map_tool:
+            self.iface.mapCanvas().setMapTool(self.previous_map_tool)
+
+    def set_inference_range(self, rect):
+        """Store the drawn inference range as a layer-CRS bbox."""
+        layer = self._current_inference_layer()
+        if layer is None:
+            self.clear_inference_range()
+            QMessageBox.warning(
+                self, "Warning", "Selected raster layer is no longer available."
+            )
+            return
+
+        bbox = self._range_bbox_for_layer(rect, layer)
+        if bbox is None:
+            self.clear_inference_range()
+            QMessageBox.warning(
+                self,
+                "Warning",
+                "The drawn range does not intersect the selected raster layer.",
+            )
+            return
+
+        self.inference_bbox = bbox
+        self.inference_bbox_crs = self._layer_crs_authid(layer)
+        self.inference_range_layer_source = layer.source()
+        self.range_status_label.setText(
+            f"{bbox[0]:.3f}, {bbox[1]:.3f}, {bbox[2]:.3f}, {bbox[3]:.3f}"
+        )
+        self.draw_range_btn.setChecked(False)
+        if self.previous_map_tool:
+            self.iface.mapCanvas().setMapTool(self.previous_map_tool)
+
+    def clear_inference_range(self, *args):
+        """Clear the selected inference range."""
+        self.inference_bbox = None
+        self.inference_bbox_crs = None
+        self.inference_range_layer_source = None
+        if "range_status_label" in self.__dict__:
+            self.range_status_label.setText("Full raster")
+        if "draw_range_btn" in self.__dict__:
+            self.draw_range_btn.setChecked(False)
+        if self.inference_range_tool is not None:
+            self.inference_range_tool.clear_rubber_band()
+
+    def _validated_inference_bbox(self, input_path):
+        if self.inference_bbox is None:
+            return None, None, None
+        if (
+            self.inference_range_layer_source
+            and input_path != self.inference_range_layer_source
+        ):
+            return (
+                None,
+                None,
+                "The selected inference range belongs to a different raster layer. "
+                "Clear the range or select the matching raster layer.",
+            )
+        return self.inference_bbox, self.inference_bbox_crs, None
 
     def browse_model(self):
         file_path, _ = QFileDialog.getOpenFileName(
@@ -1579,9 +1775,19 @@ class SegmentationDockWidget(QDockWidget):
             QMessageBox.warning(self, "Warning", "Please fill in all fields.")
             return
 
+        inference_bbox, inference_bbox_crs, range_error = (
+            self._validated_inference_bbox(input_path)
+        )
+        if range_error:
+            QMessageBox.warning(self, "Warning", range_error)
+            return
+
         self.run_inference_btn.setEnabled(False)
         self.inference_progress.setRange(0, 0)
-        self.log("Starting inference...")
+        if inference_bbox is not None:
+            self.log("Starting inference on selected range...")
+        else:
+            self.log("Starting inference...")
 
         threshold = (
             self.threshold_spin.value() if self.threshold_check.isChecked() else None
@@ -1609,6 +1815,8 @@ class SegmentationDockWidget(QDockWidget):
             self.inf_batch_size_spin.value(),
             probability_path=probability_path,
             probability_threshold=threshold,
+            inference_bbox=inference_bbox,
+            inference_bbox_crs=inference_bbox_crs,
         )
         self.inference_worker.finished.connect(self.on_inference_finished)
         self.inference_worker.error.connect(self.on_inference_error)

--- a/qgis_plugin/geoai/dialogs/segmentation.py
+++ b/qgis_plugin/geoai/dialogs/segmentation.py
@@ -6,6 +6,7 @@ and running inference, combined in a single dockable panel.
 """
 
 import os
+import shutil
 import tempfile
 from typing import Optional
 
@@ -32,16 +33,11 @@ from qgis.PyQt.QtWidgets import (
     QScrollArea,
 )
 
-from qgis.core import (
-    QgsCoordinateTransform,
-    QgsProject,
-    QgsVectorLayer,
-    QgsRasterLayer,
-)
+from qgis.core import QgsProject, QgsVectorLayer, QgsRasterLayer
 from qgis.gui import QgsMapLayerComboBox
 from qgis.core import QgsMapLayerProxyModel
 
-from .map_tools import RectangleRangeTool
+from .inference_range import InferenceRangeMixin
 
 
 class OutputCapture:
@@ -274,7 +270,7 @@ class InferenceWorker(QThread):
 
     def run(self):
         """Execute the inference."""
-        clipped_input_path = None
+        temp_dir = None
         try:
             from ..core.geoai_task_subprocess import run_geoai_task
 
@@ -282,11 +278,8 @@ class InferenceWorker(QThread):
             input_path = self.input_path
 
             if self.inference_bbox is not None:
-                temp_file = tempfile.NamedTemporaryFile(
-                    suffix=".tif", prefix="geoai_inference_range_", delete=False
-                )
-                clipped_input_path = temp_file.name
-                temp_file.close()
+                temp_dir = tempfile.mkdtemp(prefix="geoai_inference_range_")
+                clipped_input_path = os.path.join(temp_dir, "clip.tif")
                 self.progress.emit("Clipping raster to selected range...")
                 run_geoai_task(
                     "clip_raster_by_bbox",
@@ -333,11 +326,8 @@ class InferenceWorker(QThread):
 
             self.error.emit(f"{str(e)}\n\n{traceback.format_exc()}")
         finally:
-            if clipped_input_path and os.path.exists(clipped_input_path):
-                try:
-                    os.remove(clipped_input_path)
-                except OSError:
-                    pass
+            if temp_dir:
+                shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 class VectorizeWorker(QThread):
@@ -432,7 +422,7 @@ class SmoothVectorWorker(QThread):
             self.error.emit(f"{str(e)}\n\n{traceback.format_exc()}")
 
 
-class SegmentationDockWidget(QDockWidget):
+class SegmentationDockWidget(InferenceRangeMixin, QDockWidget):
     """Dockable widget for segmentation training and inference."""
 
     def __init__(self, iface, parent=None):
@@ -1299,131 +1289,6 @@ class SegmentationDockWidget(QDockWidget):
         )
         if file_path:
             self.inf_raster_path_edit.setText(file_path)
-
-    @staticmethod
-    def _bbox_from_rect(rect):
-        return [
-            float(rect.xMinimum()),
-            float(rect.yMinimum()),
-            float(rect.xMaximum()),
-            float(rect.yMaximum()),
-        ]
-
-    @staticmethod
-    def _intersect_bboxes(first, second):
-        minx = max(first[0], second[0])
-        miny = max(first[1], second[1])
-        maxx = min(first[2], second[2])
-        maxy = min(first[3], second[3])
-        if minx >= maxx or miny >= maxy:
-            return None
-        return [minx, miny, maxx, maxy]
-
-    def _current_inference_layer(self):
-        return self.inf_raster_layer_combo.currentLayer()
-
-    def _layer_crs_authid(self, layer):
-        crs = layer.crs()
-        authid = getattr(crs, "authid", None)
-        return authid() if callable(authid) else None
-
-    def _range_bbox_for_layer(self, rect, layer):
-        canvas_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
-        layer_crs = layer.crs()
-        if canvas_crs != layer_crs:
-            transform = QgsCoordinateTransform(
-                canvas_crs, layer_crs, QgsProject.instance()
-            )
-            rect = transform.transformBoundingBox(rect)
-
-        rect_bbox = self._bbox_from_rect(rect)
-        extent_bbox = self._bbox_from_rect(layer.extent())
-        return self._intersect_bboxes(rect_bbox, extent_bbox)
-
-    def start_inference_range_tool(self):
-        """Start drawing the inference range on the map canvas."""
-        layer = self._current_inference_layer()
-        if layer is None:
-            QMessageBox.warning(
-                self,
-                "Warning",
-                "Please select a raster layer before drawing an inference range.",
-            )
-            self.draw_range_btn.setChecked(False)
-            return
-
-        if self.inference_range_tool is None:
-            self.inference_range_tool = RectangleRangeTool(self.iface.mapCanvas())
-            self.inference_range_tool.range_drawn.connect(self.set_inference_range)
-            self.inference_range_tool.range_canceled.connect(
-                self.cancel_inference_range_tool
-            )
-
-        self.previous_map_tool = self.iface.mapCanvas().mapTool()
-        self.iface.mapCanvas().setMapTool(self.inference_range_tool)
-
-    def cancel_inference_range_tool(self):
-        """Handle range drawing cancellation without clearing the saved range."""
-        self.draw_range_btn.setChecked(False)
-        if self.previous_map_tool:
-            self.iface.mapCanvas().setMapTool(self.previous_map_tool)
-
-    def set_inference_range(self, rect):
-        """Store the drawn inference range as a layer-CRS bbox."""
-        layer = self._current_inference_layer()
-        if layer is None:
-            self.clear_inference_range()
-            QMessageBox.warning(
-                self, "Warning", "Selected raster layer is no longer available."
-            )
-            return
-
-        bbox = self._range_bbox_for_layer(rect, layer)
-        if bbox is None:
-            self.clear_inference_range()
-            QMessageBox.warning(
-                self,
-                "Warning",
-                "The drawn range does not intersect the selected raster layer.",
-            )
-            return
-
-        self.inference_bbox = bbox
-        self.inference_bbox_crs = self._layer_crs_authid(layer)
-        self.inference_range_layer_source = layer.source()
-        self.range_status_label.setText(
-            f"{bbox[0]:.3f}, {bbox[1]:.3f}, {bbox[2]:.3f}, {bbox[3]:.3f}"
-        )
-        self.draw_range_btn.setChecked(False)
-        if self.previous_map_tool:
-            self.iface.mapCanvas().setMapTool(self.previous_map_tool)
-
-    def clear_inference_range(self, *args):
-        """Clear the selected inference range."""
-        self.inference_bbox = None
-        self.inference_bbox_crs = None
-        self.inference_range_layer_source = None
-        if "range_status_label" in self.__dict__:
-            self.range_status_label.setText("Full raster")
-        if "draw_range_btn" in self.__dict__:
-            self.draw_range_btn.setChecked(False)
-        if self.inference_range_tool is not None:
-            self.inference_range_tool.clear_rubber_band()
-
-    def _validated_inference_bbox(self, input_path):
-        if self.inference_bbox is None:
-            return None, None, None
-        if (
-            self.inference_range_layer_source
-            and input_path != self.inference_range_layer_source
-        ):
-            return (
-                None,
-                None,
-                "The selected inference range belongs to a different raster layer. "
-                "Clear the range or select the matching raster layer.",
-            )
-        return self.inference_bbox, self.inference_bbox_crs, None
 
     def browse_model(self):
         file_path, _ = QFileDialog.getOpenFileName(

--- a/qgis_plugin/geoai/workers/geoai_task_worker.py
+++ b/qgis_plugin/geoai/workers/geoai_task_worker.py
@@ -145,6 +145,14 @@ def _task_instance_segmentation(params: Dict[str, Any]) -> Dict[str, Any]:
     return {"output_path": params["output_path"]}
 
 
+def _task_clip_raster_by_bbox(params: Dict[str, Any]) -> Dict[str, Any]:
+    from geoai.utils.raster import clip_raster_by_bbox
+
+    _progress("Clipping raster to inference range...")
+    output_path = clip_raster_by_bbox(**params)
+    return {"output_path": output_path}
+
+
 def _task_raster_to_vector(params: Dict[str, Any]) -> Dict[str, Any]:
     from geoai.utils.raster import raster_to_vector
 
@@ -240,6 +248,7 @@ _TASKS = {
     "export_geotiff_tiles": _task_export_geotiff_tiles,
     "semantic_segmentation": _task_semantic_segmentation,
     "instance_segmentation": _task_instance_segmentation,
+    "clip_raster_by_bbox": _task_clip_raster_by_bbox,
     "raster_to_vector": _task_raster_to_vector,
     "vectorize_mask": _task_vectorize_mask,
     "smooth_vector": _task_smooth_vector,

--- a/qgis_plugin/tests/test_inference_range.py
+++ b/qgis_plugin/tests/test_inference_range.py
@@ -1,0 +1,140 @@
+from qgis.PyQt.QtWidgets import QApplication
+
+from geoai.dialogs.instance_segmentation import (
+    InstanceInferenceWorker,
+    InstanceSegmentationDockWidget,
+)
+from geoai.dialogs.segmentation import InferenceWorker, SegmentationDockWidget
+
+
+def test_semantic_bbox_intersection_clips_to_layer_extent():
+    assert SegmentationDockWidget._intersect_bboxes([0, 0, 10, 10], [5, -5, 20, 6]) == [
+        5,
+        0,
+        10,
+        6,
+    ]
+    assert SegmentationDockWidget._intersect_bboxes([0, 0, 1, 1], [2, 2, 3, 3]) is None
+
+
+def test_instance_bbox_intersection_clips_to_layer_extent():
+    assert InstanceSegmentationDockWidget._intersect_bboxes(
+        [0, 0, 10, 10], [-2, 2, 8, 12]
+    ) == [0, 2, 8, 10]
+    assert (
+        InstanceSegmentationDockWidget._intersect_bboxes([0, 0, 1, 1], [1, 1, 2, 2])
+        is None
+    )
+
+
+def test_semantic_clear_inference_range_resets_state():
+    QApplication.instance() or QApplication([])
+    widget = SegmentationDockWidget.__new__(SegmentationDockWidget)
+    widget.inference_bbox = [1, 2, 3, 4]
+    widget.inference_bbox_crs = "EPSG:3857"
+    widget.inference_range_layer_source = "image.tif"
+    widget.inference_range_tool = None
+
+    widget.clear_inference_range()
+
+    assert widget.inference_bbox is None
+    assert widget.inference_bbox_crs is None
+    assert widget.inference_range_layer_source is None
+
+
+def test_instance_clear_inference_range_resets_state():
+    QApplication.instance() or QApplication([])
+    widget = InstanceSegmentationDockWidget.__new__(InstanceSegmentationDockWidget)
+    widget.inference_bbox = [1, 2, 3, 4]
+    widget.inference_bbox_crs = "EPSG:3857"
+    widget.inference_range_layer_source = "image.tif"
+    widget.inference_range_tool = None
+
+    widget.clear_inference_range()
+
+    assert widget.inference_bbox is None
+    assert widget.inference_bbox_crs is None
+    assert widget.inference_range_layer_source is None
+
+
+def test_semantic_worker_clips_before_inference(monkeypatch):
+    calls = []
+
+    def fake_run_geoai_task(action, params, progress_callback=None):
+        calls.append((action, dict(params)))
+        if action == "clip_raster_by_bbox":
+            with open(params["output_raster"], "wb") as fp:
+                fp.write(b"temporary")
+        return {"output_path": params.get("output_path")}
+
+    monkeypatch.setattr(
+        "geoai.core.geoai_task_subprocess.run_geoai_task", fake_run_geoai_task
+    )
+
+    worker = InferenceWorker(
+        "input.tif",
+        "output.tif",
+        "model.pth",
+        "unet",
+        "resnet34",
+        3,
+        2,
+        512,
+        256,
+        4,
+        inference_bbox=[1.0, 2.0, 3.0, 4.0],
+        inference_bbox_crs="EPSG:4326",
+    )
+
+    worker.run()
+
+    assert [call[0] for call in calls] == [
+        "clip_raster_by_bbox",
+        "semantic_segmentation",
+    ]
+    assert calls[0][1]["input_raster"] == "input.tif"
+    assert calls[0][1]["bbox"] == [1.0, 2.0, 3.0, 4.0]
+    assert calls[0][1]["bbox_crs"] == "EPSG:4326"
+    assert calls[1][1]["input_path"] == calls[0][1]["output_raster"]
+    assert calls[1][1]["output_path"] == "output.tif"
+
+
+def test_instance_worker_clips_before_inference(monkeypatch):
+    calls = []
+
+    def fake_run_geoai_task(action, params, progress_callback=None):
+        calls.append((action, dict(params)))
+        if action == "clip_raster_by_bbox":
+            with open(params["output_raster"], "wb") as fp:
+                fp.write(b"temporary")
+        return {"output_path": params.get("output_path")}
+
+    monkeypatch.setattr(
+        "geoai.core.geoai_task_subprocess.run_geoai_task", fake_run_geoai_task
+    )
+
+    worker = InstanceInferenceWorker(
+        "input.tif",
+        "output.tif",
+        "model.pth",
+        3,
+        2,
+        512,
+        256,
+        0.5,
+        4,
+        inference_bbox=[1.0, 2.0, 3.0, 4.0],
+        inference_bbox_crs="EPSG:4326",
+    )
+
+    worker.run()
+
+    assert [call[0] for call in calls] == [
+        "clip_raster_by_bbox",
+        "instance_segmentation",
+    ]
+    assert calls[0][1]["input_raster"] == "input.tif"
+    assert calls[0][1]["bbox"] == [1.0, 2.0, 3.0, 4.0]
+    assert calls[0][1]["bbox_crs"] == "EPSG:4326"
+    assert calls[1][1]["input_path"] == calls[0][1]["output_raster"]
+    assert calls[1][1]["output_path"] == "output.tif"


### PR DESCRIPTION
## Summary
- Add a rubber-band "Inference Range" group to the QGIS semantic and instance segmentation dock widgets so users can pick a sub-area of the raster on the map canvas.
- Workers clip the source raster to the selected bbox via a new `clip_raster_by_bbox` subprocess task before running inference, keeping large-raster runs fast.
- Add `RectangleRangeTool` map tool and unit tests covering bbox intersection, state clearing, and the clip-then-infer worker path.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] Load a raster in QGIS, draw a range, run semantic segmentation, and verify output is clipped to the selected area.
- [ ] Repeat with the instance segmentation panel.
- [ ] Switch raster layers and confirm the saved range is cleared.

<img width="1500" height="811" alt="image" src="https://github.com/user-attachments/assets/a282fa4b-9d49-40bb-adf2-abc8feba2e11" />
