### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/geoai/agents/geo_agents.py
+++ b/geoai/agents/geo_agents.py
@@ -241,19 +241,20 @@ def create_gemini_model(
 
 
 def create_minimax_model(
-    model_id: str = "MiniMax-M2.7",
+    model_id: str = "MiniMax-M3",
     api_key: str = None,
     client_args: dict = None,
     **kwargs: Any,
 ) -> OpenAIModel:
     """Create a MiniMax model via OpenAI-compatible API.
 
-    MiniMax provides large language models including MiniMax-M2.7 and
-    MiniMax-M2.5-highspeed, accessible through an OpenAI-compatible
-    chat completions endpoint at https://api.minimax.io/v1.
+    MiniMax provides large language models including MiniMax-M3 (the latest
+    flagship model with 512K context window) and MiniMax-M2.7, accessible
+    through an OpenAI-compatible chat completions endpoint at
+    https://api.minimax.io/v1.
 
     Args:
-        model_id: MiniMax model ID. Defaults to "MiniMax-M2.7".
+        model_id: MiniMax model ID. Defaults to "MiniMax-M3".
             For a complete list of supported models,
             see https://platform.minimaxi.com/document/models.
         api_key: MiniMax API key.
@@ -319,7 +320,7 @@ class GeoAgent(Agent):
                 host="http://localhost:11434", model_id=m, **model_args
             )
         elif isinstance(model, str) and model.lower().startswith("minimax"):
-            # MiniMax models (e.g., "MiniMax-M2.7", "MiniMax-M2.5-highspeed")
+            # MiniMax models (e.g., "MiniMax-M3", "MiniMax-M2.7")
             self._model_factory = lambda m=model: create_minimax_model(
                 model_id=m, **model_args
             )
@@ -747,7 +748,7 @@ class STACAgent(Agent):
                 host="http://localhost:11434", model_id=m, **model_args
             )
         elif isinstance(model, str) and model.lower().startswith("minimax"):
-            # MiniMax models (e.g., "MiniMax-M2.7", "MiniMax-M2.5-highspeed")
+            # MiniMax models (e.g., "MiniMax-M3", "MiniMax-M2.7")
             self._model_factory = lambda m=model: create_minimax_model(
                 model_id=m, **model_args
             )
@@ -1393,7 +1394,7 @@ class CatalogAgent(Agent):
                 host="http://localhost:11434", model_id=m, **model_args
             )
         elif isinstance(model, str) and model.lower().startswith("minimax"):
-            # MiniMax models (e.g., "MiniMax-M2.7", "MiniMax-M2.5-highspeed")
+            # MiniMax models (e.g., "MiniMax-M3", "MiniMax-M2.7")
             self._model_factory = lambda m=model: create_minimax_model(
                 model_id=m, **model_args
             )

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -79,9 +79,9 @@ class TestCreateMinimaxModelExists(unittest.TestCase):
         else:
             self.fail("create_minimax_model function not found")
 
-    def test_default_model_id_is_m27(self):
-        """Test that default model_id is MiniMax-M2.7."""
-        self.assertIn('model_id: str = "MiniMax-M2.7"', self.source)
+    def test_default_model_id_is_m3(self):
+        """Test that default model_id is MiniMax-M3."""
+        self.assertIn('model_id: str = "MiniMax-M3"', self.source)
 
     def test_uses_minimax_base_url(self):
         """Test that create_minimax_model sets MiniMax API base URL."""
@@ -145,10 +145,10 @@ class TestMinimaxStringRouting(unittest.TestCase):
     def test_minimax_string_detection_logic(self):
         """Test that MiniMax string detection correctly identifies MiniMax models."""
         minimax_models = [
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
+            "minimax-m3",
             "minimax-m2.7",
         ]
         for model_str in minimax_models:
@@ -214,6 +214,7 @@ class TestMinimaxDocstring(unittest.TestCase):
                 and node.name == "create_minimax_model"
             ):
                 docstring = ast.get_docstring(node)
+                self.assertIn("MiniMax-M3", docstring)
                 self.assertIn("MiniMax-M2.7", docstring)
                 break
 
@@ -302,20 +303,20 @@ class TestMinimaxModelIntegration(unittest.TestCase):
             from geoai.agents.geo_agents import create_minimax_model
             from strands.models.openai import OpenAIModel
 
-            model = create_minimax_model(model_id="MiniMax-M2.7")
+            model = create_minimax_model(model_id="MiniMax-M3")
             self.assertIsInstance(model, OpenAIModel)
-            self.assertEqual(model.config["model_id"], "MiniMax-M2.7")
+            self.assertEqual(model.config["model_id"], "MiniMax-M3")
         except ImportError:
             self.skipTest("strands-agents or geoai dependencies not installed")
 
     @unittest.skipUnless(os.environ.get("MINIMAX_API_KEY"), "MINIMAX_API_KEY not set")
-    def test_create_minimax_m25_highspeed_live(self):
-        """Integration test: create MiniMax M2.5-highspeed model."""
+    def test_create_minimax_m27_live(self):
+        """Integration test: create MiniMax M2.7 model."""
         try:
             from geoai.agents.geo_agents import create_minimax_model
 
-            model = create_minimax_model(model_id="MiniMax-M2.5-highspeed")
-            self.assertEqual(model.config["model_id"], "MiniMax-M2.5-highspeed")
+            model = create_minimax_model(model_id="MiniMax-M2.7")
+            self.assertEqual(model.config["model_id"], "MiniMax-M2.7")
         except ImportError:
             self.skipTest("strands-agents or geoai dependencies not installed")
 


### PR DESCRIPTION
## Summary
Upgrade the MiniMax model configuration in `geoai.agents` to use the latest M3 model as default.

## Changes
- Update `create_minimax_model` default `model_id` from `MiniMax-M2.7` to `MiniMax-M3`
- Update the function docstring to highlight M3 (the latest flagship model with a 512K context window) while keeping M2.7 as a documented alternative
- Update inline example comments in `GeoAgent` / `STACAgent` / `CatalogAgent` routing branches
- Update the unit tests in `tests/test_minimax_provider.py`:
  - Rename `test_default_model_id_is_m27` → `test_default_model_id_is_m3`
  - Add an `MiniMax-M3` assertion in `test_docstring_mentions_models`
  - Refresh the string-detection sample list to use the current models (M3 / M2.7) instead of the deprecated M2.5 variants
  - Replace the live `M2.5-highspeed` integration test with the equivalent test for M2.7
- Drop references to the deprecated `MiniMax-M2.5` / `MiniMax-M2.5-highspeed`; retain `MiniMax-M2.7` as the documented alternative

## Why
`MiniMax-M3` is the new flagship MiniMax model with a 512K context window, larger maximum output, and improved tool-use / agent capabilities. Defaulting to it lets users of `GeoAgent`, `STACAgent`, and `CatalogAgent` get the best out-of-the-box experience, while users who want the previous default can still pass `model="MiniMax-M2.7"`. Older deprecated variants (`M2.5`, `M2.5-highspeed`, `M2.1`, `M2`, `M1`) are removed from the examples and tests.

## Testing
- `python -m unittest tests.test_minimax_provider -v` → 25 tests, all green (3 live integration tests skipped because `MINIMAX_API_KEY` is unset in CI)
- Verified the `MiniMax-M3` model id is accepted by `https://api.minimax.io/v1/chat/completions`
- Base URL, env-var name (`MINIMAX_API_KEY`), and the OpenAI-compatible client wiring are untouched