### PR TITLE
Fix train_pixel_regressor verbose logging

### DIFF
--- a/geoai/timm_regress.py
+++ b/geoai/timm_regress.py
@@ -759,14 +759,14 @@ def train_pixel_regressor(
         callbacks.append(_CompactProgressBar())
         model._prog_bar_metrics = False
 
-    logger = CSVLogger(model_dir, name="lightning_logs")
+    csv_logger = CSVLogger(model_dir, name="lightning_logs")
 
     trainer = pl.Trainer(
         max_epochs=num_epochs,
         accelerator=accelerator,
         devices=devices,
         callbacks=callbacks,
-        logger=logger,
+        logger=csv_logger,
         log_every_n_steps=10,
         enable_model_summary=verbose,
         **kwargs,

--- a/tests/test_timm_regress.py
+++ b/tests/test_timm_regress.py
@@ -225,8 +225,9 @@ class TestTrainPixelRegressor(unittest.TestCase):
 
         import tempfile
 
-        with tempfile.TemporaryDirectory() as tmpdir, patch.object(
-            timm_regress, "LIGHTNING_AVAILABLE", True
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch.object(timm_regress, "LIGHTNING_AVAILABLE", True),
         ):
             timm_regress.train_pixel_regressor(
                 train_image_paths=["train.tif"],

--- a/tests/test_timm_regress.py
+++ b/tests/test_timm_regress.py
@@ -188,6 +188,63 @@ class TestTimmRegressFunctionSignatures(unittest.TestCase):
         self.assertIn("min_valid_ratio", sig.parameters)
 
 
+class TestTrainPixelRegressor(unittest.TestCase):
+    """Tests for train_pixel_regressor behavior."""
+
+    @patch("geoai.timm_regress._infer_preprocessing_params", return_value=None)
+    @patch("geoai.timm_regress.pl.Trainer")
+    @patch("geoai.timm_regress.CSVLogger")
+    @patch("geoai.timm_regress.EarlyStopping")
+    @patch("geoai.timm_regress.ModelCheckpoint")
+    @patch("geoai.timm_regress.DataLoader")
+    @patch("geoai.timm_regress.PixelRegressionDataset")
+    @patch("geoai.timm_regress.PixelRegressionModel")
+    @patch("geoai.timm_regress.logger")
+    def test_verbose_logging_uses_module_logger(
+        self,
+        mock_logger,
+        mock_model_class,
+        mock_dataset_class,
+        mock_data_loader,
+        mock_checkpoint_class,
+        mock_early_stopping,
+        mock_csv_logger_class,
+        mock_trainer_class,
+        mock_preprocessing,
+    ):
+        """Test verbose training messages use the module logger."""
+        from geoai import timm_regress
+
+        csv_logger = object()
+        trainer = MagicMock()
+        checkpoint = MagicMock(best_model_path="")
+
+        mock_csv_logger_class.return_value = csv_logger
+        mock_trainer_class.return_value = trainer
+        mock_checkpoint_class.return_value = checkpoint
+
+        with patch.object(timm_regress, "LIGHTNING_AVAILABLE", True):
+            timm_regress.train_pixel_regressor(
+                train_image_paths=["train.tif"],
+                train_target_paths=["target.tif"],
+                output_dir="output",
+                num_epochs=1,
+                encoder_weights=None,
+                verbose=True,
+            )
+
+        mock_trainer_class.assert_called_once()
+        self.assertIs(mock_trainer_class.call_args.kwargs["logger"], csv_logger)
+        mock_logger.info.assert_any_call(
+            "Training %s with %s encoder for %d epochs...",
+            "unet",
+            "resnet50",
+            1,
+        )
+        mock_logger.info.assert_any_call("Loss function: %s", "MSE")
+        trainer.fit.assert_called_once()
+
+
 class TestEvaluateRegression(unittest.TestCase):
     """Tests for evaluate_regression function behavior."""
 

--- a/tests/test_timm_regress.py
+++ b/tests/test_timm_regress.py
@@ -223,11 +223,15 @@ class TestTrainPixelRegressor(unittest.TestCase):
         mock_trainer_class.return_value = trainer
         mock_checkpoint_class.return_value = checkpoint
 
-        with patch.object(timm_regress, "LIGHTNING_AVAILABLE", True):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(
+            timm_regress, "LIGHTNING_AVAILABLE", True
+        ):
             timm_regress.train_pixel_regressor(
                 train_image_paths=["train.tif"],
                 train_target_paths=["target.tif"],
-                output_dir="output",
+                output_dir=tmpdir,
                 num_epochs=1,
                 encoder_weights=None,
                 verbose=True,


### PR DESCRIPTION
## Summary
- Rename the Lightning CSVLogger variable to avoid shadowing the module logger.
- Add a mocked regression test for verbose=True training logs.

## Root cause
train_pixel_regressor assigned CSVLogger to logger, then called logger.info when verbose=True. CSVLogger does not expose info(), so the default verbose path crashed before training.

Closes #805.

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_timm_regress.py
- pre-commit run --all-files