### PR TITLE
Fix QGIS installer SSL trust for PyTorch wheels

### DIFF
--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -418,6 +418,13 @@ _WINDOWS_CRASH_CODES = {
     -1073741515,  # 0xC0000135 signed
 }
 
+_INSECURE_PACKAGE_HOSTS = [
+    "pypi.org",
+    "pypi.python.org",
+    "files.pythonhosted.org",
+    "download.pytorch.org",
+]
+
 
 def _is_ssl_error(stderr: str) -> bool:
     """Detect SSL/certificate errors in pip output.
@@ -451,14 +458,10 @@ def _get_pip_ssl_flags() -> List[str]:
     Returns:
         List of pip command-line flags.
     """
-    return [
-        "--trusted-host",
-        "pypi.org",
-        "--trusted-host",
-        "pypi.python.org",
-        "--trusted-host",
-        "files.pythonhosted.org",
-    ]
+    flags = []
+    for host in _INSECURE_PACKAGE_HOSTS:
+        flags.extend(["--trusted-host", host])
+    return flags
 
 
 def _get_uv_ssl_flags() -> List[str]:
@@ -467,12 +470,10 @@ def _get_uv_ssl_flags() -> List[str]:
     Returns:
         List of uv command-line flags.
     """
-    return [
-        "--allow-insecure-host",
-        "pypi.org",
-        "--allow-insecure-host",
-        "files.pythonhosted.org",
-    ]
+    flags = ["--native-tls"]
+    for host in _INSECURE_PACKAGE_HOSTS:
+        flags.extend(["--allow-insecure-host", host])
+    return flags
 
 
 def _is_network_error(output: str) -> bool:

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -418,12 +418,12 @@ _WINDOWS_CRASH_CODES = {
     -1073741515,  # 0xC0000135 signed
 }
 
-_INSECURE_PACKAGE_HOSTS = [
+_INSECURE_PACKAGE_HOSTS = (
     "pypi.org",
     "pypi.python.org",
     "files.pythonhosted.org",
     "download.pytorch.org",
-]
+)
 
 
 def _is_ssl_error(stderr: str) -> bool:
@@ -465,12 +465,21 @@ def _get_pip_ssl_flags() -> List[str]:
 
 
 def _get_uv_ssl_flags() -> List[str]:
-    """Get uv flags to bypass SSL verification for corporate proxies.
+    """Get default uv TLS flags.
 
     Returns:
         List of uv command-line flags.
     """
-    flags = ["--native-tls"]
+    return ["--native-tls"]
+
+
+def _get_uv_insecure_host_flags() -> List[str]:
+    """Get uv flags to bypass SSL verification after a certificate failure.
+
+    Returns:
+        List of uv command-line flags.
+    """
+    flags = []
     for host in _INSECURE_PACKAGE_HOSTS:
         flags.extend(["--allow-insecure-host", host])
     return flags
@@ -1857,6 +1866,67 @@ def _run_pip_install(
             pass
 
 
+def _retry_uv_install_with_insecure_hosts(
+    result: _PipResult,
+    cmd: List[str],
+    timeout: int,
+    env: dict,
+    subprocess_kwargs: dict,
+    label: str,
+    progress_start: int,
+    progress_end: int,
+    progress_callback: Optional[Callable[[int, str], None]] = None,
+    cancel_check: Optional[Callable[[], bool]] = None,
+) -> _PipResult:
+    """Retry a failed uv install with explicit insecure package hosts.
+
+    Args:
+        result: The failed install result to inspect.
+        cmd: The original uv install command.
+        timeout: Maximum time in seconds.
+        env: Environment variables dict.
+        subprocess_kwargs: Platform-specific kwargs for subprocess.
+        label: Human-readable label for progress messages.
+        progress_start: Start percentage for this install's progress range.
+        progress_end: End percentage for this install's progress range.
+        progress_callback: Optional progress callback.
+        cancel_check: Optional cancellation check callback.
+
+    Returns:
+        Original result if no SSL retry is needed, otherwise the retry result.
+    """
+    if result.returncode == 0:
+        return result
+
+    error_output = result.stderr or result.stdout or ""
+    if not _is_ssl_error(error_output):
+        return result
+
+    _log(
+        "uv SSL certificate error, retrying with explicit trusted package hosts...",
+        Qgis.Warning,
+    )
+    if progress_callback:
+        progress_callback(
+            progress_start,
+            "SSL certificate error, retrying with trusted package hosts...",
+        )
+    if cancel_check and cancel_check():
+        return _PipResult(-1, "", "Installation cancelled")
+
+    return _run_pip_install(
+        cmd=cmd + _get_uv_insecure_host_flags(),
+        timeout=timeout,
+        env=env,
+        subprocess_kwargs=subprocess_kwargs,
+        label="{} (SSL retry)".format(label),
+        progress_start=progress_start,
+        progress_end=progress_end,
+        progress_callback=progress_callback,
+        cancel_check=cancel_check,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Dependency installation
 # ---------------------------------------------------------------------------
@@ -1986,6 +2056,24 @@ def _reinstall_cpu_torch(
                 _log(f"Installed {pkg} (CPU)", Qgis.Success)
             else:
                 err = result.stderr or result.stdout or ""
+                if _use_uv and _is_ssl_error(err):
+                    _log(
+                        "CPU torch reinstall hit a uv SSL certificate error, "
+                        "retrying with explicit trusted package hosts...",
+                        Qgis.Warning,
+                    )
+                    retry_result = subprocess.run(
+                        cmd + _get_uv_insecure_host_flags(),
+                        capture_output=True,
+                        text=True,
+                        timeout=600,
+                        env=env,
+                        **subprocess_kwargs,
+                    )
+                    if retry_result.returncode == 0:
+                        _log(f"Installed {pkg} (CPU)", Qgis.Success)
+                        continue
+                    err = retry_result.stderr or retry_result.stdout or err
                 _log(f"Failed to install {pkg} (CPU): {err[:200]}", Qgis.Warning)
         except Exception as e:
             _log(f"Exception installing {pkg} (CPU): {e}", Qgis.Warning)
@@ -2338,6 +2426,20 @@ def install_dependencies(
                             cancel_check=cancel_check,
                         )
 
+                if result.returncode != 0 and use_uv:
+                    result = _retry_uv_install_with_insecure_hosts(
+                        result=result,
+                        cmd=base_cmd,
+                        timeout=pkg_timeout,
+                        env=env,
+                        subprocess_kwargs=subprocess_kwargs,
+                        label=label,
+                        progress_start=pkg_start,
+                        progress_end=pkg_end,
+                        progress_callback=progress_callback,
+                        cancel_check=cancel_check,
+                    )
+
                 # Retry on network errors
                 if result.returncode != 0:
                     error_output = result.stderr or result.stdout or ""
@@ -2459,6 +2561,19 @@ def install_dependencies(
                         progress_callback=progress_callback,
                         cancel_check=cancel_check,
                     )
+                    if cpu_result.returncode != 0 and use_uv:
+                        cpu_result = _retry_uv_install_with_insecure_hosts(
+                            result=cpu_result,
+                            cmd=cpu_cmd,
+                            timeout=600,
+                            env=env,
+                            subprocess_kwargs=subprocess_kwargs,
+                            label="{} (CPU fallback)".format(package_name),
+                            progress_start=pkg_start,
+                            progress_end=pkg_end,
+                            progress_callback=progress_callback,
+                            cancel_check=cancel_check,
+                        )
                     if cpu_result.returncode == 0:
                         _log(
                             "Successfully installed {} (CPU)".format(package_spec),
@@ -2614,6 +2729,20 @@ def install_dependencies(
                         cancel_check=cancel_check,
                     )
 
+            if result.returncode != 0 and use_uv:
+                result = _retry_uv_install_with_insecure_hosts(
+                    result=result,
+                    cmd=base_cmd,
+                    timeout=batch_timeout,
+                    env=env,
+                    subprocess_kwargs=subprocess_kwargs,
+                    label="dependencies",
+                    progress_start=batch_start,
+                    progress_end=batch_end,
+                    progress_callback=progress_callback,
+                    cancel_check=cancel_check,
+                )
+
             # Retry on network errors
             if result.returncode != 0:
                 error_output = result.stderr or result.stdout or ""
@@ -2699,6 +2828,19 @@ def install_dependencies(
                             progress_callback=progress_callback,
                             cancel_check=cancel_check,
                         )
+                        if result.returncode != 0 and use_uv:
+                            result = _retry_uv_install_with_insecure_hosts(
+                                result=result,
+                                cmd=retry_cmd,
+                                timeout=batch_timeout,
+                                env=env,
+                                subprocess_kwargs=subprocess_kwargs,
+                                label="dependencies (without {})".format(failed_pkg),
+                                progress_start=batch_start,
+                                progress_end=batch_end,
+                                progress_callback=progress_callback,
+                                cancel_check=cancel_check,
+                            )
                         if result.returncode == 0:
                             _log(
                                 "Batch succeeded without optional "

--- a/qgis_plugin/tests/test_venv_manager.py
+++ b/qgis_plugin/tests/test_venv_manager.py
@@ -81,9 +81,77 @@ def test_pip_ssl_flags_trust_pytorch_wheel_host():
     assert "download.pytorch.org" in flags
 
 
-def test_uv_ssl_flags_use_native_tls_and_allow_pytorch_wheel_host():
+def test_insecure_package_hosts_is_immutable():
+    assert isinstance(venv_manager._INSECURE_PACKAGE_HOSTS, tuple)
+
+
+def test_uv_ssl_flags_use_native_tls_without_insecure_hosts():
     flags = venv_manager._get_uv_ssl_flags()
 
     assert "--native-tls" in flags
+    assert "--allow-insecure-host" not in flags
+
+
+def test_uv_insecure_host_flags_allow_pytorch_wheel_host():
+    flags = venv_manager._get_uv_insecure_host_flags()
+
     assert "--allow-insecure-host" in flags
     assert "download.pytorch.org" in flags
+
+
+def test_uv_insecure_host_retry_only_after_ssl_error(monkeypatch):
+    calls = []
+
+    def fake_run_pip_install(**kwargs):
+        calls.append(kwargs["cmd"])
+        return venv_manager._PipResult(0, "ok", "")
+
+    monkeypatch.setattr(venv_manager, "_run_pip_install", fake_run_pip_install)
+
+    result = venv_manager._retry_uv_install_with_insecure_hosts(
+        result=venv_manager._PipResult(1, "", "CERTIFICATE_VERIFY_FAILED"),
+        cmd=["uv", "pip", "install", "--native-tls", "torch"],
+        timeout=1,
+        env={},
+        subprocess_kwargs={},
+        label="torch",
+        progress_start=0,
+        progress_end=1,
+    )
+
+    assert result.returncode == 0
+    assert calls == [
+        [
+            "uv",
+            "pip",
+            "install",
+            "--native-tls",
+            "torch",
+        ]
+        + venv_manager._get_uv_insecure_host_flags()
+    ]
+
+
+def test_uv_insecure_host_retry_skips_non_ssl_errors(monkeypatch):
+    calls = []
+
+    def fake_run_pip_install(**kwargs):
+        calls.append(kwargs["cmd"])
+        return venv_manager._PipResult(0, "ok", "")
+
+    monkeypatch.setattr(venv_manager, "_run_pip_install", fake_run_pip_install)
+    original = venv_manager._PipResult(1, "", "No matching distribution found")
+
+    result = venv_manager._retry_uv_install_with_insecure_hosts(
+        result=original,
+        cmd=["uv", "pip", "install", "--native-tls", "torch"],
+        timeout=1,
+        env={},
+        subprocess_kwargs={},
+        label="torch",
+        progress_start=0,
+        progress_end=1,
+    )
+
+    assert result is original
+    assert calls == []

--- a/qgis_plugin/tests/test_venv_manager.py
+++ b/qgis_plugin/tests/test_venv_manager.py
@@ -72,3 +72,18 @@ def test_version_satisfies_rejects_prerelease_for_minimum_version():
 
 def test_version_satisfies_fails_closed_for_unsupported_specifier():
     assert venv_manager._version_satisfies("0.39.0", "~=0.39.0") is False
+
+
+def test_pip_ssl_flags_trust_pytorch_wheel_host():
+    flags = venv_manager._get_pip_ssl_flags()
+
+    assert "--trusted-host" in flags
+    assert "download.pytorch.org" in flags
+
+
+def test_uv_ssl_flags_use_native_tls_and_allow_pytorch_wheel_host():
+    flags = venv_manager._get_uv_ssl_flags()
+
+    assert "--native-tls" in flags
+    assert "--allow-insecure-host" in flags
+    assert "download.pytorch.org" in flags


### PR DESCRIPTION
## Summary
- Add the PyTorch wheel host to pip and uv SSL fallback flags used by the QGIS dependency installer.
- Prefer native TLS for uv so platform certificate stores can be used before host-specific insecure allowances are needed.
- Add focused tests for the installer SSL flag helpers.

Fixes #775

## Tests
- `pytest qgis_plugin/tests/test_venv_manager.py`
- `pre-commit run --all-files`