### PR TITLE
chore: bump patch version to 0.40.1

### DIFF
--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -8,7 +8,7 @@ only when a specific symbol is first accessed.
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.40.0"
+__version__ = "0.40.1"
 
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geoai-py"
-version = "0.40.0"
+version = "0.40.1"
 dynamic = [
     "dependencies",
 ]
@@ -58,7 +58,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.40.0"
+current_version = "0.40.1"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.5.0
+version=1.5.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -59,6 +59,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.5.1
+        - Bump patch release for GeoAI package and QGIS plugin
     1.5.0
         - Bump minor release for GeoAI package and QGIS plugin
     1.4.4


### PR DESCRIPTION
## Summary
- Bump the geoai-py package version from 0.40.0 to 0.40.1
- Bump the QGIS plugin version from 1.5.0 to 1.5.1 and add a changelog entry

## Test plan
- [ ] pre-commit run --all-files passes
- [ ] CI build succeeds