### PR TITLE
fix: correct transformers dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ torch
 torchgeo
 torchinfo
 tqdm
-transformers>=5.6.2
+transformers>=4.56.2


### PR DESCRIPTION
## Summary
- Corrects the Transformers dependency from `transformers>=5.6.2` to `transformers>=4.56.2`.

## Test Plan
- Parsed every entry in `requirements.txt` with `packaging.requirements.Requirement`.

