### PR TITLE
chore: bump qgis plugin to 1.6.1 and skip existing files on PyPI upload

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,4 +27,4 @@ jobs:
                   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
               run: |
                   python -m build
-                  twine upload dist/*
+                  twine upload --skip-existing dist/*

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.6.0
+version=1.6.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 


### PR DESCRIPTION
## Summary
- Bump QGIS plugin version to 1.6.1 so the v0.41.1 release can publish to plugins.qgis.org (the previous release attempt was rejected because 1.6.0 already exists there)
- Add --skip-existing to the twine upload in the pypi workflow so re-created releases do not fail on files already published to PyPI

## Test plan
- [x] pre-commit passes
- [ ] Recreate the v0.41.1 release and confirm both the pypi and publish workflows succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin version to **1.6.1**.
* **Bug Fixes**
  * Improved release publishing so already-uploaded distribution files are skipped, reducing failed or duplicate upload attempts during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->