### PR TITLE
fix: restore print output in print_vector_info and print_raster_info

### DIFF
--- a/geoai/utils/raster.py
+++ b/geoai/utils/raster.py
@@ -247,26 +247,24 @@ def print_raster_info(
         info = get_raster_info(raster_path)
 
         # Print basic information
-        logger.info("===== RASTER INFORMATION: %s =====", raster_path)
-        logger.info("Driver: %s", info["driver"])
-        logger.info("Dimensions: %s x %s pixels", info["width"], info["height"])
-        logger.info("Number of bands: %s", info["count"])
-        logger.info("Data type: %s", info["dtype"])
-        logger.info("Coordinate Reference System: %s", info["crs"])
-        logger.info("Georeferenced Bounds: %s", info["bounds"])
-        logger.info(
-            "Pixel Resolution: %s, %s", info["resolution"][0], info["resolution"][1]
-        )
-        logger.info("NoData Value: %s", info["nodata"])
+        print(f"===== RASTER INFORMATION: {raster_path} =====")
+        print(f"Driver: {info['driver']}")
+        print(f"Dimensions: {info['width']} x {info['height']} pixels")
+        print(f"Number of bands: {info['count']}")
+        print(f"Data type: {info['dtype']}")
+        print(f"Coordinate Reference System: {info['crs']}")
+        print(f"Georeferenced Bounds: {info['bounds']}")
+        print(f"Pixel Resolution: {info['resolution'][0]}, {info['resolution'][1]}")
+        print(f"NoData Value: {info['nodata']}")
 
         # Print band statistics
-        logger.info("----- Band Statistics -----")
+        print("----- Band Statistics -----")
         for band_stat in info["band_stats"]:
-            logger.info("Band %s:", band_stat["band"])
-            logger.info("  Min: %.2f", band_stat["min"])
-            logger.info("  Max: %.2f", band_stat["max"])
-            logger.info("  Mean: %.2f", band_stat["mean"])
-            logger.info("  Std Dev: %.2f", band_stat["std"])
+            print(f"Band {band_stat['band']}:")
+            print(f"  Min: {band_stat['min']:.2f}")
+            print(f"  Max: {band_stat['max']:.2f}")
+            print(f"  Mean: {band_stat['mean']:.2f}")
+            print(f"  Std Dev: {band_stat['std']:.2f}")
 
         # Show a preview if requested
         if show_preview:

--- a/geoai/utils/vector.py
+++ b/geoai/utils/vector.py
@@ -99,22 +99,22 @@ def print_vector_info(
         info = get_vector_info(vector_path)
 
         # Print basic information
-        logger.info(f"===== VECTOR INFORMATION: {vector_path} =====")
-        logger.info(f"Driver: {info['driver']}")
-        logger.info(f"Feature count: {info['feature_count']}")
-        logger.info(f"Geometry types: {info['geometry_type']}")
-        logger.info(f"Coordinate Reference System: {info['crs']}")
-        logger.info(f"Bounds: {info['bounds']}")
-        logger.info(f"Number of attributes: {info['attribute_count']}")
-        logger.info(f"Attribute names: {', '.join(info['attribute_names'])}")
+        print(f"===== VECTOR INFORMATION: {vector_path} =====")
+        print(f"Driver: {info['driver']}")
+        print(f"Feature count: {info['feature_count']}")
+        print(f"Geometry types: {info['geometry_type']}")
+        print(f"Coordinate Reference System: {info['crs']}")
+        print(f"Bounds: {info['bounds']}")
+        print(f"Number of attributes: {info['attribute_count']}")
+        print(f"Attribute names: {', '.join(info['attribute_names'])}")
 
         # Print attribute statistics
         if info["attribute_stats"]:
-            logger.info("----- Attribute Statistics -----")
+            print("----- Attribute Statistics -----")
             for attr, stats in info["attribute_stats"].items():
-                logger.info(f"Attribute: {attr}")
+                print(f"Attribute: {attr}")
                 for stat_name, stat_value in stats.items():
-                    logger.info(
+                    print(
                         f"  {stat_name}: {stat_value:.4f}"
                         if isinstance(stat_value, float)
                         else f"  {stat_name}: {stat_value}"


### PR DESCRIPTION
## Summary
- `print_vector_info` and `print_raster_info` stopped producing any output after #651 switched them from `print()` to `logger.info()`; the library logger has no handler and the default root level is WARNING, so the messages were silently dropped
- Restore `print()` for the informational output of these two user-facing functions, keeping `logger.error` for error paths

## Test plan
- [x] `print_raster_info` on a GeoTIFF prints driver, dimensions, bands, dtype, CRS, bounds, resolution, nodata, and band statistics
- [x] `print_vector_info` on a GeoJSON prints driver, feature count, geometry types, CRS, bounds, and attribute statistics
- [x] `pre-commit run --all-files` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dataset information output now appears directly in the console when viewing raster and vector details.
  * Band and attribute statistics continue to display with the same formatting, improving consistency in command-line output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->