### PR TITLE
chore: bump geoai patch version to 0.39.4

### DIFF
--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -8,7 +8,7 @@ only when a specific symbol is first accessed.
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.39.3"
+__version__ = "0.39.4"
 
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geoai-py"
-version = "0.39.3"
+version = "0.39.4"
 dynamic = [
     "dependencies",
 ]
@@ -58,7 +58,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.39.3"
+current_version = "0.39.4"
 commit = true
 tag = true
 tag_name = "v{new_version}"


### PR DESCRIPTION
## Summary
- Bump `geoai-py` package version from `0.39.3` to `0.39.4`
- Sync `geoai.__version__` and `tool.bumpversion.current_version` with the package version

## Test Plan
- [x] Verified version metadata with Python
- [x] `python -m pytest tests/test_lazy_import.py -q`
