### PR TITLE
fix: normalize change_confidence as cosine in [-1, 1], not a 0-145 angle

### DIFF
--- a/geoai/change_detection.py
+++ b/geoai/change_detection.py
@@ -1,6 +1,7 @@
 """Change detection module for remote sensing imagery using torchange."""
 
 import logging
+import math
 import os
 import threading
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -20,6 +21,38 @@ except ImportError:
     show_change_masks = None
 
 from .utils import download_file
+
+
+def _normalize_change_confidence(
+    change_confidence: float, threshold_degrees: float = 145.0
+) -> float:
+    """Normalize a torchange change confidence value to the [0, 1] range.
+
+    torchange's AnyChange scores each mask with the negative cosine similarity
+    between its two temporal mask embeddings, so raw values lie in [-1, 1]
+    (-1 = identical embeddings / no change, 1 = opposite embeddings / maximal
+    change). Masks are kept when the raw value exceeds
+    ``cos(radians(threshold_degrees))``. This maps the raw cosine value to
+    [0, 1] so that the decision threshold lands at 0.5: values below the
+    threshold fall in [0, 0.5) and values above it fall in (0.5, 1].
+
+    Args:
+        change_confidence (float): Raw change confidence (negative cosine
+            similarity) reported by torchange, in [-1, 1].
+        threshold_degrees (float): Change confidence threshold angle in
+            degrees, matching torchange's ``change_confidence_threshold``
+            hyperparameter. Defaults to 145.0.
+
+    Returns:
+        float: Normalized confidence in [0, 1].
+    """
+    conf = float(np.clip(change_confidence, -1.0, 1.0))
+    # Clamp the angle away from 0/180 degrees so both branches below have a
+    # nonzero denominator.
+    threshold_cos = math.cos(math.radians(min(max(threshold_degrees, 1.0), 179.0)))
+    if conf >= threshold_cos:
+        return 0.5 + 0.5 * (conf - threshold_cos) / (1.0 - threshold_cos)
+    return 0.5 * (conf + 1.0) / (threshold_cos + 1.0)
 
 
 class ChangeDetection:
@@ -62,6 +95,19 @@ class ChangeDetection:
             use_normalized_feature=True,
             bitemporal_match=True,
         )
+
+    def _get_change_confidence_threshold(self) -> float:
+        """Get the model's change confidence threshold angle in degrees.
+
+        torchange stores the threshold on the model (updating it when
+        ``auto_threshold`` is enabled), so read it from there rather than
+        tracking a separate copy.
+
+        Returns:
+            float: Threshold angle in degrees. Falls back to 145.0 if the
+                model does not expose one.
+        """
+        return float(getattr(self.model, "change_confidence_threshold", 145.0))
 
     def set_hyperparameters(
         self,
@@ -479,14 +525,13 @@ class ChangeDetection:
                     else:
                         prob_components.append(("stability", 0.8))
 
-                    # Change confidence (normalize based on threshold)
+                    # Change confidence (raw value is a negative cosine
+                    # similarity in [-1, 1]; normalize against the threshold)
                     if change_confidence is not None and i < len(change_confidence):
                         conf = float(change_confidence[i])
-                        # Normalize confidence: threshold is 145, values above indicate higher confidence
-                        if conf >= 145:
-                            conf_normalized = 0.5 + min(0.5, (conf - 145) / 145)
-                        else:
-                            conf_normalized = max(0.0, conf / 145 * 0.5)
+                        conf_normalized = _normalize_change_confidence(
+                            conf, self._get_change_confidence_threshold()
+                        )
                         prob_components.append(("confidence", conf_normalized))
                     else:
                         prob_components.append(("confidence", 0.5))
@@ -1011,7 +1056,7 @@ class ChangeDetection:
                 x=stats["change_confidence"]["mean"],
                 color="red",
                 linestyle="--",
-                label=f"Mean: {stats['change_confidence']['mean']:.1f}",
+                label=f"Mean: {stats['change_confidence']['mean']:.3f}",
             )
             axes[0, 2].set_xlabel("Change Confidence")
             axes[0, 2].set_ylabel("Count")
@@ -1087,8 +1132,8 @@ Stability Scores:
         if "change_confidence" in stats:
             summary_text += f"""
 Change Confidence:
-  Mean: {stats['change_confidence']['mean']:.1f}
-  Range: {stats['change_confidence']['min']:.1f} - {stats['change_confidence']['max']:.1f}"""
+  Mean: {stats['change_confidence']['mean']:.3f}
+  Range: {stats['change_confidence']['min']:.3f} - {stats['change_confidence']['max']:.3f}"""
 
         if "areas" in stats:
             summary_text += f"""
@@ -1344,9 +1389,9 @@ Areas:
                                 change_confidence
                             ):
                                 change_conf = float(change_confidence[instance_id])
-                                # Normalize change confidence (typically around 145 threshold)
-                                change_conf_norm = max(
-                                    0.0, min(1.0, abs(change_conf) / 200.0)
+                                change_conf_norm = _normalize_change_confidence(
+                                    change_conf,
+                                    self._get_change_confidence_threshold(),
                                 )
 
                                 # Weighted combination of scores
@@ -1542,8 +1587,10 @@ Areas:
                     mask_info["change_confidence"],
                 ]
             ):
-                # Normalize change confidence (145 is typical threshold)
-                conf_norm = max(0.0, min(1.0, mask_info["change_confidence"] / 145.0))
+                conf_norm = _normalize_change_confidence(
+                    mask_info["change_confidence"],
+                    self._get_change_confidence_threshold(),
+                )
                 combined_score = (
                     0.3 * mask_info["iou_pred"]
                     + 0.3 * mask_info["stability_score"]

--- a/geoai/change_detection.py
+++ b/geoai/change_detection.py
@@ -50,7 +50,7 @@ def _normalize_change_confidence(
     # Clamp the angle away from 0/180 degrees so both branches below have a
     # nonzero denominator.
     threshold_cos = math.cos(math.radians(min(max(threshold_degrees, 1.0), 179.0)))
-    if conf >= threshold_cos:
+    if conf > threshold_cos:
         return 0.5 + 0.5 * (conf - threshold_cos) / (1.0 - threshold_cos)
     return 0.5 * (conf + 1.0) / (threshold_cos + 1.0)
 

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -515,13 +515,13 @@ class TestGetChangeConfidenceThreshold(unittest.TestCase):
     @patch("geoai.change_detection.AnyChange")
     def test_reads_threshold_from_model(self, mock_anychange, mock_download):
         mock_model = MagicMock()
-        mock_model.change_confidence_threshold = 155
         mock_anychange.return_value = mock_model
         mock_download.return_value = "/fake/ckpt.pth"
 
         from geoai.change_detection import ChangeDetection
 
         detector = ChangeDetection()
+        detector.model.change_confidence_threshold = 155
         self.assertEqual(detector._get_change_confidence_threshold(), 155.0)
 
     @patch("geoai.change_detection.download_checkpoint")

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -452,5 +452,91 @@ class TestComprehensiveReport(unittest.TestCase):
         self.detector.create_comprehensive_report({"other_key": 42})
 
 
+# ---------------------------------------------------------------------------
+# Change confidence normalization (issue #840)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeChangeConfidence(unittest.TestCase):
+    """Raw change confidence is a negative cosine similarity in [-1, 1]."""
+
+    def test_threshold_maps_to_half(self):
+        import math
+
+        from geoai.change_detection import _normalize_change_confidence
+
+        for threshold in [60.0, 145.0, 155.0]:
+            threshold_cos = math.cos(math.radians(threshold))
+            self.assertAlmostEqual(
+                _normalize_change_confidence(threshold_cos, threshold), 0.5
+            )
+
+    def test_endpoints(self):
+        from geoai.change_detection import _normalize_change_confidence
+
+        self.assertAlmostEqual(_normalize_change_confidence(-1.0, 145.0), 0.0)
+        self.assertAlmostEqual(_normalize_change_confidence(1.0, 145.0), 1.0)
+
+    def test_monotonic_over_full_range(self):
+        from geoai.change_detection import _normalize_change_confidence
+
+        values = [
+            _normalize_change_confidence(c, 145.0) for c in np.linspace(-1, 1, 41)
+        ]
+        self.assertTrue(all(a < b for a, b in zip(values, values[1:])))
+        self.assertTrue(all(0.0 <= v <= 1.0 for v in values))
+
+    def test_kept_masks_score_above_half(self):
+        """Masks surviving torchange's filter (conf > cos(threshold)) map above 0.5."""
+        from geoai.change_detection import _normalize_change_confidence
+
+        # cos(145 degrees) is about -0.819; kept masks exceed it
+        for conf in [-0.8, -0.5, 0.0, 0.5, 0.9]:
+            self.assertGreater(_normalize_change_confidence(conf, 145.0), 0.5)
+
+    def test_out_of_range_input_clamped(self):
+        from geoai.change_detection import _normalize_change_confidence
+
+        self.assertAlmostEqual(_normalize_change_confidence(-2.0, 145.0), 0.0)
+        self.assertAlmostEqual(_normalize_change_confidence(2.0, 145.0), 1.0)
+
+    def test_degenerate_threshold_angles(self):
+        """Threshold angles at 0/180 degrees must not divide by zero."""
+        from geoai.change_detection import _normalize_change_confidence
+
+        for threshold in [0.0, 180.0]:
+            for conf in [-1.0, 0.0, 1.0]:
+                value = _normalize_change_confidence(conf, threshold)
+                self.assertTrue(0.0 <= value <= 1.0)
+
+
+class TestGetChangeConfidenceThreshold(unittest.TestCase):
+    @patch("geoai.change_detection.download_checkpoint")
+    @patch("geoai.change_detection.AnyChange")
+    def test_reads_threshold_from_model(self, mock_anychange, mock_download):
+        mock_model = MagicMock()
+        mock_model.change_confidence_threshold = 155
+        mock_anychange.return_value = mock_model
+        mock_download.return_value = "/fake/ckpt.pth"
+
+        from geoai.change_detection import ChangeDetection
+
+        detector = ChangeDetection()
+        self.assertEqual(detector._get_change_confidence_threshold(), 155.0)
+
+    @patch("geoai.change_detection.download_checkpoint")
+    @patch("geoai.change_detection.AnyChange")
+    def test_falls_back_to_default(self, mock_anychange, mock_download):
+        mock_model = MagicMock(spec=[])  # no change_confidence_threshold attribute
+        mock_anychange.return_value = mock_model
+        mock_download.return_value = "/fake/ckpt.pth"
+
+        from geoai.change_detection import ChangeDetection
+
+        detector = ChangeDetection.__new__(ChangeDetection)
+        detector.model = mock_model
+        self.assertEqual(detector._get_change_confidence_threshold(), 145.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #840.

`change_confidence` from torchange's `AnyChange` is a **negative cosine similarity** in `[-1, 1]` (masks are kept when it exceeds `cos(change_confidence_threshold°)`, e.g. `cos(145°) ≈ -0.819`). Three places in `geoai/change_detection.py` normalized it as if it were on a 0–145 (or 0–200) angle scale:

- `_save_probability_mask`: `conf >= 145` was never true, so the 0.35-weighted confidence component was always ~0
- `_save_instance_scores_mask`: `abs(conf) / 200` contributed at most ~0.005 to the 0.3-weighted term
- `_extract_detailed_results` (`combined_confidence`): `conf / 145` clamped to ~0 for the 0.4-weighted term

As a result, per-instance confidence scores and the probability heatmap measured SAM mask quality only — regions with very different change magnitudes got near-identical scores.

## Changes

- Add a shared `_normalize_change_confidence()` helper that maps the raw cosine to `[0, 1]` with the model's decision threshold landing at 0.5 (kept masks map to `(0.5, 1]`, matching the original intent of the probability semantics)
- Read the threshold angle from the torchange model via `_get_change_confidence_threshold()`, so `auto_threshold` (which mutates the model's threshold at runtime) is handled correctly
- Use the helper at all three normalization sites
- Update change confidence report/plot formatting from `.1f` to `.3f` since the raw values are cosines, not large angles
- Add unit tests: threshold maps to 0.5, endpoints map to 0/1, monotonicity, kept masks score above 0.5, input clamping, degenerate 0°/180° thresholds, and threshold read/fallback

## Testing

- `pytest tests/test_change_detection.py` — 35 passed
- `pre-commit run --all-files` — all hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change-confidence normalization so exported masks and detailed results now use consistent, bounded scores.
  * The system now honors the model’s configured confidence threshold automatically, with a safe default when missing.
  * Change-confidence “Mean” values in reports now display with higher precision for more accurate summaries.
* **Tests**
  * Added unit tests covering confidence normalization, threshold reading/fallback behavior, monotonicity, and key edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->