### PR TITLE
Improve QGIS dependency resilience and Windows CI

### DIFF
--- a/.github/workflows/minimal-import.yml
+++ b/.github/workflows/minimal-import.yml
@@ -1,0 +1,45 @@
+name: Minimal import CI
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    minimal-import:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  version: ""
+                  enable-cache: false
+
+            - name: Create minimal environment
+              run: |
+                  uv venv --python 3.12
+                  uv pip install --no-deps .
+                  uv pip install click tqdm
+
+            - name: Verify minimal import surface
+              run: |
+                  .venv/bin/python - <<'PY'
+                  import sys
+                  import geoai
+                  print('geoai', geoai.__version__)
+                  assert geoai.__version__
+                  assert 'torch' not in sys.modules
+                  assert 'geopandas' not in sys.modules
+                  assert 'leafmap' not in sys.modules
+                  from geoai import FunctionStep, Pipeline
+                  step = FunctionStep('identity', lambda item: item)
+                  pipe = Pipeline([step], name='minimal-smoke')
+                  result = pipe.run(items=[{'input_path': 'minimal.tif'}])
+                  assert result.summary['completed'] == 1
+                  PY
+                  .venv/bin/geoai --help

--- a/.github/workflows/qgis-dependency-resolver.yml
+++ b/.github/workflows/qgis-dependency-resolver.yml
@@ -45,6 +45,11 @@ jobs:
               with:
                   python-version: "3.12"
 
+            - name: Install Qt6 runtime libs
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+
             - name: Install test dependencies
               run: |
                   python -m pip install --upgrade pip

--- a/.github/workflows/qgis-dependency-resolver.yml
+++ b/.github/workflows/qgis-dependency-resolver.yml
@@ -1,0 +1,54 @@
+name: QGIS dependency resolver
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - "qgis_plugin/**"
+            - ".github/workflows/qgis-dependency-resolver.yml"
+    pull_request:
+        branches:
+            - main
+        paths:
+            - "qgis_plugin/**"
+            - ".github/workflows/qgis-dependency-resolver.yml"
+
+jobs:
+    windows-python-312-resolve:
+        name: Windows Python 3.12 dependency resolve
+        runs-on: windows-latest
+        steps:
+            - uses: actions/checkout@v6
+
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.12"
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  version: ""
+                  enable-cache: false
+
+            - name: Resolve QGIS plugin dependencies without installing
+              run: |
+                  python qgis_plugin/tools/check_dependency_resolution.py --platform win32 --python-version 3.12 --timeout 900
+
+    diagnostics-unit-tests:
+        name: Resolver diagnostics tests
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.12"
+
+            - name: Install test dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install PyQt6 pytest
+
+            - name: Run resolver diagnostics tests
+              run: pytest qgis_plugin/tests/test_dependency_resolver.py -q

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,8 +11,9 @@ jobs:
     test-windows:
         runs-on: windows-latest
         strategy:
+            fail-fast: false
             matrix:
-                python-version: ["3.12"]
+                python-version: ["3.11", "3.12"]
 
         steps:
             - uses: actions/checkout@v6
@@ -23,18 +24,19 @@ jobs:
                   version: ""
                   enable-cache: false
 
+            - name: Set up Python ${{ matrix.python-version }}
+              run: uv python install ${{ matrix.python-version }}
+
             - name: Install dependencies
               run: |
                   uv venv --python ${{ matrix.python-version }}
-                  uv pip install .
+                  uv pip install . pytest
 
-            # - name: Update PROJ data files
-            #   run: |
-            #       pip install --upgrade pyproj
-            #       curl -L -o proj-data.zip https://download.osgeo.org/proj/proj-data-1.9.zip
-            #       unzip proj-data.zip -d proj-data
-            #       cp -r proj-data/* $(python -m pyproj -v | grep "PROJ_LIB" | cut -d ' ' -f 2)
-
-            - name: Test import
+            - name: Test import and CLI
               run: |
-                  .venv\Scripts\python -c "import geoai; print('geoai import successful')"
+                  .venv\Scripts\python -c "import geoai; print('geoai', geoai.__version__)"
+                  .venv\Scripts\geoai --help
+
+            - name: Run lightweight tests
+              run: |
+                  .venv\Scripts\python -m pytest tests/test_lazy_import.py -q

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.11", "3.12"]
+                python-version: ["3.11", "3.12", "3.13"]
 
         steps:
             - uses: actions/checkout@v6

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -379,12 +379,17 @@ def resolve_qgis_dependencies(
     except FileNotFoundError:
         return False, "uv is not installed; install uv to run dependency resolution."
     except subprocess.TimeoutExpired:
-        return False, "Dependency resolution timed out after {} seconds.".format(timeout)
+        return False, "Dependency resolution timed out after {} seconds.".format(
+            timeout
+        )
 
     output = (result.stderr or result.stdout or "").strip()
     if result.returncode == 0:
-        return True, "Dependency resolution succeeded for QGIS plugin on {} Python {}.".format(
-            {"win32": "Windows"}.get(platform_name, platform_name), python_version
+        return (
+            True,
+            "Dependency resolution succeeded for QGIS plugin on {} Python {}.".format(
+                {"win32": "Windows"}.get(platform_name, platform_name), python_version
+            ),
         )
     return (
         False,

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -37,11 +37,11 @@ REQUIRED_PACKAGES = [
     ("sam3", ""),
     ("deepforest", ""),
     ("omniwatermask", ""),
-    # Version is platform-specific and replaced in _get_required_packages():
-    # - macOS: >=5.1.0 (SAM 3 meta backend requirement)
-    # - Linux/Windows: ==4.57.6 (Moondream stability)
-    # Note: ordering doesn't matter with batch installs (resolver handles constraints).
-    ("transformers", ""),
+    # Version is kept at or above the geoai-py runtime requirement so the
+    # QGIS managed environment can resolve on Windows/Python 3.12.
+    # Older exact pins caused impossible constraints when geoai-py required a
+    # newer transformers release.
+    ("transformers", ">=5.6.2"),
 ]
 
 DEPS_HASH_FILE = os.path.join(VENV_DIR, "deps_hash.txt")
@@ -190,29 +190,211 @@ def _compute_deps_hash() -> str:
     return hashlib.md5(data, usedforsecurity=False).hexdigest()
 
 
-def _get_required_packages() -> List[Tuple[str, str]]:
-    """Return platform-aware dependency list.
+def _get_required_packages_for_platform(platform_name: str) -> List[Tuple[str, str]]:
+    """Return dependency list for a target platform.
 
-    On Windows, install ``triton-windows`` so SamGeo3/SAM3 imports can resolve
-    ``import triton`` in the managed venv subprocess worker.
+    Args:
+        platform_name: Python platform name such as ``win32``, ``darwin``, or
+            ``linux``.
+
+    Returns:
+        Platform-aware dependency tuples of distribution name and specifier.
     """
     packages = list(REQUIRED_PACKAGES)
-    transformers_idx = next(
-        (i for i, (name, _) in enumerate(packages) if name == "transformers"),
-        None,
-    )
-    if transformers_idx is not None:
-        if sys.platform == "darwin":
-            packages[transformers_idx] = ("transformers", ">=5.1.0")
-        else:
-            packages[transformers_idx] = ("transformers", "==4.57.6")
-    if sys.platform == "win32":
+    if platform_name == "win32":
         sam3_idx = next(
             (i for i, (name, _) in enumerate(packages) if name == "sam3"),
             len(packages),
         )
         packages.insert(sam3_idx, ("triton-windows", ""))
     return packages
+
+
+def _get_required_packages() -> List[Tuple[str, str]]:
+    """Return platform-aware dependency list.
+
+    On Windows, install ``triton-windows`` so SamGeo3/SAM3 imports can resolve
+    ``import triton`` in the managed venv subprocess worker.
+    """
+    return _get_required_packages_for_platform(sys.platform)
+
+
+def get_qgis_dependency_specs(
+    platform_name: Optional[str] = None,
+    python_version: str = "3.12",
+    include_python: bool = True,
+) -> List[str]:
+    """Return QGIS plugin dependency specifiers for resolver dry-runs.
+
+    Args:
+        platform_name: Target Python platform. Defaults to the running platform.
+        python_version: Target Python version used by the QGIS plugin workflow.
+        include_python: Include a synthetic Python constraint for diagnostics.
+
+    Returns:
+        Requirement specifier strings suitable for resolver checks.
+    """
+    target_platform = platform_name or sys.platform
+    specs = []
+    if include_python:
+        specs.append("python=={}.*".format(python_version))
+    for name, version_spec in _get_required_packages_for_platform(target_platform):
+        specs.append("{}{}".format(name, version_spec))
+    return specs
+
+
+def _uv_platform_name(platform_name: str) -> str:
+    """Map Python ``sys.platform`` names to uv resolver platform names."""
+    if platform_name == "win32":
+        return "windows"
+    if platform_name == "darwin":
+        return "macos"
+    return "linux"
+
+
+def _looks_like_resolution_conflict(output: str) -> bool:
+    """Return True if resolver output describes unsatisfiable constraints."""
+    output_lower = (output or "").lower()
+    patterns = (
+        "no solution found",
+        "resolutionimpossible",
+        "resolution impossible",
+        "unsatisfiable",
+        "cannot install",
+        "conflicting dependencies",
+        "because you require",
+        "no matching distribution found",
+        "has no wheels",
+        "requires-python",
+    )
+    return any(pattern in output_lower for pattern in patterns)
+
+
+def _extract_relevant_specs(output: str, package_specs: List[str]) -> List[str]:
+    """Find requested specs mentioned by resolver output."""
+    output_key = (output or "").lower().replace("_", "-")
+    relevant = []
+    for spec in package_specs:
+        name = re.split(r"[><=!]", spec, 1)[0].strip()
+        if name and name.lower().replace("_", "-") in output_key:
+            relevant.append(spec)
+    return relevant
+
+
+def format_dependency_resolution_diagnostic(
+    output: str,
+    package_specs: List[str],
+    python_version: str,
+    platform_name: str,
+) -> str:
+    """Format resolver failures as actionable user-facing diagnostics.
+
+    Args:
+        output: Combined stdout/stderr from the dependency resolver.
+        package_specs: Requirement specifiers involved in the attempted resolve.
+        python_version: Target Python version.
+        platform_name: Target Python platform.
+
+    Returns:
+        Concise diagnostic text for QGIS users and CI logs.
+    """
+    platform_label = {
+        "win32": "Windows",
+        "darwin": "macOS",
+        "linux": "Linux",
+    }.get(platform_name, platform_name)
+    relevant = _extract_relevant_specs(output, package_specs)
+    conflict = _looks_like_resolution_conflict(output)
+    lines = [
+        "Dependency resolution failed before installation for the GeoAI QGIS plugin.",
+        "Target environment: {} + Python {}.".format(platform_label, python_version),
+    ]
+    if conflict:
+        lines.append(
+            "The resolver reported unsatisfiable or impossible version constraints."
+        )
+    if relevant:
+        lines.append("Relevant constraints: {}.".format(", ".join(relevant[:8])))
+    lines.append(
+        "Try updating the pinned package versions in qgis_plugin/geoai/core/"
+        "venv_manager.py, or relax exact pins when upstream packages do not "
+        "publish wheels for this Python/platform combination."
+    )
+    if output:
+        lines.append("Resolver output: {}".format(output.strip()[:1200]))
+    return "\n".join(lines)
+
+
+def resolve_qgis_dependencies(
+    python_version: str = "3.12",
+    platform_name: str = "win32",
+    resolver: str = "uv",
+    timeout: int = 600,
+) -> Tuple[bool, str]:
+    """Dry-run dependency resolution for the QGIS plugin install environment.
+
+    This is intended for CI and support diagnostics. It resolves the dependency
+    set without installing large AI packages.
+
+    Args:
+        python_version: Target Python version, e.g. ``3.12``.
+        platform_name: Target Python platform, e.g. ``win32``.
+        resolver: Resolver backend. Currently only ``uv`` is supported.
+        timeout: Subprocess timeout in seconds.
+
+    Returns:
+        Tuple of success flag and diagnostic message.
+    """
+    if resolver != "uv":
+        return False, "Unsupported resolver: {}".format(resolver)
+
+    package_specs = get_qgis_dependency_specs(
+        platform_name=platform_name,
+        python_version=python_version,
+        include_python=False,
+    )
+    cmd = [
+        "uv",
+        "pip",
+        "compile",
+        "--python-version",
+        python_version,
+        "--python-platform",
+        _uv_platform_name(platform_name),
+        "--quiet",
+        "-",
+    ]
+    requirements = "\n".join(package_specs) + "\n"
+    try:
+        result = subprocess.run(
+            cmd,
+            input=requirements,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except TypeError:
+        # Some tests monkeypatch subprocess.run with a small signature.
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        return False, "uv is not installed; install uv to run dependency resolution."
+    except subprocess.TimeoutExpired:
+        return False, "Dependency resolution timed out after {} seconds.".format(timeout)
+
+    output = (result.stderr or result.stdout or "").strip()
+    if result.returncode == 0:
+        return True, "Dependency resolution succeeded for QGIS plugin on {} Python {}.".format(
+            {"win32": "Windows"}.get(platform_name, platform_name), python_version
+        )
+    return (
+        False,
+        format_dependency_resolution_diagnostic(
+            output,
+            package_specs=package_specs,
+            python_version=python_version,
+            platform_name=platform_name,
+        ),
+    )
 
 
 def _read_deps_hash() -> Optional[str]:
@@ -2652,6 +2834,18 @@ def install_dependencies(
                     "pip error output: {}".format(install_error_msg[:500]),
                     Qgis.Critical,
                 )
+                if _looks_like_resolution_conflict(install_error_msg):
+                    return (
+                        False,
+                        format_dependency_resolution_diagnostic(
+                            install_error_msg,
+                            package_specs=[package_spec],
+                            python_version="{}.{}".format(
+                                sys.version_info.major, sys.version_info.minor
+                            ),
+                            platform_name=sys.platform,
+                        ),
+                    )
                 if _is_ssl_error(install_error_msg):
                     return (
                         False,
@@ -2902,6 +3096,18 @@ def install_dependencies(
                     "Batch install failed: {}".format(error_output[:500]),
                     Qgis.Critical,
                 )
+                if _looks_like_resolution_conflict(error_output):
+                    return (
+                        False,
+                        format_dependency_resolution_diagnostic(
+                            error_output,
+                            package_specs=batch_specs,
+                            python_version="{}.{}".format(
+                                sys.version_info.major, sys.version_info.minor
+                            ),
+                            platform_name=sys.platform,
+                        ),
+                    )
                 if _is_ssl_error(error_output):
                     return (
                         False,

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -41,7 +41,7 @@ REQUIRED_PACKAGES = [
     # QGIS managed environment can resolve on Windows/Python 3.12.
     # Older exact pins caused impossible constraints when geoai-py required a
     # newer transformers release.
-    ("transformers", ">=5.6.2"),
+    ("transformers", ">=4.56.2"),
 ]
 
 DEPS_HASH_FILE = os.path.join(VENV_DIR, "deps_hash.txt")
@@ -373,9 +373,6 @@ def resolve_qgis_dependencies(
             text=True,
             timeout=timeout,
         )
-    except TypeError:
-        # Some tests monkeypatch subprocess.run with a small signature.
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     except FileNotFoundError:
         return False, "uv is not installed; install uv to run dependency resolution."
     except subprocess.TimeoutExpired:
@@ -3221,18 +3218,11 @@ def _get_verification_code(package_name: str) -> str:
     elif package_name == "sam3":
         return "import sam3; print('ok')"
     elif package_name == "transformers":
-        if sys.platform == "darwin":
-            return (
-                "import transformers; "
-                "from packaging.version import parse as _v; "
-                "v = transformers.__version__; "
-                "assert _v(v) >= _v('5.1.0'), f'Expected >=5.1.0 on macOS, got {v}'; "
-                "print(v)"
-            )
         return (
             "import transformers; "
+            "from packaging.version import parse as _v; "
             "v = transformers.__version__; "
-            "assert v == '4.57.6', f'Expected 4.57.6 on this platform, got {v}'; "
+            "assert _v(v) >= _v('4.56.2'), f'Expected >=4.56.2, got {v}'; "
             "print(v)"
         )
     elif package_name == "triton-windows":

--- a/qgis_plugin/tests/test_dependency_resolver.py
+++ b/qgis_plugin/tests/test_dependency_resolver.py
@@ -8,7 +8,7 @@ def test_windows_dependency_specs_include_python_312_and_triton():
 
     assert "python==3.12.*" in specs
     assert "triton-windows" in specs
-    assert "transformers>=5.6.2" in specs
+    assert "transformers>=4.56.2" in specs
 
 
 def test_resolution_failure_diagnostic_identifies_impossible_constraint():
@@ -34,10 +34,10 @@ def test_resolution_failure_diagnostic_identifies_impossible_constraint():
 
 
 def test_dependency_resolver_dry_run_uses_uv_compile(monkeypatch):
-    commands = []
+    calls = []
 
-    def fake_run(cmd, capture_output, text, timeout):
-        commands.append(cmd)
+    def fake_run(cmd, *args, **kwargs):
+        calls.append({"cmd": cmd, "input": kwargs.get("input")})
         return subprocess.CompletedProcess(
             cmd, 0, stdout="Resolved 10 packages", stderr=""
         )
@@ -53,8 +53,13 @@ def test_dependency_resolver_dry_run_uses_uv_compile(monkeypatch):
 
     assert ok is True
     assert "Dependency resolution succeeded" in message
-    assert commands
-    assert commands[0][:4] == ["uv", "pip", "compile", "--python-version"]
-    assert "3.12" in commands[0]
-    assert "--python-platform" in commands[0]
-    assert "windows" in commands[0]
+    assert calls
+    cmd = calls[0]["cmd"]
+    assert cmd[:4] == ["uv", "pip", "compile", "--python-version"]
+    assert "3.12" in cmd
+    assert "--python-platform" in cmd
+    assert "windows" in cmd
+    requirements = calls[0]["input"]
+    assert requirements is not None
+    assert "transformers>=4.56.2" in requirements
+    assert "triton-windows" in requirements

--- a/qgis_plugin/tests/test_dependency_resolver.py
+++ b/qgis_plugin/tests/test_dependency_resolver.py
@@ -1,0 +1,58 @@
+import subprocess
+
+from geoai.core import venv_manager
+
+
+def test_windows_dependency_specs_include_python_312_and_triton():
+    specs = venv_manager.get_qgis_dependency_specs(platform_name="win32")
+
+    assert "python==3.12.*" in specs
+    assert "triton-windows" in specs
+    assert "transformers>=5.6.2" in specs
+
+
+def test_resolution_failure_diagnostic_identifies_impossible_constraint():
+    output = """
+    Because transformers==4.57.6 has no wheels with a matching Python requirement
+    and you require transformers==4.57.6, we can conclude that your requirements
+    are unsatisfiable for Python 3.12 on win_amd64.
+    No solution found when resolving dependencies.
+    """
+
+    message = venv_manager.format_dependency_resolution_diagnostic(
+        output,
+        package_specs=["transformers==4.57.6", "sam3"],
+        python_version="3.12",
+        platform_name="win32",
+    )
+
+    assert "Dependency resolution failed before installation" in message
+    assert "Python 3.12" in message
+    assert "Windows" in message
+    assert "transformers==4.57.6" in message
+    assert "impossible" in message.lower() or "unsatisfiable" in message.lower()
+
+
+def test_dependency_resolver_dry_run_uses_uv_compile(monkeypatch):
+    commands = []
+
+    def fake_run(cmd, capture_output, text, timeout):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="Resolved 10 packages", stderr="")
+
+    monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
+
+    ok, message = venv_manager.resolve_qgis_dependencies(
+        python_version="3.12",
+        platform_name="win32",
+        resolver="uv",
+        timeout=5,
+    )
+
+    assert ok is True
+    assert "Dependency resolution succeeded" in message
+    assert commands
+    assert commands[0][:4] == ["uv", "pip", "compile", "--python-version"]
+    assert "3.12" in commands[0]
+    assert "--python-platform" in commands[0]
+    assert "windows" in commands[0]

--- a/qgis_plugin/tests/test_dependency_resolver.py
+++ b/qgis_plugin/tests/test_dependency_resolver.py
@@ -38,7 +38,9 @@ def test_dependency_resolver_dry_run_uses_uv_compile(monkeypatch):
 
     def fake_run(cmd, capture_output, text, timeout):
         commands.append(cmd)
-        return subprocess.CompletedProcess(cmd, 0, stdout="Resolved 10 packages", stderr="")
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="Resolved 10 packages", stderr=""
+        )
 
     monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
 

--- a/qgis_plugin/tools/check_dependency_resolution.py
+++ b/qgis_plugin/tools/check_dependency_resolution.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+"""Dry-run resolver for GeoAI QGIS plugin dependencies.
+
+This script is intentionally lightweight: it stubs the tiny part of QGIS needed
+by ``venv_manager`` and asks uv to resolve the plugin dependency set for a
+target Python/platform without installing the large AI packages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import types
+
+
+def _install_qgis_stub() -> None:
+    """Install the minimal qgis.core stub required by venv_manager imports."""
+    if "qgis" in sys.modules:
+        return
+    qgis = types.ModuleType("qgis")
+    qgis.__path__ = []
+    core = types.ModuleType("qgis.core")
+
+    class _Qgis:
+        Info = 0
+        Warning = 1
+        Critical = 2
+        Success = 3
+        QGIS_VERSION = "resolver-stub"
+
+    class _QgsMessageLog:
+        @staticmethod
+        def logMessage(message, tag="GeoAI", level=0):  # noqa: N802 - QGIS API
+            return None
+
+    setattr(core, "Qgis", _Qgis)
+    setattr(core, "QgsMessageLog", _QgsMessageLog)
+    setattr(qgis, "core", core)
+    sys.modules["qgis"] = qgis
+    sys.modules["qgis.core"] = core
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Dry-run GeoAI QGIS plugin dependency resolution."
+    )
+    parser.add_argument("--python-version", default="3.12")
+    parser.add_argument(
+        "--platform",
+        default="win32",
+        choices=["win32", "darwin", "linux"],
+        help="Target Python platform to resolve for.",
+    )
+    parser.add_argument("--timeout", type=int, default=600)
+    args = parser.parse_args(argv)
+
+    _install_qgis_stub()
+    plugin_root = pathlib.Path(__file__).resolve().parents[1]
+    if str(plugin_root) not in sys.path:
+        sys.path.insert(0, str(plugin_root))
+
+    venv_manager_path = plugin_root / "geoai" / "core" / "venv_manager.py"
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "geoai_qgis_venv_manager", venv_manager_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {venv_manager_path}")
+    venv_manager = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = venv_manager
+    spec.loader.exec_module(venv_manager)
+
+    success, message = venv_manager.resolve_qgis_dependencies(
+        python_version=args.python_version,
+        platform_name=args.platform,
+        timeout=args.timeout,
+    )
+    print(message)
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a QGIS dependency resolver dry-run workflow for Windows + Python 3.12, plus a standalone diagnostic script and unit tests.
- Improve QGIS plugin dependency diagnostics for unsatisfiable/impossible version constraints, and relax the transformers constraint so the Windows/Python 3.12 QGIS environment resolves.
- Expand Windows CI to Python 3.11/3.12 with install, import, `geoai --help`, and lightweight lazy-import tests.
- Add a fast minimal-import CI job that installs the package without heavy dependencies and checks `import geoai`, `geoai.__version__`, `geoai --help`, and lightweight pipeline utilities.

## Tests
- `python -m pytest tests/test_lazy_import.py -q`
- `python -m pytest qgis_plugin/tests/test_dependency_resolver.py -q`
- `python qgis_plugin/tools/check_dependency_resolution.py --python-version 3.12 --platform win32`
- `uv pip compile pyproject.toml --python-version 3.12 --python-platform windows --quiet`
- `uv pip compile pyproject.toml --python-version 3.11 --python-platform windows --quiet`
- Minimal no-deps smoke test in a temporary Python 3.12 venv
