### PR TITLE
Stream DINOv3 GeoTIFF segmentation output

### DIFF
--- a/geoai/dinov3_finetune.py
+++ b/geoai/dinov3_finetune.py
@@ -987,7 +987,7 @@ def dinov3_segment_geotiff(
             """Run inference on a batch and write each output window."""
             tensor = torch.from_numpy(np.stack(batch_imgs)).to(dev)
             logits = model_module(tensor)
-            probs = torch.softmax(logits, dim=1).cpu().numpy()
+            preds = torch.argmax(logits, dim=1).cpu().numpy().astype(np.uint8)
 
             for k, (rs, _re, cs, _ce, wrs, wre, wcs, wce, h, w) in enumerate(
                 batch_meta
@@ -996,7 +996,7 @@ def dinov3_segment_geotiff(
                 local_re = local_rs + (wre - wrs)
                 local_cs = wcs - cs
                 local_ce = local_cs + (wce - wcs)
-                pred = np.argmax(probs[k, :, :h, :w], axis=0).astype(np.uint8)
+                pred = preds[k, :h, :w]
                 pred = pred[local_rs:local_re, local_cs:local_ce]
                 out_window = Window(wcs, wrs, wce - wcs, wre - wrs)
                 dst.write(pred, 1, window=out_window)

--- a/geoai/dinov3_finetune.py
+++ b/geoai/dinov3_finetune.py
@@ -928,14 +928,35 @@ def dinov3_segment_geotiff(
                 "Processing %d x %d = %d windows", n_rows, n_cols, n_rows * n_cols
             )
 
-        # Accumulate per-class votes for overlapping windows.
-        votes = np.zeros((num_classes, height, width), dtype=np.float32)
-        count = np.zeros((height, width), dtype=np.float32)
-
         # Precompute the padded tensor size so every window in a batch
         # has the same spatial dimensions.
         padded_h = window_size + (patch_size - window_size % patch_size) % patch_size
         padded_w = padded_h  # square
+
+        row_starts = [min(i * stride, height - 1) for i in range(n_rows)]
+        col_starts = [min(j * stride, width - 1) for j in range(n_cols)]
+
+        def _write_boundaries(starts: List[int], size: int) -> List[int]:
+            """Return output boundaries for non-overlapping window interiors.
+
+            Args:
+                starts: Window start offsets along one raster dimension.
+                size: Full size of the raster dimension.
+
+            Returns:
+                Monotonic boundaries with one more element than ``starts``.
+            """
+            boundaries = [0]
+            for idx in range(len(starts) - 1):
+                left_end = min(starts[idx] + window_size, size)
+                right_start = starts[idx + 1]
+                overlap_size = max(0, left_end - right_start)
+                boundaries.append(right_start + overlap_size // 2)
+            boundaries.append(size)
+            return boundaries
+
+        row_boundaries = _write_boundaries(row_starts, height)
+        col_boundaries = _write_boundaries(col_starts, width)
 
         def _prepare_window(img: np.ndarray) -> Tuple[np.ndarray, int, int]:
             """Normalise, channel-select, and pad a raw window."""
@@ -960,64 +981,83 @@ def dinov3_segment_geotiff(
 
         def _flush_batch(
             batch_imgs: List[np.ndarray],
-            batch_meta: List[Tuple[int, int, int, int, int, int]],
+            batch_meta: List[Tuple[int, int, int, int, int, int, int, int, int, int]],
+            dst: Any,
         ) -> None:
-            """Run inference on a collected batch and accumulate votes."""
+            """Run inference on a batch and write each output window."""
             tensor = torch.from_numpy(np.stack(batch_imgs)).to(dev)
             logits = model_module(tensor)
             probs = torch.softmax(logits, dim=1).cpu().numpy()
 
-            for k, (rs, re, cs, ce, h, w) in enumerate(batch_meta):
-                votes[:, rs:re, cs:ce] += probs[k, :, :h, :w]
-                count[rs:re, cs:ce] += 1.0
+            for k, (rs, _re, cs, _ce, wrs, wre, wcs, wce, h, w) in enumerate(
+                batch_meta
+            ):
+                local_rs = wrs - rs
+                local_re = local_rs + (wre - wrs)
+                local_cs = wcs - cs
+                local_ce = local_cs + (wce - wcs)
+                pred = np.argmax(probs[k, :, :h, :w], axis=0).astype(np.uint8)
+                pred = pred[local_rs:local_re, local_cs:local_ce]
+                out_window = Window(wcs, wrs, wce - wcs, wre - wrs)
+                dst.write(pred, 1, window=out_window)
 
+        meta.update({"count": 1, "dtype": "uint8", "compress": "lzw"})
         with torch.no_grad():
             batch_imgs: List[np.ndarray] = []
-            batch_meta: List[Tuple[int, int, int, int, int, int]] = []
+            batch_meta: List[
+                Tuple[int, int, int, int, int, int, int, int, int, int]
+            ] = []
 
             total_windows = n_rows * n_cols
             pbar = tqdm(total=total_windows, disable=quiet, desc="Windows")
 
-            for i in range(n_rows):
-                for j in range(n_cols):
-                    row_start = i * stride
-                    col_start = j * stride
-                    row_end = min(row_start + window_size, height)
-                    col_end = min(col_start + window_size, width)
+            with rasterio.open(output_path, "w", **meta) as dst:
+                for i, row_start in enumerate(row_starts):
+                    for j, col_start in enumerate(col_starts):
+                        row_end = min(row_start + window_size, height)
+                        col_end = min(col_start + window_size, width)
+                        write_row_start = row_boundaries[i]
+                        write_row_end = row_boundaries[i + 1]
+                        write_col_start = col_boundaries[j]
+                        write_col_end = col_boundaries[j + 1]
 
-                    win = Window(
-                        col_start,
-                        row_start,
-                        col_end - col_start,
-                        row_end - row_start,
-                    )
-                    raw = src.read(window=win).astype(np.float32)
-                    img, h, w = _prepare_window(raw)
+                        win = Window(
+                            col_start,
+                            row_start,
+                            col_end - col_start,
+                            row_end - row_start,
+                        )
+                        raw = src.read(window=win).astype(np.float32)
+                        img, h, w = _prepare_window(raw)
 
-                    batch_imgs.append(img)
-                    batch_meta.append((row_start, row_end, col_start, col_end, h, w))
+                        batch_imgs.append(img)
+                        batch_meta.append(
+                            (
+                                row_start,
+                                row_end,
+                                col_start,
+                                col_end,
+                                write_row_start,
+                                write_row_end,
+                                write_col_start,
+                                write_col_end,
+                                h,
+                                w,
+                            )
+                        )
 
-                    if len(batch_imgs) == batch_size:
-                        _flush_batch(batch_imgs, batch_meta)
-                        pbar.update(len(batch_imgs))
-                        batch_imgs.clear()
-                        batch_meta.clear()
+                        if len(batch_imgs) == batch_size:
+                            _flush_batch(batch_imgs, batch_meta, dst)
+                            pbar.update(len(batch_imgs))
+                            batch_imgs.clear()
+                            batch_meta.clear()
 
-            # Flush remaining windows.
-            if batch_imgs:
-                _flush_batch(batch_imgs, batch_meta)
-                pbar.update(len(batch_imgs))
+                # Flush remaining windows.
+                if batch_imgs:
+                    _flush_batch(batch_imgs, batch_meta, dst)
+                    pbar.update(len(batch_imgs))
 
             pbar.close()
-
-        # Majority vote (avoid division by zero).
-        count = np.maximum(count, 1.0)
-        votes /= count[np.newaxis, :, :]
-        output = np.argmax(votes, axis=0).astype(np.uint8)
-
-    meta.update({"count": 1, "dtype": "uint8", "compress": "lzw"})
-    with rasterio.open(output_path, "w", **meta) as dst:
-        dst.write(output, 1)
 
     if not quiet:
         logger.info("Segmentation saved to %s", output_path)

--- a/tests/test_dinov3_finetune.py
+++ b/tests/test_dinov3_finetune.py
@@ -754,6 +754,121 @@ class TestSegmentGeotiffFunction(unittest.TestCase):
                 overlap=512,
             )
 
+    def test_streams_window_outputs_without_full_raster_buffers(self):
+        """dinov3_segment_geotiff should write windows without full buffers."""
+        try:
+            from rasterio.windows import Window
+        except ImportError:
+            self.skipTest("rasterio not installed")
+
+        import geoai.dinov3_finetune as dinov3_finetune
+
+        image = np.ones((3, 6, 6), dtype=np.uint8) * 255
+        output = np.full((6, 6), 255, dtype=np.uint8)
+        original_zeros = np.zeros
+        test_case = self
+
+        class ConstantSegmenter(nn.Module):
+            """Dummy segmenter that predicts class 1 everywhere."""
+
+            patch_size = 2
+
+            def forward(self, tensor):
+                """Return constant two-class logits matching the input size."""
+                batch, _, height, width = tensor.shape
+                logits = torch.zeros((batch, 2, height, width), device=tensor.device)
+                logits[:, 1] = 1.0
+                return logits
+
+        class FakeSrc:
+            """Minimal raster source for windowed reads."""
+
+            count = 3
+            shape = (6, 6)
+            meta = {
+                "driver": "GTiff",
+                "height": 6,
+                "width": 6,
+                "count": 3,
+                "dtype": "uint8",
+            }
+
+            def __enter__(self):
+                """Return the fake source context."""
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                """Exit the fake source context."""
+                return False
+
+            def read(self, window):
+                """Read a CHW slice for the requested raster window."""
+                row_start = int(window.row_off)
+                col_start = int(window.col_off)
+                row_end = row_start + int(window.height)
+                col_end = col_start + int(window.width)
+                return image[:, row_start:row_end, col_start:col_end]
+
+        class FakeDst:
+            """Minimal raster destination for windowed writes."""
+
+            def __enter__(self):
+                """Return the fake destination context."""
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                """Exit the fake destination context."""
+                return False
+
+            def write(self, data, indexes, window):
+                """Write a 2D array into the requested output window."""
+                test_case.assertEqual(indexes, 1)
+                test_case.assertNotEqual(data.shape, output.shape)
+                test_case.assertIsInstance(window, Window)
+                row_start = int(window.row_off)
+                col_start = int(window.col_off)
+                row_end = row_start + int(window.height)
+                col_end = col_start + int(window.width)
+                output[row_start:row_end, col_start:col_end] = data
+
+        def fake_open(path, mode="r", **kwargs):
+            """Return a fake raster source or destination."""
+            if mode == "w":
+                self.assertEqual(kwargs["count"], 1)
+                self.assertEqual(kwargs["dtype"], "uint8")
+                return FakeDst()
+            return FakeSrc()
+
+        def guarded_zeros(shape, *args, **kwargs):
+            """Fail on full-raster accumulator allocations."""
+            shape_tuple = tuple(shape) if isinstance(shape, tuple) else (shape,)
+            forbidden_shapes = {(2, 6, 6), (6, 6)}
+            if shape_tuple in forbidden_shapes:
+                raise AssertionError(f"full-raster allocation attempted: {shape_tuple}")
+            return original_zeros(shape, *args, **kwargs)
+
+        with (
+            patch.object(
+                dinov3_finetune.DINOv3Segmenter,
+                "load_from_checkpoint",
+                return_value=ConstantSegmenter(),
+            ),
+            patch("rasterio.open", side_effect=fake_open),
+            patch("geoai.dinov3_finetune.np.zeros", side_effect=guarded_zeros),
+        ):
+            dinov3_finetune.dinov3_segment_geotiff(
+                input_path="input.tif",
+                output_path="output.tif",
+                checkpoint_path="model.ckpt",
+                window_size=4,
+                overlap=2,
+                batch_size=2,
+                device="cpu",
+                quiet=True,
+            )
+
+        np.testing.assert_array_equal(output, np.ones((6, 6), dtype=np.uint8))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dinov3_finetune.py
+++ b/tests/test_dinov3_finetune.py
@@ -847,6 +847,10 @@ class TestSegmentGeotiffFunction(unittest.TestCase):
                 raise AssertionError(f"full-raster allocation attempted: {shape_tuple}")
             return original_zeros(shape, *args, **kwargs)
 
+        def fail_softmax(*args, **kwargs):
+            """Fail if streaming inference materializes class probabilities."""
+            raise AssertionError("streaming inference should use logits argmax")
+
         with (
             patch.object(
                 dinov3_finetune.DINOv3Segmenter,
@@ -855,6 +859,7 @@ class TestSegmentGeotiffFunction(unittest.TestCase):
             ),
             patch("rasterio.open", side_effect=fake_open),
             patch("geoai.dinov3_finetune.np.zeros", side_effect=guarded_zeros),
+            patch("geoai.dinov3_finetune.torch.softmax", side_effect=fail_softmax),
         ):
             dinov3_finetune.dinov3_segment_geotiff(
                 input_path="input.tif",


### PR DESCRIPTION
## Summary
- Stream DINOv3 GeoTIFF segmentation predictions directly to the output raster by writing non-overlap window interiors.
- Remove full-raster vote, count, and output buffers that caused MemoryError on large rasters.
- Add a regression test that fails if full-raster accumulator allocations return.

Fixes #798

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_dinov3_finetune.py -q
- pre-commit run --all-files