### PR TITLE
Bump minor versions

### DIFF
--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -584,7 +584,7 @@ The QGIS plugin supports any models supported by [Pytorch Segmentation Models](h
 
 - If you report a plugin issue on GitHub, include the Markdown from `GeoAI` menu → `Generate Diagnostics Report...`.
 - Dependency installer shows `Failed to install geoai-py: SSL certificate error`:
-  - Update the GeoAI plugin to v1.4.4 or newer.
+  - Update the GeoAI plugin to v1.5.0 or newer.
   - Click **Reinstall Dependencies**, and restart QGIS.
   - Recent plugin versions retry package installs with native TLS plus trusted package hosts for PyPI, PyTorch, and uv certificate errors.
   - If the error persists on a managed network, confirm that QGIS can access `pypi.org`, `files.pythonhosted.org`, and `download.pytorch.org`.

--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -8,7 +8,7 @@ only when a specific symbol is first accessed.
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.39.4"
+__version__ = "0.40.0"
 
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geoai-py"
-version = "0.39.4"
+version = "0.40.0"
 dynamic = [
     "dependencies",
 ]
@@ -58,7 +58,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.39.4"
+current_version = "0.40.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.4.4
+version=1.5.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -59,6 +59,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.5.0
+        - Bump minor release for GeoAI package and QGIS plugin
     1.4.4
         - Improve built-in dependency installer SSL fallback for PyPI, PyTorch, and uv certificate errors (#786)
         - Improve Windows/Python 3.12 dependency resolution diagnostics for the QGIS managed environment


### PR DESCRIPTION
## Summary

- bump geoai-py from 0.39.4 to 0.40.0
- bump QGIS plugin from 1.4.4 to 1.5.0
- update plugin changelog and QGIS plugin docs version reference

## Validation

- python -c "import geoai; print(geoai.__version__)"
- parsed qgis_plugin/geoai/metadata.txt version
- pre-commit run --all-files
