### PR TITLE
Fix macOS QGIS SAM3 verification

### DIFF
--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -2448,21 +2448,46 @@ def _is_torch_related_verify_failure(message: str) -> bool:
     return any(marker in msg for marker in torch_markers)
 
 
-def _is_optional_verify_package(package_name: str) -> bool:
+def _is_optional_verify_package(
+    package_name: str, platform_name: Optional[str] = None
+) -> bool:
     """Return True if verification failure for this package can be non-fatal.
 
     Some packages are installed as optional feature backends and may fail to
     import on specific platforms due to upstream native dependency issues
     without breaking the core plugin functionality.
+
+    Args:
+        package_name: Distribution name to check.
+        platform_name: Target platform name. Defaults to the current platform.
+
+    Returns:
+        True if verification failure for the package should be non-fatal.
     """
-    if sys.platform == "win32" and package_name in ("sam3", "triton-windows"):
+    target_platform = platform_name or sys.platform
+    if target_platform == "win32" and package_name in ("sam3", "triton-windows"):
+        return True
+    if target_platform == "darwin" and package_name == "sam3":
         return True
     return False
 
 
-def _is_optional_install_package(package_name: str) -> bool:
-    """Return True if install failure for this package can be non-fatal."""
-    if sys.platform == "win32" and package_name == "triton-windows":
+def _is_optional_install_package(
+    package_name: str, platform_name: Optional[str] = None
+) -> bool:
+    """Return True if install failure for this package can be non-fatal.
+
+    Args:
+        package_name: Distribution name to check.
+        platform_name: Target platform name. Defaults to the current platform.
+
+    Returns:
+        True if installation failure for the package should be non-fatal.
+    """
+    target_platform = platform_name or sys.platform
+    if target_platform == "win32" and package_name == "triton-windows":
+        return True
+    if target_platform == "darwin" and package_name == "sam3":
         return True
     return False
 

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -62,6 +62,7 @@ changelog=
     1.4.4
         - Improve built-in dependency installer SSL fallback for PyPI, PyTorch, and uv certificate errors (#786)
         - Improve Windows/Python 3.12 dependency resolution diagnostics for the QGIS managed environment
+        - Allow macOS QGIS dependency verification to continue when optional SAM3 import fails (#797)
     1.4.3
         - Bump patch release for GeoAI package and QGIS plugin
     1.4.2

--- a/qgis_plugin/tests/test_dependency_resolver.py
+++ b/qgis_plugin/tests/test_dependency_resolver.py
@@ -11,6 +11,16 @@ def test_windows_dependency_specs_include_python_312_and_triton():
     assert "transformers>=4.56.2" in specs
 
 
+def test_macos_sam3_is_optional_without_triton_windows():
+    specs = venv_manager.get_qgis_dependency_specs(platform_name="darwin")
+
+    assert "python==3.12.*" in specs
+    assert "sam3" in specs
+    assert "triton-windows" not in specs
+    assert venv_manager._is_optional_verify_package("sam3", "darwin") is True
+    assert venv_manager._is_optional_install_package("sam3", "darwin") is True
+
+
 def test_resolution_failure_diagnostic_identifies_impossible_constraint():
     output = """
     Because transformers==4.57.6 has no wheels with a matching Python requirement

--- a/qgis_plugin/tests/test_venv_manager.py
+++ b/qgis_plugin/tests/test_venv_manager.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from geoai.core import venv_manager
 
 
@@ -201,3 +203,44 @@ def test_omniwatermask_verification_bootstraps_torch_before_import():
 
     assert "add_dll_directory" in code
     assert "import torch; import omniwatermask" in code
+
+
+def test_verify_venv_treats_macos_sam3_import_failure_as_optional(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        package_name = cmd[-1]
+        calls.append(package_name)
+        if package_name == "sam3":
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                stdout="",
+                stderr="ModuleNotFoundError: No module named 'triton'",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(venv_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager, "get_venv_python_path", lambda _venv_dir: "python"
+    )
+    monkeypatch.setattr(venv_manager, "_get_clean_env_for_venv", lambda: {})
+    monkeypatch.setattr(venv_manager, "_get_subprocess_kwargs", lambda: {})
+    monkeypatch.setattr(
+        venv_manager,
+        "_get_required_packages",
+        lambda: [("torch", ""), ("sam3", ""), ("geoai-py", "")],
+    )
+    monkeypatch.setattr(
+        venv_manager,
+        "_get_verification_code",
+        lambda package_name: package_name,
+    )
+    monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
+
+    ready, message = venv_manager.verify_venv("/tmp/geoai-test-venv")
+
+    assert ready is True
+    assert message == "Virtual environment ready (optional packages unavailable: sam3)"
+    assert calls == ["torch", "sam3", "geoai-py"]


### PR DESCRIPTION
## Summary
- Treat SAM3 install and verification failures as optional on macOS so QGIS dependency setup can complete when triton is unavailable.
- Keep triton-windows handling scoped to Windows and add tests for the macOS optional path.
- Add the fix to the QGIS plugin changelog.

Closes #797

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest qgis_plugin/tests
- pre-commit run --all-files