### PR TITLE
chore: bump version to 0.41.0 (qgis plugin 1.6.0)

### DIFF
--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -8,7 +8,7 @@ only when a specific symbol is first accessed.
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.40.1"
+__version__ = "0.41.0"
 
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geoai-py"
-version = "0.40.1"
+version = "0.41.0"
 dynamic = [
     "dependencies",
 ]
@@ -59,7 +59,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.40.1"
+current_version = "0.41.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.5.2
+version=1.6.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 


### PR DESCRIPTION
Minor version bump ahead of the v0.41.0 release.

- `geoai-py` package: 0.40.1 → **0.41.0**
- QGIS plugin: 1.5.2 → **1.6.0**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project, package, and plugin version numbers to the latest release.
  * Brought version metadata into sync across the app and plugin files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->