### PR TITLE
Bump package and plugin patch versions

### DIFF
--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -8,7 +8,7 @@ only when a specific symbol is first accessed.
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.39.1"
+__version__ = "0.39.2"
 
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geoai-py"
-version = "0.39.1"
+version = "0.39.2"
 dynamic = [
     "dependencies",
 ]
@@ -58,7 +58,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.39.1"
+current_version = "0.39.2"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.4.1
+version=1.4.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -59,6 +59,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.4.2
+        - Fix QGIS installer SSL trust for PyTorch wheels (#775)
     1.4.1
         - Fix QGIS stale GeoAI venv detection (#773)
         - Add inference range drawing to QGIS segmentation panels (#771)


### PR DESCRIPTION
## Summary
- Bump the Python package version from 0.39.1 to 0.39.2.
- Bump the QGIS plugin version from 1.4.1 to 1.4.2.
- Add a QGIS plugin changelog entry for the installer SSL trust fix.

## Tests
- `python -c "import tomllib, geoai; data=tomllib.load(open('pyproject.toml','rb')); assert data['project']['version']=='0.39.2'; assert data['tool']['bumpversion']['current_version']=='0.39.2'; assert geoai.__version__=='0.39.2'; print('version checks passed')"`
- `pytest qgis_plugin/tests/test_diagnostics.py qgis_plugin/tests/test_venv_manager.py`
- `pre-commit run --all-files`