### PR TITLE
Fix Windows QGIS torch DLL bootstrap

### DIFF
--- a/qgis_plugin/geoai/core/diagnostics.py
+++ b/qgis_plugin/geoai/core/diagnostics.py
@@ -15,6 +15,7 @@ from .venv_manager import (
     VENV_DIR,
     _get_clean_env_for_venv,
     _get_subprocess_kwargs,
+    _get_windows_dll_setup_code,
     detect_nvidia_gpu,
     get_venv_python_path,
     get_venv_site_packages,
@@ -379,7 +380,7 @@ def _run_probe(
 
 def _package_import_probe_script(module_name: str) -> str:
     module_json = json.dumps(module_name)
-    return textwrap.dedent(f"""
+    return _get_windows_dll_setup_code() + "\n" + textwrap.dedent(f"""
         import importlib
         import json
         import traceback
@@ -405,7 +406,7 @@ def _package_import_probe_script(module_name: str) -> str:
 
 
 def _torch_runtime_probe_script() -> str:
-    return textwrap.dedent("""
+    return _get_windows_dll_setup_code() + "\n" + textwrap.dedent("""
         import json
         import traceback
 

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 import time
 from typing import Callable, List, Optional, Tuple
 
@@ -870,6 +871,52 @@ def _get_subprocess_kwargs() -> dict:
         kwargs["startupinfo"] = startupinfo
         kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
     return kwargs
+
+
+def _get_windows_dll_setup_code() -> str:
+    """Return Python code that registers venv DLL directories on Windows.
+
+    Returns:
+        A Python source string that is safe to prepend to isolated subprocess
+        probes before importing packages with native PyTorch dependencies.
+    """
+    return textwrap.dedent("""
+        import os as _geoai_os
+        import sys as _geoai_sys
+
+        if _geoai_sys.platform == "win32":
+            try:
+                import sysconfig as _geoai_sysconfig
+
+                _geoai_site_packages = (
+                    _geoai_sysconfig.get_paths().get("platlib")
+                    or _geoai_sysconfig.get_paths().get("purelib")
+                )
+            except Exception:
+                _geoai_site_packages = None
+
+            if _geoai_site_packages:
+                _geoai_dll_dirs = [
+                    _geoai_os.path.join(_geoai_site_packages, "torch", "lib"),
+                    _geoai_os.path.join(_geoai_site_packages, "torch", "bin"),
+                    _geoai_os.path.join(_geoai_site_packages, "torchvision"),
+                ]
+                _geoai_path_parts = [
+                    p for p in _geoai_os.environ.get("PATH", "").split(_geoai_os.pathsep)
+                    if p
+                ]
+                for _geoai_dll_dir in _geoai_dll_dirs:
+                    if not _geoai_os.path.isdir(_geoai_dll_dir):
+                        continue
+                    if hasattr(_geoai_os, "add_dll_directory"):
+                        try:
+                            _geoai_os.add_dll_directory(_geoai_dll_dir)
+                        except OSError:
+                            pass
+                    if _geoai_dll_dir not in _geoai_path_parts:
+                        _geoai_path_parts.insert(0, _geoai_dll_dir)
+                _geoai_os.environ["PATH"] = _geoai_os.pathsep.join(_geoai_path_parts)
+        """).strip()
 
 
 def _get_qgis_proxy_settings() -> Optional[str]:
@@ -2321,6 +2368,7 @@ def _verify_cuda_in_venv(venv_dir: str) -> bool:
     subprocess_kwargs = _get_subprocess_kwargs()
 
     cuda_test_code = (
+        _get_windows_dll_setup_code() + "\n"
         "import torch; "
         "print('torch=' + torch.__version__); "
         "print('cuda_built=' + str(torch.version.cuda)); "
@@ -3207,18 +3255,19 @@ def _get_verification_code(package_name: str) -> str:
     Returns:
         Python code string to verify the package.
     """
+    prefix = _get_windows_dll_setup_code() + "\n"
     if package_name == "torch":
-        return "import torch; t = torch.tensor([1, 2, 3]); print(t.sum())"
+        code = "import torch; t = torch.tensor([1, 2, 3]); print(t.sum())"
     elif package_name == "torchvision":
-        return "import torchvision; print(torchvision.__version__)"
+        code = "import torchvision; print(torchvision.__version__)"
     elif package_name == "geoai-py":
-        return "import geoai; print(geoai.__version__)"
+        code = "import geoai; print(geoai.__version__)"
     elif package_name == "segment-geospatial":
-        return "import samgeo; print(samgeo.__version__)"
+        code = "import torch; import samgeo; print(samgeo.__version__)"
     elif package_name == "sam3":
-        return "import sam3; print('ok')"
+        code = "import torch; import sam3; print('ok')"
     elif package_name == "transformers":
-        return (
+        code = (
             "import transformers; "
             "from packaging.version import parse as _v; "
             "v = transformers.__version__; "
@@ -3226,14 +3275,15 @@ def _get_verification_code(package_name: str) -> str:
             "print(v)"
         )
     elif package_name == "triton-windows":
-        return "import triton; print('ok')"
+        code = "import triton; print('ok')"
     elif package_name == "deepforest":
-        return "from deepforest import main; print('ok')"
+        code = "import torch; from deepforest import main; print('ok')"
     elif package_name == "omniwatermask":
-        return "import omniwatermask; print('ok')"
+        code = "import torch; import omniwatermask; print('ok')"
     else:
         import_name = package_name.replace("-", "_")
-        return f"import {import_name}"
+        code = f"import {import_name}"
+    return prefix + code
 
 
 def verify_venv(

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -905,17 +905,21 @@ def _get_windows_dll_setup_code() -> str:
                     p for p in _geoai_os.environ.get("PATH", "").split(_geoai_os.pathsep)
                     if p
                 ]
+                _geoai_dll_handles = []
                 for _geoai_dll_dir in _geoai_dll_dirs:
                     if not _geoai_os.path.isdir(_geoai_dll_dir):
                         continue
                     if hasattr(_geoai_os, "add_dll_directory"):
                         try:
-                            _geoai_os.add_dll_directory(_geoai_dll_dir)
+                            _geoai_dll_handles.append(
+                                _geoai_os.add_dll_directory(_geoai_dll_dir)
+                            )
                         except OSError:
                             pass
                     if _geoai_dll_dir not in _geoai_path_parts:
                         _geoai_path_parts.insert(0, _geoai_dll_dir)
                 _geoai_os.environ["PATH"] = _geoai_os.pathsep.join(_geoai_path_parts)
+                _geoai_sys._geoai_dll_handles = _geoai_dll_handles
         """).strip()
 
 

--- a/qgis_plugin/geoai/workers/samgeo_worker.py
+++ b/qgis_plugin/geoai/workers/samgeo_worker.py
@@ -24,6 +24,45 @@ _STATE = {
 }
 
 
+def _bootstrap_windows_torch_dll_dirs() -> None:
+    """Register venv PyTorch DLL directories before importing SamGeo on Windows."""
+    if sys.platform != "win32":
+        return
+
+    try:
+        import sysconfig
+
+        site_packages = sysconfig.get_paths().get(
+            "platlib"
+        ) or sysconfig.get_paths().get("purelib")
+    except Exception:
+        site_packages = None
+
+    if not site_packages:
+        return
+
+    dll_dirs = [
+        os.path.join(site_packages, "torch", "lib"),
+        os.path.join(site_packages, "torch", "bin"),
+        os.path.join(site_packages, "torchvision"),
+    ]
+    path_parts = [p for p in os.environ.get("PATH", "").split(os.pathsep) if p]
+    for dll_dir in dll_dirs:
+        if not os.path.isdir(dll_dir):
+            continue
+        if hasattr(os, "add_dll_directory"):
+            try:
+                os.add_dll_directory(dll_dir)
+            except OSError:
+                pass
+        if dll_dir not in path_parts:
+            path_parts.insert(0, dll_dir)
+    os.environ["PATH"] = os.pathsep.join(path_parts)
+
+
+_bootstrap_windows_torch_dll_dirs()
+
+
 def _send_ok(result: Any = None) -> None:
     _PROTO_STDOUT.write(json.dumps({"type": "ok", "result": result}) + "\n")
     _PROTO_STDOUT.flush()

--- a/qgis_plugin/geoai/workers/samgeo_worker.py
+++ b/qgis_plugin/geoai/workers/samgeo_worker.py
@@ -47,12 +47,13 @@ def _bootstrap_windows_torch_dll_dirs() -> None:
         os.path.join(site_packages, "torchvision"),
     ]
     path_parts = [p for p in os.environ.get("PATH", "").split(os.pathsep) if p]
+    _dll_handles: list = []
     for dll_dir in dll_dirs:
         if not os.path.isdir(dll_dir):
             continue
         if hasattr(os, "add_dll_directory"):
             try:
-                os.add_dll_directory(dll_dir)
+                _dll_handles.append(os.add_dll_directory(dll_dir))
             except OSError:
                 pass
         if dll_dir not in path_parts:

--- a/qgis_plugin/tests/test_diagnostics.py
+++ b/qgis_plugin/tests/test_diagnostics.py
@@ -226,3 +226,22 @@ def test_diagnostics_report_handles_missing_venv(monkeypatch):
 
     assert "- Virtual environment exists: `No`" in report
     assert "- Error: `Virtual environment does not exist.`" in report
+
+
+def test_diagnostics_import_probes_bootstrap_windows_torch_dll_dirs():
+    script = diagnostics._package_import_probe_script("samgeo")
+
+    compile(script, "<geoai_package_probe>", "exec")
+
+    assert "add_dll_directory" in script
+    assert 'module_name = "samgeo"' in script
+    assert "importlib.import_module(module_name)" in script
+
+
+def test_diagnostics_torch_runtime_probe_bootstraps_windows_torch_dll_dirs():
+    script = diagnostics._torch_runtime_probe_script()
+
+    compile(script, "<geoai_torch_probe>", "exec")
+
+    assert "add_dll_directory" in script
+    assert "import torch" in script

--- a/qgis_plugin/tests/test_venv_manager.py
+++ b/qgis_plugin/tests/test_venv_manager.py
@@ -177,3 +177,27 @@ def test_uv_insecure_host_retry_skips_non_ssl_errors(monkeypatch):
 
     assert result is original
     assert calls == []
+
+
+def test_windows_dll_setup_code_compiles_and_registers_torch_dirs():
+    code = venv_manager._get_windows_dll_setup_code()
+
+    compile(code, "<geoai_windows_dll_setup>", "exec")
+
+    assert "add_dll_directory" in code
+    assert '"torch", "lib"' in code
+    assert '"torchvision"' in code
+
+
+def test_segment_geospatial_verification_bootstraps_torch_before_samgeo():
+    code = venv_manager._get_verification_code("segment-geospatial")
+
+    assert "add_dll_directory" in code
+    assert "import torch; import samgeo" in code
+
+
+def test_omniwatermask_verification_bootstraps_torch_before_import():
+    code = venv_manager._get_verification_code("omniwatermask")
+
+    assert "add_dll_directory" in code
+    assert "import torch; import omniwatermask" in code


### PR DESCRIPTION
Fixes #792

Summary:
- Register the managed venv torch DLL directories in Windows subprocess probes before importing torch-backed packages.
- Pre-import torch when verifying SamGeo, SAM3, DeepForest, and OmniWaterMask so indirect c10.dll loading succeeds.
- Add the same DLL bootstrap to the SamGeo worker subprocess.
- Cover the verification and diagnostics probe generation with tests.

Tests:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest qgis_plugin/tests
- pre-commit run --all-files