### PR TITLE
feat: add 'quackosm' and 'localtileserver' to optional dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ exclude = ["docs*"]
 dependencies = {file = ["requirements.txt"]}
 
 [project.optional-dependencies]
-extra = ["overturemaps", "torchange", "lightly-train", "multiclean", "omnicloudmask", "omniwatermask", "smoothify"]
+extra = ["overturemaps", "torchange", "lightly-train", "multiclean", "omnicloudmask", "omniwatermask", "quackosm", "smoothify", "localtileserver==0.11.0"]
 building = ["buildingregulariser"]
 agents = ["strands-agents", "strands-agents-tools", "strands-agents[ollama]", "strands-agents[anthropic]", "strands-agents[openai]"]
 onnx = ["onnx>=1.21.0", "onnxruntime"]


### PR DESCRIPTION
- Updated the 'extra' dependencies to include 'quackosm' and 'localtileserver==0.11.0' for enhanced functionality.