### PR TITLE
Fix QGIS CUDA torch dependency install

### DIFF
--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -49,7 +49,7 @@ DEPS_HASH_FILE = os.path.join(VENV_DIR, "deps_hash.txt")
 CUDA_FLAG_FILE = os.path.join(VENV_DIR, "cuda_installed.txt")
 
 # Bump when install logic changes significantly to force re-install.
-_INSTALL_LOGIC_VERSION = "10"
+_INSTALL_LOGIC_VERSION = "11"
 
 # Bump independently for CUDA-specific install logic changes.
 _CUDA_LOGIC_VERSION = "1"
@@ -615,6 +615,8 @@ _INSECURE_PACKAGE_HOSTS = (
     "files.pythonhosted.org",
     "download.pytorch.org",
 )
+
+_TORCH_DISTRIBUTIONS = ("torch", "torchvision")
 
 
 def _is_ssl_error(stderr: str) -> bool:
@@ -2358,6 +2360,128 @@ def _reinstall_cpu_torch(
         progress_callback(98, "CPU torch installed, re-verifying...")
 
 
+def _get_installed_distribution_version(
+    python_path: str,
+    dist_name: str,
+    env: dict,
+    subprocess_kwargs: dict,
+) -> Optional[str]:
+    """Read an installed distribution version from the managed venv.
+
+    Args:
+        python_path: Path to the venv Python.
+        dist_name: Distribution name to query.
+        env: Environment dict for subprocess.
+        subprocess_kwargs: Platform-specific subprocess kwargs.
+
+    Returns:
+        Installed version string, or None if it cannot be read.
+    """
+    script = (
+        "import importlib.metadata as metadata; "
+        "print(metadata.version({!r}))".format(dist_name)
+    )
+    try:
+        result = subprocess.run(
+            [python_path, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+            **subprocess_kwargs,
+        )
+    except Exception as exc:
+        _log(
+            "Could not read installed {} version: {}".format(dist_name, exc),
+            Qgis.Warning,
+        )
+        return None
+
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout or "").strip()
+        _log(
+            "Could not read installed {} version: {}".format(
+                dist_name, output[:200] or result.returncode
+            ),
+            Qgis.Warning,
+        )
+        return None
+
+    version = result.stdout.strip()
+    return version or None
+
+
+def _get_installed_torch_constraints(
+    python_path: str,
+    env: dict,
+    subprocess_kwargs: dict,
+) -> List[str]:
+    """Build constraints that preserve installed PyTorch wheel variants.
+
+    Args:
+        python_path: Path to the venv Python.
+        env: Environment dict for subprocess.
+        subprocess_kwargs: Platform-specific subprocess kwargs.
+
+    Returns:
+        Constraint lines for installed torch distributions.
+    """
+    constraints = []
+    for dist_name in _TORCH_DISTRIBUTIONS:
+        version = _get_installed_distribution_version(
+            python_path,
+            dist_name,
+            env,
+            subprocess_kwargs,
+        )
+        if version:
+            constraints.append("{}=={}".format(dist_name, version))
+    return constraints
+
+
+def _write_constraints_file(constraints: List[str]) -> Optional[str]:
+    """Write temporary pip constraints for dependency installation.
+
+    Args:
+        constraints: Requirement constraint lines.
+
+    Returns:
+        Path to the temporary constraints file, or None when no constraints
+        were written.
+    """
+    if not constraints:
+        return None
+
+    try:
+        os.makedirs(CACHE_DIR, exist_ok=True)
+        fd, path = tempfile.mkstemp(
+            prefix="geoai_torch_constraints_",
+            suffix=".txt",
+            dir=CACHE_DIR,
+            text=True,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write("\n".join(constraints) + "\n")
+        return path
+    except Exception as exc:
+        _log(f"Failed to write torch constraints file: {exc}", Qgis.Warning)
+        return None
+
+
+def _remove_temp_file(path: Optional[str]) -> None:
+    """Remove a temporary file if it exists.
+
+    Args:
+        path: File path to remove.
+    """
+    if not path:
+        return
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
 def _verify_cuda_in_venv(venv_dir: str) -> bool:
     """Run a CUDA smoke test inside the venv.
 
@@ -2555,6 +2679,7 @@ def install_dependencies(
 
     # -- Phase A: CUDA packages (individual installs) -------------------------
     _force_cuda_reinstall = False
+    _cuda_index_for_batch = None
     if cuda_packages:
         _precheck_env = _get_clean_env_for_venv()
         _precheck_kwargs = _get_subprocess_kwargs()
@@ -2627,6 +2752,7 @@ def install_dependencies(
                 is_cuda_package = False
                 _driver_too_old = True
             else:
+                _cuda_index_for_batch = cuda_index
                 pip_args.extend(
                     [
                         "--index-url",
@@ -2971,6 +3097,30 @@ def install_dependencies(
             return False, "Installation cancelled"
 
         batch_specs = ["{}{}".format(name, ver) for name, ver in batch_packages]
+        constraint_args: List[str] = []
+        torch_index_args: List[str] = []
+        constraints_file = None
+        if cuda_enabled and not _cuda_fell_back and not _driver_too_old:
+            torch_constraints = _get_installed_torch_constraints(
+                python_path,
+                env,
+                subprocess_kwargs,
+            )
+            constraints_file = _write_constraints_file(torch_constraints)
+            if constraints_file:
+                constraint_args = ["--constraint", constraints_file]
+                if _cuda_index_for_batch:
+                    torch_index_args = [
+                        "--extra-index-url",
+                        "https://download.pytorch.org/whl/{}".format(
+                            _cuda_index_for_batch
+                        ),
+                    ]
+                _log(
+                    "Constraining batch install to existing PyTorch packages: "
+                    "{}".format(", ".join(torch_constraints)),
+                    Qgis.Info,
+                )
         _log(
             "Installing {} packages in batch: {}".format(
                 len(batch_specs), ", ".join(batch_specs)
@@ -2989,6 +3139,8 @@ def install_dependencies(
                 "--upgrade",
             ]
             pip_args.extend(_get_uv_ssl_flags())
+            pip_args.extend(torch_index_args)
+            pip_args.extend(constraint_args)
             pip_args.extend(batch_specs)
             base_cmd = [uv_path] + pip_args
         else:
@@ -3001,6 +3153,8 @@ def install_dependencies(
             ]
             pip_args.extend(_get_pip_ssl_flags())
             pip_args.extend(_get_pip_proxy_args())
+            pip_args.extend(torch_index_args)
+            pip_args.extend(constraint_args)
             pip_args.extend(batch_specs)
             base_cmd = [python_path, "-m", "pip"] + pip_args
 
@@ -3112,6 +3266,8 @@ def install_dependencies(
                                 "--upgrade",
                             ]
                             retry_args.extend(_get_uv_ssl_flags())
+                            retry_args.extend(torch_index_args)
+                            retry_args.extend(constraint_args)
                             retry_args.extend(retry_specs)
                             retry_cmd = [uv_path] + retry_args
                         else:
@@ -3124,6 +3280,8 @@ def install_dependencies(
                             ]
                             retry_args.extend(_get_pip_ssl_flags())
                             retry_args.extend(_get_pip_proxy_args())
+                            retry_args.extend(torch_index_args)
+                            retry_args.extend(constraint_args)
                             retry_args.extend(retry_specs)
                             retry_cmd = [
                                 python_path,
@@ -3229,6 +3387,8 @@ def install_dependencies(
         except Exception as e:
             _log("Exception during batch install: {}".format(e), Qgis.Critical)
             return False, "Error installing dependencies: {}".format(str(e)[:200])
+        finally:
+            _remove_temp_file(constraints_file)
 
     if progress_callback:
         progress_callback(100, "All dependencies installed")

--- a/qgis_plugin/tests/test_venv_manager.py
+++ b/qgis_plugin/tests/test_venv_manager.py
@@ -1,4 +1,5 @@
 import subprocess
+from pathlib import Path
 
 from geoai.core import venv_manager
 
@@ -203,6 +204,99 @@ def test_omniwatermask_verification_bootstraps_torch_before_import():
 
     assert "add_dll_directory" in code
     assert "import torch; import omniwatermask" in code
+
+
+def test_write_constraints_file_writes_requested_constraints(tmp_path, monkeypatch):
+    monkeypatch.setattr(venv_manager, "CACHE_DIR", str(tmp_path))
+
+    path = venv_manager._write_constraints_file(
+        ["torch==2.12.0+cu128", "torchvision==0.27.0+cu128"]
+    )
+
+    assert path is not None
+    path_obj = Path(path)
+    assert path_obj.read_text(encoding="utf-8") == (
+        "torch==2.12.0+cu128\n" "torchvision==0.27.0+cu128\n"
+    )
+
+    venv_manager._remove_temp_file(path)
+    assert not path_obj.exists()
+
+
+def test_cuda_batch_install_constrains_existing_torch_wheels(tmp_path, monkeypatch):
+    from geoai.core import uv_manager
+
+    calls = []
+    written_constraints = []
+    constraints_path = str(tmp_path / "torch-constraints.txt")
+
+    def fake_run(cmd, *args, **kwargs):
+        script = cmd[-1]
+        if "torch.version.cuda" in script:
+            return subprocess.CompletedProcess(cmd, 0, stdout="12.8\n", stderr="")
+        if "metadata.version('torch')" in script:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="2.12.0+cu128\n", stderr=""
+            )
+        if "metadata.version('torchvision')" in script:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="0.27.0+cu128\n", stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    def fake_run_pip_install(**kwargs):
+        calls.append(kwargs)
+        return venv_manager._PipResult(0, "ok", "")
+
+    def fake_write_constraints(constraints):
+        written_constraints.extend(constraints)
+        return constraints_path
+
+    monkeypatch.setattr(uv_manager, "uv_exists", lambda: False)
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager, "get_venv_python_path", lambda _venv_dir: "python"
+    )
+    monkeypatch.setattr(venv_manager, "_get_clean_env_for_venv", lambda: {})
+    monkeypatch.setattr(venv_manager, "_get_subprocess_kwargs", lambda: {})
+    monkeypatch.setattr(
+        venv_manager,
+        "_get_required_packages",
+        lambda: [
+            ("torch", ">=2.0.0"),
+            ("torchvision", ">=0.15.0"),
+            ("geoai-py", ">=0.39.0"),
+            ("segment-geospatial", ""),
+        ],
+    )
+    monkeypatch.setattr(
+        venv_manager,
+        "detect_nvidia_gpu",
+        lambda: (True, {"compute_cap": 12.0, "driver_version": "572.76"}),
+    )
+    monkeypatch.setattr(venv_manager, "_select_cuda_index", lambda _gpu_info: "cu128")
+    monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
+    monkeypatch.setattr(venv_manager, "_run_pip_install", fake_run_pip_install)
+    monkeypatch.setattr(venv_manager, "_write_constraints_file", fake_write_constraints)
+
+    ok, message = venv_manager.install_dependencies(
+        venv_dir=str(tmp_path / "venv"),
+        cuda_enabled=True,
+    )
+
+    assert ok is True
+    assert message == "All dependencies installed successfully"
+    assert written_constraints == [
+        "torch==2.12.0+cu128",
+        "torchvision==0.27.0+cu128",
+    ]
+    batch_cmd = calls[-1]["cmd"]
+    assert "--extra-index-url" in batch_cmd
+    assert "https://download.pytorch.org/whl/cu128" in batch_cmd
+    assert "--constraint" in batch_cmd
+    assert constraints_path in batch_cmd
+    assert "geoai-py>=0.39.0" in batch_cmd
+    assert "segment-geospatial" in batch_cmd
 
 
 def test_verify_venv_treats_macos_sam3_import_failure_as_optional(monkeypatch):


### PR DESCRIPTION
Fixes #807.

## Summary
- Preserve the CUDA PyTorch and TorchVision wheel variants during the later QGIS managed-venv batch dependency install.
- Add the matching PyTorch CUDA wheel index during constrained batch resolves so local CUDA versions remain resolvable.
- Bump the QGIS dependency install logic version so affected managed environments are marked stale and reinstall.
- Add tests for constraint-file writing and CUDA batch command construction.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest qgis_plugin/tests/test_venv_manager.py qgis_plugin/tests/test_dependency_resolver.py
- pre-commit run --all-files
