### PR TITLE
fix: make set_hyperparameters only update explicitly passed params

### DIFF
--- a/geoai/change_detection.py
+++ b/geoai/change_detection.py
@@ -55,6 +55,19 @@ def _normalize_change_confidence(
     return 0.5 * (conf + 1.0) / (threshold_cos + 1.0)
 
 
+# Maps ChangeDetection.set_hyperparameters() argument names to the attribute
+# names torchange's AnyChange stores them under.
+_HYPERPARAMETER_ATTRS = {
+    "change_confidence_threshold": "change_confidence_threshold",
+    "auto_threshold": "auto_threshold",
+    "use_normalized_feature": "use_normalized_feature",
+    "area_thresh": "area_thresh",
+    "match_hist": "match_hist",
+    "object_sim_thresh": "object_sim_thresh",
+    "bitemporal_match": "use_bitemporal_match",
+}
+
+
 class ChangeDetection:
     """A class for change detection on geospatial imagery using torchange and SAM."""
 
@@ -111,39 +124,64 @@ class ChangeDetection:
 
     def set_hyperparameters(
         self,
-        change_confidence_threshold: int = 155,
-        auto_threshold: bool = False,
-        use_normalized_feature: bool = True,
-        area_thresh: float = 0.8,
-        match_hist: bool = False,
-        object_sim_thresh: int = 60,
-        bitemporal_match: bool = True,
+        change_confidence_threshold: Optional[int] = None,
+        auto_threshold: Optional[bool] = None,
+        use_normalized_feature: Optional[bool] = None,
+        area_thresh: Optional[float] = None,
+        match_hist: Optional[bool] = None,
+        object_sim_thresh: Optional[int] = None,
+        bitemporal_match: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         """
-        Set hyperparameters for the change detection model.
+        Update hyperparameters for the change detection model.
+
+        Only the parameters explicitly provided (not None) are changed; all
+        other hyperparameters keep their current values on the model.
 
         Args:
-            change_confidence_threshold (int): Change confidence threshold for SAM
-            auto_threshold (bool): Whether to use auto threshold for SAM
-            use_normalized_feature (bool): Whether to use normalized feature for SAM
-            area_thresh (float): Area threshold for SAM
-            match_hist (bool): Whether to use match hist for SAM
-            object_sim_thresh (int): Object similarity threshold for SAM
-            bitemporal_match (bool): Whether to use bitemporal match for SAM
-            **kwargs: Keyword arguments for model hyperparameters
+            change_confidence_threshold (int, optional): Change confidence
+                threshold angle in degrees for SAM. Defaults to None (keep
+                current value; 145 after initialization).
+            auto_threshold (bool, optional): Whether to use auto threshold for
+                SAM. Defaults to None (keep current value).
+            use_normalized_feature (bool, optional): Whether to use normalized
+                feature for SAM. Defaults to None (keep current value).
+            area_thresh (float, optional): Area threshold for SAM. Defaults to
+                None (keep current value).
+            match_hist (bool, optional): Whether to use match hist for SAM.
+                Defaults to None (keep current value).
+            object_sim_thresh (int, optional): Object similarity threshold for
+                SAM. Defaults to None (keep current value).
+            bitemporal_match (bool, optional): Whether to use bitemporal match
+                for SAM. Defaults to None (keep current value).
+            **kwargs: Additional keyword arguments for model hyperparameters.
         """
-        if self.model:
-            self.model.set_hyperparameters(
-                change_confidence_threshold=change_confidence_threshold,
-                auto_threshold=auto_threshold,
-                use_normalized_feature=use_normalized_feature,
-                area_thresh=area_thresh,
-                match_hist=match_hist,
-                object_sim_thresh=object_sim_thresh,
-                bitemporal_match=bitemporal_match,
-                **kwargs,
+        if not self.model:
+            return
+
+        updates = {
+            name: value
+            for name, value in (
+                ("change_confidence_threshold", change_confidence_threshold),
+                ("auto_threshold", auto_threshold),
+                ("use_normalized_feature", use_normalized_feature),
+                ("area_thresh", area_thresh),
+                ("match_hist", match_hist),
+                ("object_sim_thresh", object_sim_thresh),
+                ("bitemporal_match", bitemporal_match),
             )
+            if value is not None
+        }
+        # torchange's AnyChange.set_hyperparameters() assigns every argument
+        # unconditionally, so forward the model's current values for anything
+        # not being updated to avoid resetting it to torchange defaults.
+        current = {
+            name: getattr(self.model, attr)
+            for name, attr in _HYPERPARAMETER_ATTRS.items()
+            if hasattr(self.model, attr)
+        }
+        self.model.set_hyperparameters(**{**current, **updates, **kwargs})
 
     def set_mask_generator_params(
         self,

--- a/geoai/change_detection.py
+++ b/geoai/change_detection.py
@@ -157,22 +157,20 @@ class ChangeDetection:
                 for SAM. Defaults to None (keep current value).
             **kwargs: Additional keyword arguments for model hyperparameters.
         """
+        # Snapshot the arguments before any other locals are created, so the
+        # parameter names in _HYPERPARAMETER_ATTRS stay the single source of
+        # truth for which hyperparameters exist.
+        provided = locals()
         if not self.model:
             return
 
         updates = {
-            name: value
-            for name, value in (
-                ("change_confidence_threshold", change_confidence_threshold),
-                ("auto_threshold", auto_threshold),
-                ("use_normalized_feature", use_normalized_feature),
-                ("area_thresh", area_thresh),
-                ("match_hist", match_hist),
-                ("object_sim_thresh", object_sim_thresh),
-                ("bitemporal_match", bitemporal_match),
-            )
-            if value is not None
+            name: provided[name]
+            for name in _HYPERPARAMETER_ATTRS
+            if provided[name] is not None
         }
+        if not updates and not kwargs:
+            return
         # torchange's AnyChange.set_hyperparameters() assigns every argument
         # unconditionally, so forward the model's current values for anything
         # not being updated to avoid resetting it to torchange defaults.

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -236,6 +236,11 @@ class TestSetHyperparametersPreservesUnspecified(unittest.TestCase):
         self.detector.set_hyperparameters()
         self.assertEqual(self.detector.model.change_confidence_threshold, 170)
 
+    def test_noop_without_model_even_with_args(self):
+        self.detector.model = None
+        # Should not raise
+        self.detector.set_hyperparameters(area_thresh=0.9)
+
     def test_bitemporal_match_maps_to_model_attribute(self):
         self.detector.set_hyperparameters(bitemporal_match=False)
         self.assertFalse(self.detector.model.use_bitemporal_match)

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -15,6 +15,39 @@ import numpy as np
 # ---------------------------------------------------------------------------
 
 
+class _FakeAnyChange:
+    """Mimics torchange's AnyChange hyperparameter storage.
+
+    ``set_hyperparameters`` assigns every argument unconditionally, exactly
+    like the upstream implementation, and ``bitemporal_match`` is stored as
+    ``use_bitemporal_match``.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def make_mask_generator(self, **kwargs):
+        pass
+
+    def set_hyperparameters(
+        self,
+        change_confidence_threshold=155,
+        auto_threshold=False,
+        use_normalized_feature=True,
+        area_thresh=0.8,
+        match_hist=False,
+        object_sim_thresh=60,
+        bitemporal_match=True,
+    ):
+        self.area_thresh = area_thresh
+        self.match_hist = match_hist
+        self.change_confidence_threshold = change_confidence_threshold
+        self.auto_threshold = auto_threshold
+        self.use_normalized_feature = use_normalized_feature
+        self.object_sim_thresh = object_sim_thresh
+        self.use_bitemporal_match = bitemporal_match
+
+
 def _create_test_geotiff(path, width=64, height=64, bands=3, dtype="uint8"):
     """Create a minimal GeoTIFF for testing."""
     import rasterio
@@ -169,6 +202,52 @@ class TestSetHyperparameters(unittest.TestCase):
     def test_set_mask_generator_params_noop_without_model(self):
         self.detector.model = None
         self.detector.set_mask_generator_params()
+
+
+class TestSetHyperparametersPreservesUnspecified(unittest.TestCase):
+    """Regression tests for issue #844: set_hyperparameters() must not reset
+    parameters the caller did not pass."""
+
+    @patch("geoai.change_detection.download_checkpoint")
+    @patch("geoai.change_detection.AnyChange", _FakeAnyChange)
+    def setUp(self, mock_download):
+        mock_download.return_value = "/fake/ckpt.pth"
+
+        from geoai.change_detection import ChangeDetection
+
+        self.detector = ChangeDetection()
+
+    def test_init_defaults_applied(self):
+        self.assertEqual(self.detector.model.change_confidence_threshold, 145)
+        self.assertTrue(self.detector.model.use_normalized_feature)
+        self.assertTrue(self.detector.model.use_bitemporal_match)
+
+    def test_updating_one_param_preserves_others(self):
+        self.detector.set_hyperparameters(area_thresh=0.9)
+        self.assertEqual(self.detector.model.area_thresh, 0.9)
+        # Threshold must stay at the init value (145), not reset to
+        # torchange's default (155).
+        self.assertEqual(self.detector.model.change_confidence_threshold, 145)
+        self.assertEqual(self.detector.model.object_sim_thresh, 60)
+        self.assertTrue(self.detector.model.use_bitemporal_match)
+
+    def test_no_args_is_a_noop(self):
+        self.detector.set_hyperparameters(change_confidence_threshold=170)
+        self.detector.set_hyperparameters()
+        self.assertEqual(self.detector.model.change_confidence_threshold, 170)
+
+    def test_bitemporal_match_maps_to_model_attribute(self):
+        self.detector.set_hyperparameters(bitemporal_match=False)
+        self.assertFalse(self.detector.model.use_bitemporal_match)
+        self.detector.set_hyperparameters(match_hist=True)
+        self.assertFalse(self.detector.model.use_bitemporal_match)
+
+    def test_false_and_zero_values_are_forwarded(self):
+        self.detector.set_hyperparameters(
+            use_normalized_feature=False, object_sim_thresh=0
+        )
+        self.assertFalse(self.detector.model.use_normalized_feature)
+        self.assertEqual(self.detector.model.object_sim_thresh, 0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #844

## Problem

`ChangeDetection._init_model()` sets `change_confidence_threshold=145`, but `ChangeDetection.set_hyperparameters()` declared its own defaults (`change_confidence_threshold=155`, plus defaults for every other param) and forwarded all of them to `AnyChange.set_hyperparameters()` on every call. Since torchange assigns each attribute unconditionally, changing one knob silently reset all the others:

```python
cd = ChangeDetection(sam_model_type="vit_b", sam_checkpoint=ckpt)
cd.model.change_confidence_threshold   # 145
cd.set_hyperparameters(area_thresh=0.9)  # meant to change only area_thresh
cd.model.change_confidence_threshold   # 155 — silently changed
```

This shifted detection sensitivity (and `object_sim_thresh`, `match_hist`, ...) without the user asking, which also changed what `_normalize_change_confidence` produces.

## Fix

- All `set_hyperparameters()` parameters now default to `None`.
- Only explicitly passed (non-None) values are updated; everything else is forwarded from the model's current values, so nothing is reset. Calling with no arguments is a no-op.
- `bitemporal_match` is read back from the model's `use_bitemporal_match` attribute (torchange stores it under that name).
- Docstring updated to document the keep-current-value semantics.

## Tests

Added a regression test class using a stateful fake that replicates torchange's `AnyChange.set_hyperparameters` assignment behavior verbatim, covering:
- init defaults (threshold stays 145)
- updating one param preserves the others
- no-arg call is a no-op
- `bitemporal_match` ↔ `use_bitemporal_match` mapping survives subsequent updates
- falsy values (`False`, `0`) are still forwarded

All 40 tests in `tests/test_change_detection.py` pass; pre-commit passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a single change-detection hyperparameter now preserves the other existing settings instead of resetting them.
  * Calling hyperparameter updates with no values is now a no-op.
  * Falsey and zero values (e.g., `false`, `0`) are now applied correctly.
  * The `bitemporal_match` option is now correctly mapped to the underlying setting, preventing unintended overwrites.
  * Hyperparameter updates no longer error when no detector model is present.
* **Tests**
  * Added regression coverage to verify preservation, mapping, no-op behavior, and falsey/zero handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->