### PR TITLE
Fix Mask R-CNN training worker default

### DIFF
--- a/geoai/train.py
+++ b/geoai/train.py
@@ -1521,8 +1521,10 @@ def train_MaskRCNN_model(
             will try to load optimizer and scheduler states as well. Defaults to False.
         print_freq (int): Frequency of printing training progress. Defaults to 10.
         device (torch.device): Device to train on. If None, uses CUDA if available.
-        num_workers (int): Number of workers for data loading. If None, uses 0 on
-            macOS and Windows, 8 otherwise.
+        num_workers (int): Number of workers for data loading. If None, uses 0.
+            GeoTIFF loading through rasterio/GDAL can hang when forked by
+            DataLoader workers, especially in notebooks. Pass a positive value
+            explicitly when multiprocessing is known to be stable.
         verbose (bool): If True, prints detailed training progress. Defaults to True.
         model_name (str): Name of the model architecture. Defaults to
             "maskrcnn_resnet50_fpn".
@@ -1741,12 +1743,10 @@ def train_MaskRCNN_model(
             multiclass=multiclass,
         )
 
-    # Create data loaders
-    # Use num_workers=0 on macOS and Windows to avoid multiprocessing issues
-    # Windows often has issues with multiprocessing in Jupyter notebooks
-    # Increase num_workers for better data loading performance
+    # Use a conservative default to avoid rasterio/GDAL multiprocessing hangs.
+    # Pass a positive num_workers explicitly for faster loading when stable.
     if num_workers is None:
-        num_workers = 0 if platform.system() in ["Darwin", "Windows"] else 8
+        num_workers = 0
 
     train_loader = DataLoader(
         train_dataset,
@@ -5756,6 +5756,7 @@ def train_instance_segmentation_model(
     val_split: float = 0.2,
     visualize: bool = False,
     device: Optional[torch.device] = None,
+    num_workers: Optional[int] = None,
     verbose: bool = True,
     instance_labels: bool = False,
     multiclass: bool = False,
@@ -5787,6 +5788,10 @@ def train_instance_segmentation_model(
         val_split (float): Fraction of data to use for validation (0-1). Defaults to 0.2.
         visualize (bool): Whether to generate visualizations. Defaults to False.
         device (torch.device): Device to train on. If None, uses CUDA if available.
+        num_workers (int): Number of workers for data loading. If None, uses 0.
+            GeoTIFF loading through rasterio/GDAL can hang when forked by
+            DataLoader workers, especially in notebooks. Pass a positive value
+            explicitly when multiprocessing is known to be stable.
         verbose (bool): If True, prints detailed training progress. Defaults to True.
         instance_labels (bool): If True, treat label mask pixel values as
             pre-assigned instance IDs instead of running connected-component
@@ -5824,6 +5829,7 @@ def train_instance_segmentation_model(
         val_split=val_split,
         visualize=visualize,
         device=device,
+        num_workers=num_workers,
         verbose=verbose,
         instance_labels=instance_labels,
         multiclass=multiclass,

--- a/tests/test_instance_segmentation.py
+++ b/tests/test_instance_segmentation.py
@@ -342,6 +342,113 @@ class TestInferenceReturnStructure:
 
 
 # ---------------------------------------------------------------------------
+# train_MaskRCNN_model: DataLoader worker defaults
+# ---------------------------------------------------------------------------
+
+
+class TestMaskRCNNTrainingWorkers:
+    """Ensure Mask R-CNN training uses safe DataLoader worker defaults."""
+
+    def _make_training_dirs(self, tmp_path):
+        """Create matching image and label directories for training setup."""
+        rasterio = pytest.importorskip("rasterio")
+
+        images_dir = tmp_path / "images"
+        labels_dir = tmp_path / "labels"
+        images_dir.mkdir()
+        labels_dir.mkdir()
+
+        image = np.zeros((3, 16, 16), dtype=np.uint8)
+        label = np.zeros((16, 16), dtype=np.uint8)
+
+        for idx in range(2):
+            filename = f"chip_{idx}.tif"
+            with rasterio.open(
+                images_dir / filename,
+                "w",
+                driver="GTiff",
+                height=image.shape[1],
+                width=image.shape[2],
+                count=image.shape[0],
+                dtype=image.dtype,
+            ) as dst:
+                dst.write(image)
+            with rasterio.open(
+                labels_dir / filename,
+                "w",
+                driver="GTiff",
+                height=label.shape[0],
+                width=label.shape[1],
+                count=1,
+                dtype=label.dtype,
+            ) as dst:
+                dst.write(label, 1)
+
+        return images_dir, labels_dir
+
+    def _run_training_with_captured_workers(self, monkeypatch, tmp_path, **kwargs):
+        """Run a mocked training pass and return DataLoader worker counts."""
+        import torch
+
+        import geoai.train as train_module
+
+        captured_workers = []
+
+        class FakeDataLoader:
+            """Capture DataLoader construction without iterating over data."""
+
+            def __init__(self, dataset, **loader_kwargs):
+                self.dataset = dataset
+                captured_workers.append(loader_kwargs["num_workers"])
+
+            def __len__(self):
+                return 1
+
+        monkeypatch.setattr(train_module, "DataLoader", FakeDataLoader)
+        monkeypatch.setattr(
+            train_module,
+            "train_one_epoch",
+            lambda *args, **kwargs: 0.1,
+        )
+        monkeypatch.setattr(
+            train_module,
+            "evaluate",
+            lambda *args, **kwargs: {"loss": 0.2, "IoU": 0.5},
+        )
+
+        images_dir, labels_dir = self._make_training_dirs(tmp_path)
+
+        train_module.train_MaskRCNN_model(
+            images_dir=str(images_dir),
+            labels_dir=str(labels_dir),
+            output_dir=str(tmp_path / "output"),
+            model=torch.nn.Linear(1, 1),
+            batch_size=1,
+            num_epochs=1,
+            pretrained=False,
+            device=torch.device("cpu"),
+            verbose=False,
+            **kwargs,
+        )
+
+        return captured_workers
+
+    def test_default_num_workers_is_zero(self, monkeypatch, tmp_path):
+        """Default DataLoader workers avoid rasterio multiprocessing hangs."""
+        workers = self._run_training_with_captured_workers(monkeypatch, tmp_path)
+
+        assert workers == [0, 0]
+
+    def test_explicit_num_workers_is_preserved(self, monkeypatch, tmp_path):
+        """An explicit worker count is passed through to both DataLoaders."""
+        workers = self._run_training_with_captured_workers(
+            monkeypatch, tmp_path, num_workers=2
+        )
+
+        assert workers == [2, 2]
+
+
+# ---------------------------------------------------------------------------
 # Multiclass ObjectDetectionDataset
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- default Mask R-CNN training DataLoader workers to 0 to avoid rasterio/GDAL multiprocessing hangs at the first batch
- expose num_workers directly on train_instance_segmentation_model while preserving explicit overrides
- add regression coverage for the default and override behavior

## Context

Addresses discussion #793, where Mask R-CNN instance segmentation training could appear to freeze at startup.

## Validation

- pytest tests/test_instance_segmentation.py -q
- pre-commit run --all-files
