### PR TITLE
feat: add road network simplification example

### DIFF
--- a/docs/examples/road_network_simplification.ipynb
+++ b/docs/examples/road_network_simplification.ipynb
@@ -50,7 +50,8 @@
     "import matplotlib.pyplot as plt\n",
     "import osmnx as ox\n",
     "\n",
-    "import geoai"
+    "import geoai\n",
+    "import leafmap"
    ]
   },
   {
@@ -160,8 +161,31 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
+    "m.add_gdf(\n",
+    "    roads,\n",
+    "    layer_name=\"Original\",\n",
+    "    style={\"color\": \"blue\", \"weight\": 2},\n",
+    "    zoom_to_layer=True,\n",
+    ")\n",
+    "m.add_gdf(\n",
+    "    simplified,\n",
+    "    layer_name=\"Simplified\",\n",
+    "    style={\"color\": \"red\", \"weight\": 2},\n",
+    "    zoom_to_layer=True,\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Save the simplified network\n",
@@ -172,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "## Use an exclusion mask (optional)\n",
@@ -194,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,13 +232,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "geo",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/docs/examples/road_network_simplification.ipynb
+++ b/docs/examples/road_network_simplification.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Road network simplification\n",
+    "\n",
+    "This notebook demonstrates how to simplify road networks with `geoai.simplify_road_network`, a convenience wrapper around [`neatnet`](https://uscuni.org/neatnet/). The workflow is useful for post-processing road centerlines from OpenStreetMap or road vectors derived from deep learning segmentation masks.\n",
+    "\n",
+    "The simplification collapses transportation-oriented geometries such as dual carriageways, roundabouts, and complex intersections into a more morphological centerline network."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Install optional dependencies\n",
+    "\n",
+    "`neatnet` and `osmnx` are optional network-processing dependencies. Uncomment the next cell if they are not installed in your environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U \"geoai-py[networks]\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import osmnx as ox\n",
+    "\n",
+    "import geoai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Download a sample road network\n",
+    "\n",
+    "For a reproducible, lightweight example, download a small drivable street network from OpenStreetMap and project it to a local CRS before simplification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "place = \"Piedmont, California, USA\"\n",
+    "\n",
+    "# Download a drivable street graph and project it to a local CRS.\n",
+    "graph = ox.graph_from_place(place, network_type=\"drive\")\n",
+    "graph = ox.project_graph(graph)\n",
+    "\n",
+    "# Convert the graph edges to a GeoDataFrame of road geometries.\n",
+    "roads = ox.graph_to_gdfs(\n",
+    "    ox.convert.to_undirected(graph),\n",
+    "    nodes=False,\n",
+    "    edges=True,\n",
+    "    node_geometry=False,\n",
+    "    fill_edge_geometry=True,\n",
+    ").reset_index(drop=True)\n",
+    "\n",
+    "roads = roads[[\"geometry\"]].copy()\n",
+    "roads.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Visualize the original road network"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = roads.plot(figsize=(8, 8), linewidth=0.6)\n",
+    "ax.set_title(\"Original road network\")\n",
+    "ax.set_axis_off()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Simplify the road network\n",
+    "\n",
+    "Call `geoai.simplify_road_network()` with a GeoDataFrame. You can also pass a vector file path, for example `geoai.simplify_road_network(\"roads.gpkg\")`.\n",
+    "\n",
+    "`neatnet` may add a `_status` column describing whether each output geometry is original, changed, or newly created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simplified = geoai.simplify_road_network(roads)\n",
+    "simplified.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## Compare original and simplified networks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 2, figsize=(14, 7))\n",
+    "\n",
+    "roads.plot(ax=axes[0], linewidth=0.6, color=\"tab:blue\")\n",
+    "simplified.plot(ax=axes[1], linewidth=0.8, color=\"tab:red\")\n",
+    "\n",
+    "axes[0].set_title(\"Original\")\n",
+    "axes[1].set_title(\"Simplified\")\n",
+    "for ax in axes:\n",
+    "    ax.set_axis_off()\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "## Save the simplified network\n",
+    "\n",
+    "Write the simplified network to any vector format supported by GeoPandas/Fiona. GeoPackage is a good default for preserving CRS and attributes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = \"piedmont_roads_simplified.gpkg\"\n",
+    "geoai.simplify_road_network(roads, output=output)\n",
+    "output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "## Use an exclusion mask (optional)\n",
+    "\n",
+    "If building footprints or other protected areas are available, pass them as `exclusion_mask` to preserve real enclosed blocks that should not be collapsed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# buildings = ox.features_from_place(place, tags={\"building\": True}).to_crs(roads.crs)\n",
+    "# simplified_with_buildings = geoai.simplify_road_network(\n",
+    "#     roads,\n",
+    "#     exclusion_mask=buildings.geometry,\n",
+    "# )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/networks.md
+++ b/docs/networks.md
@@ -1,0 +1,3 @@
+# networks module
+
+::: geoai.networks

--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -478,6 +478,7 @@ _LAZY_SUBMODULES = {
     "extract",
     "hf",
     "inference",
+    "networks",
     "segment",
     "train",
     "agents",

--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -141,6 +141,8 @@ _LAZY_SYMBOL_MAP = {
     "classify_image": ("classify", None),
     "classify_images": ("classify", None),
     "train_classifier": ("classify", None),
+    # --- geoai.networks ---
+    "simplify_road_network": ("networks", None),
     # --- geoai.download ---
     "download_naip": ("download", None),
     "download_overture_buildings": ("download", None),

--- a/geoai/networks.py
+++ b/geoai/networks.py
@@ -1,0 +1,93 @@
+"""Road network processing utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def _import_geopandas():
+    """Import geopandas with a helpful error message."""
+    try:
+        import geopandas as gpd
+    except ImportError as exc:  # pragma: no cover - dependency is required by geoai
+        raise ImportError(
+            "geopandas is required for road network processing. "
+            "Install it with `pip install geopandas`."
+        ) from exc
+    return gpd
+
+
+def _import_neatnet():
+    """Import neatnet with a helpful error message."""
+    try:
+        import neatnet
+    except ImportError as exc:
+        raise ImportError(
+            "neatnet is required to simplify road networks. Install the optional "
+            "network dependencies with `pip install geoai-py[networks]` or install "
+            "neatnet directly with `pip install neatnet`."
+        ) from exc
+    return neatnet
+
+
+def simplify_road_network(
+    roads: Any,
+    output: str | Path | None = None,
+    exclusion_mask: Any | None = None,
+    **kwargs: Any,
+):
+    """Simplify a road or street network with ``neatnet``.
+
+    This function wraps :func:`neatnet.neatify` to convert transportation-oriented
+    street geometries, such as dual carriageways and roundabouts, into a simpler
+    morphological network that better represents street centerlines. It is useful
+    for post-processing road networks derived from deep learning segmentation or
+    vectorized masks.
+
+    Args:
+        roads: Input road network as a GeoDataFrame or a path to any vector file
+            supported by GeoPandas, such as GeoPackage, GeoJSON, or Shapefile.
+        output: Optional path where the simplified network will be written. The
+            driver is inferred from the file extension by GeoPandas/Fiona.
+        exclusion_mask: Optional GeoSeries, GeoDataFrame, geometry sequence, or
+            vector file path passed to ``neatnet.neatify`` as ``exclusion_mask``.
+            Building footprints are commonly used to preserve real street blocks.
+        **kwargs: Additional keyword arguments forwarded to
+            :func:`neatnet.neatify`.
+
+    Returns:
+        geopandas.GeoDataFrame: The simplified road network.
+
+    Raises:
+        ImportError: If ``neatnet`` is not installed.
+
+    Examples:
+        >>> import geoai
+        >>> simplified = geoai.simplify_road_network("roads.gpkg")
+        >>> simplified.to_file("roads_simplified.gpkg")
+    """
+    gpd = _import_geopandas()
+    neatnet = _import_neatnet()
+
+    if isinstance(roads, (str, Path)):
+        roads_gdf = gpd.read_file(roads)
+    else:
+        roads_gdf = roads
+
+    neatify_kwargs = dict(kwargs)
+    if exclusion_mask is not None:
+        if isinstance(exclusion_mask, (str, Path)):
+            exclusion_data = gpd.read_file(exclusion_mask)
+            neatify_kwargs["exclusion_mask"] = exclusion_data.geometry
+        else:
+            neatify_kwargs["exclusion_mask"] = exclusion_mask
+
+    simplified = neatnet.neatify(roads_gdf, **neatify_kwargs)
+
+    if output is not None:
+        output_path = Path(output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        simplified.to_file(output_path)
+
+    return simplified

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,7 @@ nav:
           - examples/AutoModel.ipynb
           - examples/onnx.ipynb
           - examples/smooth_vector.ipynb
+          - examples/road_network_simplification.ipynb
           - examples/timelapse.ipynb
           - examples/prithvi.ipynb
           - examples/train_timm_regressor.ipynb
@@ -234,6 +235,7 @@ nav:
           - map_tools module: map_tools.md
           - map_widgets module: map_widgets.md
           - moondream module: moondream.md
+          - networks module: networks.md
           - onnx module: onnx.md
           - prithvi module: prithvi.md
           - recognize module: recognize.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ agents = ["strands-agents", "strands-agents-tools", "strands-agents[ollama]", "s
 onnx = ["onnx>=1.21.0", "onnxruntime"]
 sr = ["opensr-model"]
 rfdetr = ["rfdetr"]
+networks = ["neatnet", "osmnx"]
 
 [tool.uv]
 # Enforce minimum versions for transitive dependencies to resolve

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,0 +1,78 @@
+"""Tests for road network simplification helpers."""
+
+from types import SimpleNamespace
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import LineString, Polygon
+
+from geoai.networks import simplify_road_network
+
+
+def test_simplify_road_network_calls_neatnet_neatify(monkeypatch):
+    """simplify_road_network should delegate GeoDataFrame inputs to neatnet.neatify."""
+    roads = gpd.GeoDataFrame(
+        {"name": ["A", "B"]},
+        geometry=[LineString([(0, 0), (1, 0)]), LineString([(0, 1), (1, 1)])],
+        crs="EPSG:3857",
+    )
+    simplified = roads.copy()
+    simplified["_status"] = ["original", "original"]
+    buildings = gpd.GeoSeries(
+        [Polygon([(0, 0), (0, 1), (1, 1), (1, 0)])], crs=roads.crs
+    )
+    calls = {}
+
+    def fake_neatify(gdf, **kwargs):
+        calls["gdf"] = gdf
+        calls["kwargs"] = kwargs
+        return simplified
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "neatnet", SimpleNamespace(neatify=fake_neatify)
+    )
+
+    result = simplify_road_network(
+        roads,
+        exclusion_mask=buildings,
+        artifact_threshold=8,
+    )
+
+    assert result is simplified
+    assert calls["gdf"] is roads
+    assert calls["kwargs"]["exclusion_mask"] is buildings
+    assert calls["kwargs"]["artifact_threshold"] == 8
+
+
+def test_simplify_road_network_writes_output(monkeypatch, tmp_path):
+    """simplify_road_network should write outputs when an output path is supplied."""
+    roads = gpd.GeoDataFrame(
+        {"name": ["A"]}, geometry=[LineString([(0, 0), (1, 0)])], crs="EPSG:3857"
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "neatnet",
+        SimpleNamespace(neatify=lambda gdf, **kwargs: roads.copy()),
+    )
+    output = tmp_path / "simplified.gpkg"
+
+    result = simplify_road_network(roads, output=output)
+
+    assert output.exists()
+    assert isinstance(result, gpd.GeoDataFrame)
+
+
+def test_simplify_road_network_requires_neatnet(monkeypatch):
+    """A clear installation hint should be raised when neatnet is unavailable."""
+    monkeypatch.delitem(__import__("sys").modules, "neatnet", raising=False)
+
+    def fake_import(name, *args, **kwargs):
+        if name == "neatnet":
+            raise ImportError("missing neatnet")
+        return original_import(name, *args, **kwargs)
+
+    original_import = __import__("builtins").__import__
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    with pytest.raises(ImportError, match="pip install geoai-py\[networks\]"):
+        simplify_road_network(gpd.GeoDataFrame(geometry=[]))


### PR DESCRIPTION
## Summary
- Add `geoai.networks.simplify_road_network()` as a small wrapper around `neatnet.neatify` for road/street network simplification
- Add optional `networks` dependency extra with `neatnet` and `osmnx`
- Add a road network simplification notebook example and API docs page

## Test plan
- [x] `pytest tests/test_networks.py -q`
- [x] `pre-commit run --files geoai/networks.py geoai/__init__.py tests/test_networks.py pyproject.toml mkdocs.yml docs/networks.md docs/examples/road_network_simplification.ipynb`
- [x] `mkdocs build`

Closes #164
