### PR TITLE
fix: resolve QGIS plugin GPU dependency install failure from PyTorch index

### DIFF
--- a/.github/workflows/qgis-dependency-resolver.yml
+++ b/.github/workflows/qgis-dependency-resolver.yml
@@ -35,6 +35,10 @@ jobs:
               run: |
                   python qgis_plugin/tools/check_dependency_resolution.py --platform win32 --python-version 3.12 --timeout 900
 
+            - name: Resolve with PyTorch CUDA index (mirrors GPU install, issue #829)
+              run: |
+                  python qgis_plugin/tools/check_dependency_resolution.py --platform win32 --python-version 3.12 --cuda-index cu126 --timeout 900
+
     diagnostics-unit-tests:
         name: Resolver diagnostics tests
         runs-on: ubuntu-latest

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -49,7 +49,7 @@ DEPS_HASH_FILE = os.path.join(VENV_DIR, "deps_hash.txt")
 CUDA_FLAG_FILE = os.path.join(VENV_DIR, "cuda_installed.txt")
 
 # Bump when install logic changes significantly to force re-install.
-_INSTALL_LOGIC_VERSION = "11"
+_INSTALL_LOGIC_VERSION = "12"
 
 # Bump independently for CUDA-specific install logic changes.
 _CUDA_LOGIC_VERSION = "1"
@@ -331,6 +331,7 @@ def resolve_qgis_dependencies(
     platform_name: str = "win32",
     resolver: str = "uv",
     timeout: int = 600,
+    cuda_index: Optional[str] = None,
 ) -> Tuple[bool, str]:
     """Dry-run dependency resolution for the QGIS plugin install environment.
 
@@ -342,6 +343,11 @@ def resolve_qgis_dependencies(
         platform_name: Target Python platform, e.g. ``win32``.
         resolver: Resolver backend. Currently only ``uv`` is supported.
         timeout: Subprocess timeout in seconds.
+        cuda_index: Optional PyTorch CUDA wheel index (e.g. ``cu126``). When
+            set, the resolve mirrors the real GPU install by adding the
+            PyTorch ``--extra-index-url`` and the multi-index strategy so CI
+            reproduces the index configuration users actually hit. See
+            https://github.com/opengeos/geoai/issues/829.
 
     Returns:
         Tuple of success flag and diagnostic message.
@@ -363,8 +369,16 @@ def resolve_qgis_dependencies(
         "--python-platform",
         _uv_platform_name(platform_name),
         "--quiet",
-        "-",
     ]
+    if cuda_index:
+        cmd.extend(
+            [
+                "--extra-index-url",
+                "https://download.pytorch.org/whl/{}".format(cuda_index),
+            ]
+        )
+        cmd.extend(_UV_MULTI_INDEX_STRATEGY)
+    cmd.append("-")
     requirements = "\n".join(package_specs) + "\n"
     try:
         result = subprocess.run(
@@ -617,6 +631,17 @@ _INSECURE_PACKAGE_HOSTS = (
 )
 
 _TORCH_DISTRIBUTIONS = ("torch", "torchvision")
+
+# When a uv install also points at the PyTorch wheel index via
+# ``--extra-index-url``, uv defaults to the "first-index" strategy and only
+# considers a package on the first index that lists it. The PyTorch index
+# hosts stale copies of common packages (e.g. ``requests==2.28.1``), which
+# makes geoai-py's transitive requirement of ``requests>=2.32.2`` (via
+# ``datasets``) unsatisfiable and aborts the whole install. Telling uv to
+# consider all indexes lets the newest compatible version win (pulled from
+# PyPI) while ``torch``/``torchvision`` still come from the PyTorch index.
+# See https://github.com/opengeos/geoai/issues/829.
+_UV_MULTI_INDEX_STRATEGY = ("--index-strategy", "unsafe-best-match")
 
 
 def _is_ssl_error(stderr: str) -> bool:
@@ -3140,6 +3165,8 @@ def install_dependencies(
             ]
             pip_args.extend(_get_uv_ssl_flags())
             pip_args.extend(torch_index_args)
+            if torch_index_args:
+                pip_args.extend(_UV_MULTI_INDEX_STRATEGY)
             pip_args.extend(constraint_args)
             pip_args.extend(batch_specs)
             base_cmd = [uv_path] + pip_args
@@ -3267,6 +3294,8 @@ def install_dependencies(
                             ]
                             retry_args.extend(_get_uv_ssl_flags())
                             retry_args.extend(torch_index_args)
+                            if torch_index_args:
+                                retry_args.extend(_UV_MULTI_INDEX_STRATEGY)
                             retry_args.extend(constraint_args)
                             retry_args.extend(retry_specs)
                             retry_cmd = [uv_path] + retry_args

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -641,6 +641,13 @@ _TORCH_DISTRIBUTIONS = ("torch", "torchvision")
 # consider all indexes lets the newest compatible version win (pulled from
 # PyPI) while ``torch``/``torchvision`` still come from the PyTorch index.
 # See https://github.com/opengeos/geoai/issues/829.
+#
+# Tradeoff: uv documents ``unsafe-best-match`` as relaxing its dependency-
+# confusion protection, since it lets any configured index supply the winning
+# version for a given package name. That is acceptable here because both
+# indexes (PyPI and download.pytorch.org) are official and trusted, and the
+# torch distributions themselves stay pinned to the installed build via the
+# ``--constraint`` file written alongside these args.
 _UV_MULTI_INDEX_STRATEGY = ("--index-strategy", "unsafe-best-match")
 
 

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.5.1
+version=1.5.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -59,6 +59,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    1.5.2
+        - Fix dependency installation failing on GPU installs when the PyTorch wheel index shadowed newer shared packages such as requests, blocking geoai-py/datasets resolution (#827, #829, #831, #833)
     1.5.1
         - Bump patch release for GeoAI package and QGIS plugin
     1.5.0

--- a/qgis_plugin/tests/test_dependency_resolver.py
+++ b/qgis_plugin/tests/test_dependency_resolver.py
@@ -73,3 +73,62 @@ def test_dependency_resolver_dry_run_uses_uv_compile(monkeypatch):
     assert requirements is not None
     assert "transformers>=4.56.2" in requirements
     assert "triton-windows" in requirements
+
+
+def test_dependency_resolver_adds_pytorch_index_and_strategy_for_cuda(monkeypatch):
+    """CUDA resolve must mirror the real install: PyTorch extra index + strategy.
+
+    Regression guard for issue #829: without the multi-index strategy, uv only
+    considers the (stale) PyTorch index for shared packages like ``requests``,
+    making geoai-py's ``datasets`` requirement unsatisfiable.
+    """
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append({"cmd": cmd})
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="Resolved 10 packages", stderr=""
+        )
+
+    monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
+
+    ok, _ = venv_manager.resolve_qgis_dependencies(
+        python_version="3.12",
+        platform_name="win32",
+        resolver="uv",
+        timeout=5,
+        cuda_index="cu126",
+    )
+
+    assert ok is True
+    cmd = calls[0]["cmd"]
+    assert "--extra-index-url" in cmd
+    assert "https://download.pytorch.org/whl/cu126" in cmd
+    assert "--index-strategy" in cmd
+    assert "unsafe-best-match" in cmd
+    # The strategy flags must come before the trailing "-" stdin marker.
+    assert cmd[-1] == "-"
+
+
+def test_dependency_resolver_omits_pytorch_index_without_cuda(monkeypatch):
+    """The default (CPU) resolve must not add the PyTorch index or strategy."""
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append({"cmd": cmd})
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="Resolved 10 packages", stderr=""
+        )
+
+    monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
+
+    venv_manager.resolve_qgis_dependencies(
+        python_version="3.12",
+        platform_name="win32",
+        resolver="uv",
+        timeout=5,
+    )
+
+    cmd = calls[0]["cmd"]
+    assert "--extra-index-url" not in cmd
+    assert "--index-strategy" not in cmd

--- a/qgis_plugin/tools/check_dependency_resolution.py
+++ b/qgis_plugin/tools/check_dependency_resolution.py
@@ -53,6 +53,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Target Python platform to resolve for.",
     )
     parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument(
+        "--cuda-index",
+        default=None,
+        help=(
+            "PyTorch CUDA wheel index to mirror a GPU install, e.g. 'cu126'. "
+            "When set, the resolve adds the PyTorch --extra-index-url and the "
+            "multi-index strategy, reproducing the real install (issue #829)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     _install_qgis_stub()
@@ -76,6 +85,7 @@ def main(argv: list[str] | None = None) -> int:
         python_version=args.python_version,
         platform_name=args.platform,
         timeout=args.timeout,
+        cuda_index=args.cuda_index,
     )
     print(message)
     return 0 if success else 1


### PR DESCRIPTION
## Summary

Multiple users reported the GeoAI QGIS plugin installing the base plugin fine but failing at the "install dependencies" step, leaving `geoai-py` and every geospatial package uninstalled while `torch`/`torchvision` installed correctly (#826, #827, #829, #831, #833).

Root cause: on GPU installs the batch install step passes the PyTorch wheel index via `--extra-index-url`. uv defaults to a first-index strategy, so shared packages such as `requests` are only considered from the PyTorch index, which ships a stale `requests==2.28.1`. That makes `geoai-py`'s transitive `requests>=2.32.2` (pulled in by `datasets>=4.8.4`) unsatisfiable and aborts the whole install. Issue #829 diagnosed this precisely.

Reproduced locally with uv (the plugin's resolver):

```
Because only requests==2.28.1 is available and datasets>=4.8.4 depends on
requests>=2.32.2 ... geoai-py>=0.39.0 cannot be used ... unsatisfiable.
hint: requests was found on download.pytorch.org/whl/cu126, but not at the
requested version. ... use --index-strategy unsafe-best-match ...
```

## Changes

- Add `--index-strategy unsafe-best-match` to the uv batch and retry install commands whenever the PyTorch `--extra-index-url` is present. The newest compatible version now wins from PyPI, while `torch`/`torchvision` still resolve from the PyTorch index and stay pinned by the existing torch constraints file.
- Mirror the real GPU index configuration in the dry-run resolver (`resolve_qgis_dependencies(cuda_index=...)`) and the `check_dependency_resolution.py` tool, and add a CI job that resolves with `--cuda-index cu126`. This scenario fails without the fix and passes with it, guarding against regressions.
- Bump `_INSTALL_LOGIC_VERSION` so previously failed managed environments reinstall automatically, and bump the plugin to 1.5.2 with a changelog entry.

## Notes on the reported issues

- #827, #829, #831, #833: Windows GPU installs matching the PyTorch-index conflict above. Fixed and validated.
- #826: Intel macOS (no GPU). On the CPU path the PyTorch index is never added, and dependency resolution succeeds cleanly in testing for both arm64 and x86_64 macOS (torch resolves to 2.2.2 on Intel). This one could not be reproduced as a resolver conflict; the install-logic bump forces a fresh reinstall which should clear a stale/partial venv. If it still fails after updating to 1.5.2, please reopen with the install log.

## Test plan

- [x] Reproduced the exact `requests`/`datasets` conflict with `uv pip compile` + the PyTorch extra index (full plugin spec set), and confirmed `--index-strategy unsafe-best-match` resolves it while keeping `torch==*+cu126`.
- [x] `check_dependency_resolution.py --cuda-index cu126` returns success with the fix (exit 0); the same scenario fails without the strategy.
- [x] New unit tests assert the CUDA resolve adds the PyTorch index + strategy and the CPU resolve does not.
- [x] CI: QGIS dependency resolver (both CPU and new cu126 jobs) and resolver diagnostics tests pass.

Fixes #826
Fixes #827
Fixes #829
Fixes #831
Fixes #833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation for GPU-enabled setups, reducing failures caused by package index conflicts during installation.
  * Made dependency resolution more reliable when using CUDA-specific Python package sources.
* **New Features**
  * Added support for selecting a CUDA wheel index during dependency checks and installation workflows.
* **Chores**
  * Updated the plugin version to 1.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->