### PR TITLE
fix: QGIS plugin install failures on paths with spaces and NumPy skew

### DIFF
--- a/qgis_plugin/geoai/core/diagnostics.py
+++ b/qgis_plugin/geoai/core/diagnostics.py
@@ -72,6 +72,7 @@ def generate_diagnostics_report() -> str:
         f"- Python version: `{_value(qgis_info.get('python_version'))}`",
         f"- Python executable: `{_value(qgis_info.get('python_executable'))}`",
         f"- Python prefix: `{_value(qgis_info.get('python_prefix'))}`",
+        f"- NumPy loaded in QGIS: `{_value(qgis_info.get('numpy_version'))}`",
         "",
         "## Operating System",
         "",
@@ -127,6 +128,27 @@ def _get_plugin_info() -> Dict[str, str]:
     return {"path": plugin_dir, "version": version}
 
 
+def _get_qgis_numpy_version() -> str:
+    """Report the NumPy already loaded in the QGIS process.
+
+    The package table is collected with the venv's Python, so it only ever
+    shows the venv's NumPy. When QGIS bundles an older NumPy, that one wins
+    ``sys.modules`` and breaks in-process imports of venv packages (issues
+    #688 and #854) while the report still looks healthy. Record it separately
+    so the skew is visible.
+
+    Returns:
+        The NumPy version string, "Not loaded", or "Unknown".
+    """
+    numpy_module = sys.modules.get("numpy")
+    if numpy_module is None:
+        try:
+            import numpy as numpy_module
+        except Exception:
+            return "Not loaded"
+    return str(getattr(numpy_module, "__version__", "Unknown"))
+
+
 def _get_qgis_info() -> Dict[str, str]:
     try:
         from qgis.core import Qgis
@@ -140,6 +162,7 @@ def _get_qgis_info() -> Dict[str, str]:
         "python_version": sys.version.replace("\n", " "),
         "python_executable": sys.executable,
         "python_prefix": sys.prefix,
+        "numpy_version": _get_qgis_numpy_version(),
     }
 
 

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -3080,13 +3080,11 @@ def install_dependencies(
                         or "Return code {}".format(result.returncode)
                     )
                     _log(
-                        "Failed to install {}: {}".format(
-                            package_spec, error_msg[:500]
-                        ),
+                        "Failed to install {}: {}".format(package_spec, error_msg),
                         Qgis.Critical,
                     )
                     install_failed = True
-                    install_error_msg = error_msg
+                    install_error_msg = _truncate_error(error_msg)
                     last_returncode = result.returncode
 
             except subprocess.TimeoutExpired:
@@ -3200,7 +3198,7 @@ def install_dependencies(
 
             if install_failed:
                 _log(
-                    "pip error output: {}".format(install_error_msg[:500]),
+                    "pip error output: {}".format(install_error_msg),
                     Qgis.Critical,
                 )
                 if _looks_like_resolution_conflict(install_error_msg):
@@ -3499,7 +3497,7 @@ def install_dependencies(
                     _classify_batch_error(error_output, batch_specs) or "dependencies"
                 )
                 _log(
-                    "Batch install failed: {}".format(error_output[:500]),
+                    "Batch install failed: {}".format(error_output),
                     Qgis.Critical,
                 )
                 if _looks_like_resolution_conflict(error_output):

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -632,6 +632,11 @@ _INSECURE_PACKAGE_HOSTS = (
 
 _TORCH_DISTRIBUTIONS = ("torch", "torchvision")
 
+# Characters of installer output kept in a user-facing error message. Large
+# enough that uv's nested "Caused by:" chain survives; the message is also
+# written to the QGIS log in full.
+_ERROR_DETAIL_LIMIT = 1200
+
 # When a uv install also points at the PyTorch wheel index via
 # ``--extra-index-url``, uv defaults to the "first-index" strategy and only
 # considers a package on the first index that lists it. The PyTorch index
@@ -675,6 +680,31 @@ def _is_hash_mismatch(output: str) -> bool:
     """
     output_lower = output.lower()
     return "do not match the hashes" in output_lower or "hash mismatch" in output_lower
+
+
+def _truncate_error(output: str, limit: int = _ERROR_DETAIL_LIMIT) -> str:
+    """Shorten installer output while keeping both ends of the message.
+
+    Installer failures put the headline at the start and the actual cause at
+    the end (uv nests it under ``Caused by:``). A plain head slice drops the
+    cause, so keep a head and a tail when the output is too long.
+
+    Args:
+        output: Raw stdout/stderr from the installer.
+        limit: Maximum number of characters to keep.
+
+    Returns:
+        The output, elided in the middle if it exceeds ``limit``.
+    """
+    text = (output or "").strip()
+    if len(text) <= limit:
+        return text
+
+    marker = "\n[...]\n"
+    keep = limit - len(marker)
+    head = keep // 2
+    tail = keep - head
+    return text[:head].rstrip() + marker + text[-tail:].lstrip()
 
 
 def _get_pip_ssl_flags() -> List[str]:
@@ -1101,6 +1131,58 @@ def venv_exists(venv_dir: str = None) -> bool:
         venv_dir = VENV_DIR
     python_path = get_venv_python_path(venv_dir)
     return os.path.exists(python_path)
+
+
+def venv_python_works(venv_dir: str = None) -> bool:
+    """Check that the venv interpreter exists *and* actually runs.
+
+    ``venv_exists`` only stats the executable, so a venv left half-created by
+    an interrupted install (or with its interpreter quarantined by antivirus)
+    looks healthy and is reused forever. uv then fails with "Failed to inspect
+    Python interpreter", which no reinstall can clear. See issue #850.
+
+    Args:
+        venv_dir: Optional venv directory path. Uses VENV_DIR if None.
+
+    Returns:
+        True if the interpreter runs successfully.
+    """
+    if not venv_exists(venv_dir):
+        return False
+
+    python_path = get_venv_python_path(venv_dir)
+    try:
+        result = subprocess.run(
+            [python_path, "-c", "import sys; sys.exit(0)"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=_get_clean_env_for_venv(),
+            **_get_subprocess_kwargs(),
+        )
+    except subprocess.TimeoutExpired:
+        # A slow first launch (antivirus scanning a fresh interpreter) is not
+        # proof of breakage, and the caller reacts by deleting the venv. Keep
+        # it: a real fault resurfaces as an install error with full output.
+        _log(
+            "Venv interpreter check timed out; assuming it is usable",
+            Qgis.Warning,
+        )
+        return True
+    except (OSError, subprocess.SubprocessError) as e:
+        _log("Venv interpreter is not runnable: {}".format(e), Qgis.Warning)
+        return False
+
+    if result.returncode != 0:
+        _log(
+            "Venv interpreter exited with code {}: {}".format(
+                result.returncode,
+                _truncate_error(result.stderr or result.stdout or ""),
+            ),
+            Qgis.Warning,
+        )
+        return False
+    return True
 
 
 def ensure_venv_packages_available() -> bool:
@@ -1938,7 +2020,7 @@ def create_venv(
             )
             _log(f"Failed to create venv: {error_msg}", Qgis.Critical)
             _cleanup_partial_venv(venv_dir)
-            return False, f"Failed to create venv: {error_msg[:200]}"
+            return False, f"Failed to create venv: {_truncate_error(error_msg)}"
 
     except subprocess.TimeoutExpired:
         _log("Virtual environment creation timed out", Qgis.Critical)
@@ -2471,6 +2553,56 @@ def _get_installed_torch_constraints(
     return constraints
 
 
+def _build_constraint_args(
+    constraints_file: str,
+    subprocess_kwargs: dict,
+    use_uv: bool,
+) -> List[str]:
+    """Build the ``--constraint`` flag for an installer command.
+
+    uv splits the value of ``--constraint`` on whitespace so that
+    ``UV_CONSTRAINT`` can name several files, which shreds an absolute path
+    under a home directory containing a space (``C:\\Users\\Louis Roy\\...``)
+    into separate, bogus file names. See issue #853.
+
+    The constraints file is written into ``CACHE_DIR`` and installs run with
+    ``cwd=CACHE_DIR``, so the bare file name resolves and can never contain a
+    space. pip does not split, so it keeps the unambiguous absolute path.
+
+    Args:
+        constraints_file: Absolute path to the constraints file.
+        subprocess_kwargs: Kwargs the installer runs with; supplies ``cwd``.
+        use_uv: True when the command is a uv invocation.
+
+    Returns:
+        Constraint flag and value, or an empty list if no safe value exists.
+    """
+    if not use_uv:
+        return ["--constraint", constraints_file]
+
+    cwd = (subprocess_kwargs or {}).get("cwd")
+    if cwd:
+        try:
+            relative = os.path.relpath(constraints_file, cwd)
+        except ValueError:  # Different drive on Windows.
+            relative = None
+        if relative and not any(c.isspace() for c in relative):
+            return ["--constraint", relative]
+
+    if not any(c.isspace() for c in constraints_file):
+        return ["--constraint", constraints_file]
+
+    # Constraints only pin already-installed torch builds, so dropping them is
+    # a resolution risk, not a failure; passing a value uv would mis-split is.
+    _log(
+        "Skipping torch constraints: no whitespace-free path for {}".format(
+            constraints_file
+        ),
+        Qgis.Warning,
+    )
+    return []
+
+
 def _write_constraints_file(constraints: List[str]) -> Optional[str]:
     """Write temporary pip constraints for dependency installation.
 
@@ -2971,7 +3103,7 @@ def install_dependencies(
                 )
                 install_failed = True
                 install_error_msg = "Error installing {}: {}".format(
-                    package_name, str(e)[:200]
+                    package_name, _truncate_error(str(e))
                 )
 
             # CUDA -> CPU fallback
@@ -3050,7 +3182,7 @@ def install_dependencies(
                         cpu_err = cpu_result.stderr or cpu_result.stdout or ""
                         install_error_msg = (
                             "CUDA and CPU install both failed for {}: {}".format(
-                                package_name, cpu_err[:200]
+                                package_name, _truncate_error(cpu_err)
                             )
                         )
                 except subprocess.TimeoutExpired:
@@ -3062,7 +3194,7 @@ def install_dependencies(
                 except Exception as e:
                     install_error_msg = (
                         "CUDA and CPU install both failed for {}: {}".format(
-                            package_name, str(e)[:200]
+                            package_name, _truncate_error(str(e))
                         )
                     )
 
@@ -3117,9 +3249,7 @@ def install_dependencies(
                     )
                 return (
                     False,
-                    "Failed to install {}: {}".format(
-                        package_name, install_error_msg[:200]
-                    ),
+                    "Failed to install {}: {}".format(package_name, install_error_msg),
                 )
 
     # -- Phase B: Batch install remaining packages ----------------------------
@@ -3140,7 +3270,9 @@ def install_dependencies(
             )
             constraints_file = _write_constraints_file(torch_constraints)
             if constraints_file:
-                constraint_args = ["--constraint", constraints_file]
+                constraint_args = _build_constraint_args(
+                    constraints_file, subprocess_kwargs, use_uv
+                )
                 if _cuda_index_for_batch:
                     torch_index_args = [
                         "--extra-index-url",
@@ -3148,11 +3280,12 @@ def install_dependencies(
                             _cuda_index_for_batch
                         ),
                     ]
-                _log(
-                    "Constraining batch install to existing PyTorch packages: "
-                    "{}".format(", ".join(torch_constraints)),
-                    Qgis.Info,
-                )
+                if constraint_args:
+                    _log(
+                        "Constraining batch install to existing PyTorch packages: "
+                        "{}".format(", ".join(torch_constraints)),
+                        Qgis.Info,
+                    )
         _log(
             "Installing {} packages in batch: {}".format(
                 len(batch_specs), ", ".join(batch_specs)
@@ -3414,7 +3547,9 @@ def install_dependencies(
                     )
                 return (
                     False,
-                    "Failed to install {}: {}".format(failed_pkg, error_output[:200]),
+                    "Failed to install {}: {}".format(
+                        failed_pkg, _truncate_error(error_output)
+                    ),
                 )
 
         except subprocess.TimeoutExpired:
@@ -3422,7 +3557,9 @@ def install_dependencies(
             return False, "Dependency installation timed out"
         except Exception as e:
             _log("Exception during batch install: {}".format(e), Qgis.Critical)
-            return False, "Error installing dependencies: {}".format(str(e)[:200])
+            return False, "Error installing dependencies: {}".format(
+                _truncate_error(str(e))
+            )
         finally:
             _remove_temp_file(constraints_file)
 
@@ -3560,9 +3697,7 @@ def verify_venv(
             )
 
             if result.returncode != 0:
-                error_detail = (
-                    result.stderr[:300] if result.stderr else result.stdout[:300]
-                )
+                error_detail = _truncate_error(result.stderr or result.stdout or "")
                 _log(
                     "Package {} verification failed: {}".format(
                         package_name, error_detail
@@ -3578,7 +3713,7 @@ def verify_venv(
                     optional_failures.append(package_name)
                     continue
                 return False, "Package {} is broken: {}".format(
-                    package_name, error_detail[:200]
+                    package_name, error_detail
                 )
 
         except subprocess.TimeoutExpired:
@@ -3598,9 +3733,7 @@ def verify_venv(
                     **subprocess_kwargs,
                 )
                 if result.returncode != 0:
-                    error_detail = (
-                        result.stderr[:300] if result.stderr else result.stdout[:300]
-                    )
+                    error_detail = _truncate_error(result.stderr or result.stdout or "")
                     if _is_optional_verify_package(package_name):
                         _log(
                             "Package {} verification failed on retry but is optional "
@@ -3610,7 +3743,7 @@ def verify_venv(
                         optional_failures.append(package_name)
                         continue
                     return False, "Package {} is broken: {}".format(
-                        package_name, error_detail[:200]
+                        package_name, error_detail
                     )
             except subprocess.TimeoutExpired:
                 if _is_optional_verify_package(package_name):
@@ -4160,11 +4293,25 @@ def create_venv_and_install(
             progress_callback(13, "uv package installer ready")
 
     # Step 2: Create venv (13-18%)
+    reusable_venv = False
     if venv_exists():
-        _log("Virtual environment already exists", Qgis.Info)
         if progress_callback:
-            progress_callback(18, "Virtual environment ready")
-    else:
+            progress_callback(15, "Checking virtual environment...")
+        reusable_venv = venv_python_works()
+        if reusable_venv:
+            _log("Virtual environment already exists", Qgis.Info)
+            if progress_callback:
+                progress_callback(18, "Virtual environment ready")
+        else:
+            _log(
+                "Existing virtual environment is broken; recreating it",
+                Qgis.Warning,
+            )
+            if progress_callback:
+                progress_callback(15, "Repairing virtual environment...")
+            _cleanup_partial_venv(VENV_DIR)
+
+    if not reusable_venv:
         success, msg = create_venv(progress_callback=progress_callback)
         if not success:
             return False, msg

--- a/qgis_plugin/geoai/core/venv_manager.py
+++ b/qgis_plugin/geoai/core/venv_manager.py
@@ -3178,18 +3178,36 @@ def install_dependencies(
                         _cuda_fell_back = True
                     else:
                         cpu_err = cpu_result.stderr or cpu_result.stdout or ""
+                        _log(
+                            "Failed to install {} (CPU fallback): {}".format(
+                                package_spec, cpu_err
+                            ),
+                            Qgis.Critical,
+                        )
                         install_error_msg = (
                             "CUDA and CPU install both failed for {}: {}".format(
                                 package_name, _truncate_error(cpu_err)
                             )
                         )
                 except subprocess.TimeoutExpired:
+                    _log(
+                        "Installation of {} (CPU fallback) timed out".format(
+                            package_spec
+                        ),
+                        Qgis.Critical,
+                    )
                     install_error_msg = (
                         "CUDA and CPU install both timed out for {}".format(
                             package_name
                         )
                     )
                 except Exception as e:
+                    _log(
+                        "Exception installing {} (CPU fallback): {}".format(
+                            package_spec, e
+                        ),
+                        Qgis.Critical,
+                    )
                     install_error_msg = (
                         "CUDA and CPU install both failed for {}: {}".format(
                             package_name, _truncate_error(str(e))

--- a/qgis_plugin/geoai/dialogs/samgeo.py
+++ b/qgis_plugin/geoai/dialogs/samgeo.py
@@ -60,8 +60,34 @@ from .._pkg_resources_compat import ensure_pkg_resources
 
 
 def _use_samgeo_subprocess() -> bool:
-    """Use subprocess SamGeo on Windows to avoid QGIS/PyTorch DLL conflicts."""
-    return os.name == "nt"
+    """Decide whether to run SamGeo in the managed venv subprocess.
+
+    Importing the managed venv's packages into the QGIS process is unsafe on
+    every platform, not just Windows. QGIS ships its own NumPy and imports it
+    at startup, so prepending the venv's site-packages to ``sys.path`` cannot
+    displace it: the venv's SciPy/scikit stack (built for NumPy 2) then runs
+    against QGIS's NumPy 1.x and fails on NumPy-2-only names --
+    ``numpy.lib.array_utils`` (issue #688) and ``np.long`` reached via
+    ``scipy.sparse`` (issue #854). This was gated to Windows, where the
+    subprocess is also required for an unrelated PyTorch DLL conflict, which
+    left macOS and Linux exposed to the skew.
+
+    Windows always uses the subprocess because of that DLL conflict. Elsewhere
+    it is used whenever the managed venv exists, which is exactly when the
+    version skew is possible. Without a managed venv there is nothing to skew
+    against -- SamGeo can only come from the interpreter running QGIS -- so the
+    in-process path stays available for users who launch QGIS from an
+    environment that already provides SamGeo.
+
+    Returns:
+        True if model loading and inference should run in a subprocess.
+    """
+    if os.name == "nt":
+        return True
+
+    from ..core.venv_manager import venv_exists
+
+    return venv_exists()
 
 
 class SamGeoModelLoadWorker(QThread):

--- a/qgis_plugin/geoai/workers/samgeo_worker.py
+++ b/qgis_plugin/geoai/workers/samgeo_worker.py
@@ -148,12 +148,50 @@ def _supported_methods_for(sam) -> set[str]:
     return methods
 
 
+def _resolve_device(device: Any) -> Any:
+    """Pick an accelerator for automatic device selection.
+
+    The QGIS process used to choose the device, but it can only inspect its own
+    torch, which may be missing or a different build from the venv's. This
+    process owns the torch that actually runs the model, so resolve here. MPS
+    is checked before CUDA to match the previous in-process behavior.
+
+    Args:
+        device: Requested device, or None/"auto" to detect one.
+
+    Returns:
+        A concrete device string, or the caller's value if it was explicit.
+    """
+    if device and device != "auto":
+        return device
+
+    try:
+        import torch
+    except Exception:
+        return None
+
+    try:
+        mps = getattr(torch.backends, "mps", None)
+        if mps is not None and mps.is_available():
+            return "mps"
+    except Exception:
+        pass
+
+    try:
+        if torch.cuda.is_available():
+            return "cuda"
+    except Exception:
+        pass
+
+    return "cpu"
+
+
 def _handle_init(req: dict) -> Any:
     shim_installed = _ensure_pkg_resources_shim()
 
     model_version = str(req.get("model_version") or "")
     backend = req.get("backend")
-    device = req.get("device")
+    device = _resolve_device(req.get("device"))
     confidence = req.get("confidence")
     enable_interactive = bool(req.get("enable_interactive", False))
 

--- a/qgis_plugin/tests/test_diagnostics.py
+++ b/qgis_plugin/tests/test_diagnostics.py
@@ -245,3 +245,41 @@ def test_diagnostics_torch_runtime_probe_bootstraps_windows_torch_dll_dirs():
 
     assert "add_dll_directory" in script
     assert "import torch" in script
+
+
+def test_qgis_numpy_version_reports_already_loaded_module(monkeypatch):
+    """The package table shows the venv's NumPy, so QGIS's must be separate."""
+    import sys
+    import types
+
+    fake_numpy = types.ModuleType("numpy")
+    fake_numpy.__version__ = "1.26.4"
+    monkeypatch.setitem(sys.modules, "numpy", fake_numpy)
+
+    assert diagnostics._get_qgis_numpy_version() == "1.26.4"
+
+
+def test_qgis_numpy_version_when_numpy_is_absent(monkeypatch):
+    import builtins
+    import sys
+
+    monkeypatch.delitem(sys.modules, "numpy", raising=False)
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "numpy":
+            raise ImportError("no numpy")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert diagnostics._get_qgis_numpy_version() == "Not loaded"
+
+
+def test_diagnostics_report_includes_qgis_numpy(monkeypatch):
+    """Regression test for issue #854: the NumPy skew must be visible."""
+    monkeypatch.setattr(diagnostics, "_get_qgis_numpy_version", lambda: "1.26.4")
+
+    report = diagnostics.generate_diagnostics_report()
+
+    assert "- NumPy loaded in QGIS: `1.26.4`" in report

--- a/qgis_plugin/tests/test_samgeo_subprocess_gate.py
+++ b/qgis_plugin/tests/test_samgeo_subprocess_gate.py
@@ -1,0 +1,97 @@
+"""Tests for keeping the managed venv's SamGeo out of the QGIS process.
+
+QGIS imports its own NumPy at startup, so the venv's NumPy-2-era SciPy/scikit
+stack breaks when imported in-process (issues #688 and #854). These cover the
+gate that routes model loading into the venv subprocess instead.
+"""
+
+import sys
+import types
+
+from geoai.dialogs import samgeo
+from geoai.workers import samgeo_worker
+
+
+def test_use_subprocess_on_windows_without_venv(monkeypatch):
+    """Windows needs the subprocess for the PyTorch DLL conflict regardless."""
+    monkeypatch.setattr(samgeo.os, "name", "nt")
+
+    assert samgeo._use_samgeo_subprocess() is True
+
+
+def test_use_subprocess_on_posix_when_venv_exists(monkeypatch):
+    """Regression test for issue #854: macOS/Linux must not import in-process."""
+    from geoai.core import venv_manager
+
+    monkeypatch.setattr(samgeo.os, "name", "posix")
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: True)
+
+    assert samgeo._use_samgeo_subprocess() is True
+
+
+def test_in_process_on_posix_without_venv(monkeypatch):
+    """No managed venv means no version skew, so keep the in-process path."""
+    from geoai.core import venv_manager
+
+    monkeypatch.setattr(samgeo.os, "name", "posix")
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: False)
+
+    assert samgeo._use_samgeo_subprocess() is False
+
+
+def _fake_torch(mps_available=False, cuda_available=False):
+    torch = types.ModuleType("torch")
+    backends = types.ModuleType("torch.backends")
+    mps = types.ModuleType("torch.backends.mps")
+    mps.is_available = lambda: mps_available
+    backends.mps = mps
+    torch.backends = backends
+    cuda = types.SimpleNamespace(is_available=lambda: cuda_available)
+    torch.cuda = cuda
+    return torch
+
+
+def _install_torch(monkeypatch, torch):
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch.backends", torch.backends)
+
+
+def test_resolve_device_prefers_mps(monkeypatch):
+    """The dialog used to pick MPS in auto mode; the worker must keep doing so."""
+    _install_torch(monkeypatch, _fake_torch(mps_available=True, cuda_available=True))
+
+    assert samgeo_worker._resolve_device("auto") == "mps"
+    assert samgeo_worker._resolve_device(None) == "mps"
+
+
+def test_resolve_device_falls_back_to_cuda(monkeypatch):
+    _install_torch(monkeypatch, _fake_torch(mps_available=False, cuda_available=True))
+
+    assert samgeo_worker._resolve_device("auto") == "cuda"
+
+
+def test_resolve_device_falls_back_to_cpu(monkeypatch):
+    _install_torch(monkeypatch, _fake_torch(mps_available=False, cuda_available=False))
+
+    assert samgeo_worker._resolve_device("auto") == "cpu"
+
+
+def test_resolve_device_respects_explicit_choice(monkeypatch):
+    _install_torch(monkeypatch, _fake_torch(mps_available=True, cuda_available=True))
+
+    assert samgeo_worker._resolve_device("cpu") == "cpu"
+    assert samgeo_worker._resolve_device("cuda") == "cuda"
+
+
+def test_resolve_device_survives_broken_torch(monkeypatch):
+    """Detection must not turn an import problem into a device crash."""
+    torch = _fake_torch()
+
+    def boom():
+        raise RuntimeError("mps probe failed")
+
+    torch.backends.mps.is_available = boom
+    torch.cuda.is_available = boom
+    _install_torch(monkeypatch, torch)
+
+    assert samgeo_worker._resolve_device("auto") == "cpu"

--- a/qgis_plugin/tests/test_venv_manager.py
+++ b/qgis_plugin/tests/test_venv_manager.py
@@ -579,3 +579,52 @@ def test_single_package_install_failure_message_is_bounded(tmp_path, monkeypatch
     assert len(message) < 2000
     assert "could not build wheel" in message
     assert message.endswith("Caused by: boom")
+
+
+def test_cpu_fallback_failure_logs_full_output(tmp_path, monkeypatch):
+    """The CPU fallback is issue #850's path, so its raw output must be logged."""
+    from geoai.core import uv_manager
+
+    logged = []
+    huge_stderr = "error: no matching distribution\n" + ("z" * 40000) + "\nCaused by: 1"
+
+    def fake_run_pip_install(**kwargs):
+        # CUDA attempt fails, then the CPU fallback fails too.
+        return venv_manager._PipResult(1, "", huge_stderr)
+
+    monkeypatch.setattr(uv_manager, "uv_exists", lambda: False)
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager, "get_venv_python_path", lambda _venv_dir: "python"
+    )
+    monkeypatch.setattr(venv_manager, "_get_clean_env_for_venv", lambda: {})
+    monkeypatch.setattr(venv_manager, "_get_subprocess_kwargs", lambda: {})
+    monkeypatch.setattr(
+        venv_manager, "_get_required_packages", lambda: [("torch", ">=2.0.0")]
+    )
+    monkeypatch.setattr(
+        venv_manager,
+        "detect_nvidia_gpu",
+        lambda: (True, {"compute_cap": 12.0, "driver_version": "572.76"}),
+    )
+    monkeypatch.setattr(venv_manager, "_select_cuda_index", lambda _gpu_info: "cu128")
+    monkeypatch.setattr(venv_manager, "_run_pip_install", fake_run_pip_install)
+    monkeypatch.setattr(
+        venv_manager.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(venv_manager, "_log", lambda msg, *a, **k: logged.append(msg))
+
+    ok, message = venv_manager.install_dependencies(
+        venv_dir=str(tmp_path / "venv"),
+        cuda_enabled=True,
+    )
+
+    assert ok is False
+    # The user-facing message stays bounded...
+    assert len(message) < 2000
+    assert "CUDA and CPU install both failed for torch" in message
+    # ...but the log keeps the CPU fallback output in full for diagnosis.
+    fallback_logs = [m for m in logged if "(CPU fallback)" in m]
+    assert any(huge_stderr in m for m in fallback_logs), "full CPU output not logged"

--- a/qgis_plugin/tests/test_venv_manager.py
+++ b/qgis_plugin/tests/test_venv_manager.py
@@ -338,3 +338,204 @@ def test_verify_venv_treats_macos_sam3_import_failure_as_optional(monkeypatch):
     assert ready is True
     assert message == "Virtual environment ready (optional packages unavailable: sam3)"
     assert calls == ["torch", "sam3", "geoai-py"]
+
+
+def test_build_constraint_args_uses_relative_path_for_uv(tmp_path):
+    """uv splits --constraint on whitespace, so the value must have none."""
+    cache_dir = tmp_path / "CPDO USER" / ".qgis_geoai"
+    cache_dir.mkdir(parents=True)
+    constraints_file = str(cache_dir / "geoai_torch_constraints_ab.txt")
+
+    args = venv_manager._build_constraint_args(
+        constraints_file,
+        {"cwd": str(cache_dir)},
+        use_uv=True,
+    )
+
+    assert args == ["--constraint", "geoai_torch_constraints_ab.txt"]
+    assert not any(c.isspace() for c in args[1])
+
+
+def test_build_constraint_args_keeps_absolute_path_for_pip(tmp_path):
+    """pip does not split the value, so it keeps the unambiguous path."""
+    cache_dir = tmp_path / "Louis Roy" / ".qgis_geoai"
+    cache_dir.mkdir(parents=True)
+    constraints_file = str(cache_dir / "constraints.txt")
+
+    args = venv_manager._build_constraint_args(
+        constraints_file,
+        {"cwd": str(cache_dir)},
+        use_uv=False,
+    )
+
+    assert args == ["--constraint", constraints_file]
+
+
+def test_build_constraint_args_drops_constraint_when_path_has_space(tmp_path):
+    """A value uv would mis-split is worse than no constraint at all."""
+    constraints_file = str(tmp_path / "Louis Roy" / "constraints.txt")
+
+    args = venv_manager._build_constraint_args(
+        constraints_file,
+        {"cwd": str(tmp_path / "elsewhere dir")},
+        use_uv=True,
+    )
+
+    assert args == []
+
+
+def test_cuda_batch_install_constraint_arg_is_whitespace_free_for_uv(
+    tmp_path, monkeypatch
+):
+    """Regression test for issue #853: home directories containing a space."""
+    from geoai.core import uv_manager
+
+    calls = []
+    cache_dir = tmp_path / "Louis Roy Byaruhanga" / ".qgis_geoai"
+    cache_dir.mkdir(parents=True)
+    constraints_path = str(cache_dir / "geoai_torch_constraints_xy.txt")
+
+    def fake_run(cmd, *args, **kwargs):
+        script = cmd[-1]
+        if "torch.version.cuda" in script:
+            return subprocess.CompletedProcess(cmd, 0, stdout="12.8\n", stderr="")
+        if "metadata.version('torch')" in script:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="2.12.0+cu128\n", stderr=""
+            )
+        if "metadata.version('torchvision')" in script:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="0.27.0+cu128\n", stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    def fake_run_pip_install(**kwargs):
+        calls.append(kwargs)
+        return venv_manager._PipResult(0, "ok", "")
+
+    monkeypatch.setattr(uv_manager, "uv_exists", lambda: True)
+    monkeypatch.setattr(uv_manager, "get_uv_path", lambda: "uv")
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager, "get_venv_python_path", lambda _venv_dir: "python"
+    )
+    monkeypatch.setattr(venv_manager, "_get_clean_env_for_venv", lambda: {})
+    monkeypatch.setattr(
+        venv_manager, "_get_subprocess_kwargs", lambda: {"cwd": str(cache_dir)}
+    )
+    monkeypatch.setattr(
+        venv_manager,
+        "_get_required_packages",
+        lambda: [("torch", ">=2.0.0"), ("geoai-py", ">=0.39.0")],
+    )
+    monkeypatch.setattr(
+        venv_manager,
+        "detect_nvidia_gpu",
+        lambda: (True, {"compute_cap": 12.0, "driver_version": "572.76"}),
+    )
+    monkeypatch.setattr(venv_manager, "_select_cuda_index", lambda _gpu_info: "cu128")
+    monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
+    monkeypatch.setattr(venv_manager, "_run_pip_install", fake_run_pip_install)
+    monkeypatch.setattr(
+        venv_manager, "_write_constraints_file", lambda _c: constraints_path
+    )
+
+    ok, _message = venv_manager.install_dependencies(
+        venv_dir=str(tmp_path / "venv"),
+        cuda_enabled=True,
+    )
+
+    assert ok is True
+    batch_cmd = calls[-1]["cmd"]
+    assert "--constraint" in batch_cmd
+    value = batch_cmd[batch_cmd.index("--constraint") + 1]
+    assert not any(c.isspace() for c in value)
+    assert value == "geoai_torch_constraints_xy.txt"
+
+
+def test_truncate_error_keeps_head_and_tail():
+    """uv nests the real cause at the end, so a head-only slice loses it."""
+    output = "headline error\n" + ("x" * 5000) + "\nCaused by: exit status 1"
+
+    truncated = venv_manager._truncate_error(output, limit=200)
+
+    assert len(truncated) <= 200
+    assert truncated.startswith("headline error")
+    assert truncated.endswith("Caused by: exit status 1")
+
+
+def test_truncate_error_returns_short_output_unchanged():
+    assert venv_manager._truncate_error("  boom  ") == "boom"
+
+
+def test_venv_python_works_false_when_interpreter_fails(tmp_path, monkeypatch):
+    """Regression test for issue #850: an unrunnable interpreter is not healthy."""
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager, "get_venv_python_path", lambda _venv_dir=None: "python"
+    )
+    monkeypatch.setattr(venv_manager, "_get_clean_env_for_venv", lambda: {})
+    monkeypatch.setattr(venv_manager, "_get_subprocess_kwargs", lambda: {})
+    monkeypatch.setattr(
+        venv_manager.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 1, stdout="", stderr="boom"),
+    )
+
+    assert venv_manager.venv_python_works(str(tmp_path)) is False
+
+
+def test_venv_python_works_false_when_interpreter_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: False)
+
+    assert venv_manager.venv_python_works(str(tmp_path)) is False
+
+
+def test_venv_python_works_true_when_interpreter_runs(tmp_path, monkeypatch):
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager, "get_venv_python_path", lambda _venv_dir=None: "python"
+    )
+    monkeypatch.setattr(venv_manager, "_get_clean_env_for_venv", lambda: {})
+    monkeypatch.setattr(venv_manager, "_get_subprocess_kwargs", lambda: {})
+    monkeypatch.setattr(
+        venv_manager.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 0, stdout="", stderr=""),
+    )
+
+    assert venv_manager.venv_python_works(str(tmp_path)) is True
+
+
+def test_venv_python_works_true_on_timeout(tmp_path, monkeypatch):
+    """A slow launch must not trigger deletion of a multi-GB healthy venv."""
+
+    def fake_run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="python", timeout=60)
+
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager, "get_venv_python_path", lambda _venv_dir=None: "python"
+    )
+    monkeypatch.setattr(venv_manager, "_get_clean_env_for_venv", lambda: {})
+    monkeypatch.setattr(venv_manager, "_get_subprocess_kwargs", lambda: {})
+    monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
+
+    assert venv_manager.venv_python_works(str(tmp_path)) is True
+
+
+def test_venv_python_works_false_when_interpreter_cannot_launch(tmp_path, monkeypatch):
+    """OSError is how a missing python3XX.dll surfaces (issue #850)."""
+
+    def fake_run(*_args, **_kwargs):
+        raise OSError("dll load failed")
+
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager, "get_venv_python_path", lambda _venv_dir=None: "python"
+    )
+    monkeypatch.setattr(venv_manager, "_get_clean_env_for_venv", lambda: {})
+    monkeypatch.setattr(venv_manager, "_get_subprocess_kwargs", lambda: {})
+    monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
+
+    assert venv_manager.venv_python_works(str(tmp_path)) is False

--- a/qgis_plugin/tests/test_venv_manager.py
+++ b/qgis_plugin/tests/test_venv_manager.py
@@ -539,3 +539,43 @@ def test_venv_python_works_false_when_interpreter_cannot_launch(tmp_path, monkey
     monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
 
     assert venv_manager.venv_python_works(str(tmp_path)) is False
+
+
+def test_single_package_install_failure_message_is_bounded(tmp_path, monkeypatch):
+    """Raw installer output must not reach the UI dialog unbounded."""
+    from geoai.core import uv_manager
+
+    huge_stderr = "error: could not build wheel\n" + ("y" * 50000) + "\nCaused by: boom"
+
+    def fake_run_pip_install(**_kwargs):
+        return venv_manager._PipResult(1, "", huge_stderr)
+
+    monkeypatch.setattr(uv_manager, "uv_exists", lambda: False)
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda _venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager, "get_venv_python_path", lambda _venv_dir: "python"
+    )
+    monkeypatch.setattr(venv_manager, "_get_clean_env_for_venv", lambda: {})
+    monkeypatch.setattr(venv_manager, "_get_subprocess_kwargs", lambda: {})
+    monkeypatch.setattr(
+        venv_manager, "_get_required_packages", lambda: [("torch", ">=2.0.0")]
+    )
+    monkeypatch.setattr(
+        venv_manager,
+        "detect_nvidia_gpu",
+        lambda: (True, {"compute_cap": 3.0, "driver_version": "390.00"}),
+    )
+    # Driver too old: torch installs as a plain package, so a failure returns
+    # the raw stderr directly instead of going through the CPU fallback.
+    monkeypatch.setattr(venv_manager, "_select_cuda_index", lambda _gpu_info: None)
+    monkeypatch.setattr(venv_manager, "_run_pip_install", fake_run_pip_install)
+
+    ok, message = venv_manager.install_dependencies(
+        venv_dir=str(tmp_path / "venv"),
+        cuda_enabled=True,
+    )
+
+    assert ok is False
+    assert len(message) < 2000
+    assert "could not build wheel" in message
+    assert message.endswith("Caused by: boom")


### PR DESCRIPTION
Fixes #850, fixes #853, fixes #854.

All three are QGIS plugin bugs. Each root cause was reproduced against real `uv` / `numpy` / `scipy` before fixing.

## #853 — `Unexpected '[', expected '-c', '-e', '-r' ... at C:\Users\Louis:1:1`

`uv` splits the value of `--constraint` on whitespace so that `UV_CONSTRAINT` can name several files. The torch constraints file lives under `CACHE_DIR` (`~/.qgis_geoai`), so any user whose home contains a space got the path shredded — `C:\Users\Louis Roy Byaruhanga\...` was parsed as a file named `C:\Users\Louis`, which uv then tried to read as a requirements file. Reproduced exactly:

```console
$ uv pip install --constraint '/…/Louis Roy/.qgis_geoai/c.txt' numpy
error: File not found: `/…/Louis`
```

The file is written into `CACHE_DIR` and installs already run with `cwd=CACHE_DIR`, so uv now gets the bare file name, which can never contain a space. pip does not split, so it keeps the unambiguous absolute path. Verified against real uv — the constraint is now honored rather than erroring.

This was a regression from #835, which introduced `--constraint`. It only fires when CUDA is enabled, matching the reporter's "GPU Detected: RTX 3060".

## #850 — `Failed to install torch: ... Failed to inspect Python interpreter`

Two separate problems.

**The root cause was truncated away.** Installer output was sliced to 200 characters, then the composed message was sliced to 200 again, and the 43-character prefix ate into the second slice. uv puts the real cause at the *end*, nested under `Caused by:`, so the exit status never reached the user — which is exactly where the screenshot in the issue cuts off. Errors are now elided in the middle, keeping both ends:

```
Failed to install torch: CUDA and CPU install both failed for torch: error: Failed to inspect
Python interpreter from provided path at `venv_py3.12\Scripts\python.exe`
  Caused by: Querying Python at `C:\Users\CPDO USER\...\python.exe` failed with exit status
  exit status: 3221225781
```

That preserved status is `0xC0000135` (`STATUS_DLL_NOT_FOUND`) — the kind of cause that was being discarded.

**A broken venv was reused forever.** `venv_exists()` only stats the interpreter, so a venv left half-created by an interrupted install (or with its interpreter quarantined by antivirus) looked healthy and no reinstall could clear it. `create_venv_and_install` now runs the interpreter and rebuilds the venv if it does not launch.

Note the relative path in uv's message (`venv_py3.12\Scripts\python.exe`) is a red herring — `--python` is passed absolute; uv renders it relative to `cwd`. I confirmed `--python` does **not** whitespace-split.

⚠️ To be clear about scope: the underlying reason that user's interpreter won't launch is still unknown, because the message that would have identified it was truncated. This makes 850 **diagnosable and self-healing** rather than definitively fixed — the rebuild should clear it, and if it doesn't, the next report will carry the actual cause.

## #854 — `Failed to load model: module 'numpy' has no attribute 'long'`

`np.long` exists in NumPy 2.x, so this isn't a plain NumPy-2 removal. The real chain, reproduced end-to-end:

- QGIS imports its **bundled NumPy 1.26** at startup. Prepending the venv's site-packages to `sys.path` cannot displace an already-imported module, so the venv's NumPy 2.3.5 is never loaded in-process.
- Loading SamGeo in-process pulls in the venv's `sklearn.cluster` → `scipy.sparse` → `scipy/sparse/_sputils.py:17`, which reads `np.long` at **import time** (verified: scipy 1.18).
- `np.long` was removed in NumPy 1.24 and — unlike `np.int`/`np.bool` — was **never added to `__former_attrs__`**, so it raises the bare `module 'numpy' has no attribute 'long'` instead of NumPy's usual helpful message (verified against numpy 1.26.4).

This is the same root cause as #688 (`No module named 'numpy.lib.array_utils'`, QGIS NumPy 1.26.4 vs venv 2.3.5), which was fixed only for the raster→vector step. The subprocess path that avoids it was gated to Windows, where it was added for an *unrelated* PyTorch DLL conflict — leaving macOS and Linux exposed.

The gate now also returns true wherever the managed venv exists, which is exactly when the skew is possible. Without a managed venv there is nothing to skew against (SamGeo can only come from the interpreter running QGIS), so the in-process path stays available for users who launch QGIS from an environment that already provides SamGeo — I deliberately avoided an unconditional `return True`, which would have broken those users, since the subprocess client hard-fails with "GeoAI virtual environment not found".

Automatic device selection moves into the worker, so it uses the torch that actually runs the model rather than the QGIS process's (possibly absent or different) torch. MPS is still preferred over CUDA, matching the previous behavior.

## Diagnostics

The package table is collected with the venv's Python, so #854's report showed `NumPy 2.3.5` while QGIS's NumPy 1.26 was the actual culprit — actively misleading for this class of bug. The report now also records the NumPy loaded in the QGIS process.

## Testing

101 plugin tests pass (22 new). Black and Bandit (`--severity-level medium`, 0 findings) both clean.

The new tests are verified non-vacuous — reverting the #853 fix makes `test_cuda_batch_install_constraint_arg_is_whitespace_free_for_uv` fail. Beyond the unit tests, both #850 and #853 were reproduced and re-verified against real `uv`, and #854's chain against real `numpy`/`scipy`.

One hazard caught during self-review and covered by a test: a venv health-check timeout must **not** be treated as breakage, or a slow first launch under antivirus would delete a healthy multi-GB venv.

Not verified in a live QGIS session — I don't have QGIS 4 with the managed venv here, and #854 in particular depends on a QGIS build that bundles NumPy 1.x. The #854 gate change is the one worth a real-QGIS smoke test on macOS before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Diagnostics now report whether NumPy is loaded in QGIS and its detected version.
  - SamGeo now auto-resolves the inference device at runtime (MPS, then CUDA, then CPU).

- **Bug Fixes**
  - Managed virtual environments are now checked and automatically repaired when broken.
  - Dependency install/verification errors are more readable via improved truncation.
  - Batch installation constraint handling is more reliable, especially with paths containing spaces.
  - SamGeo model loading runs out-of-process on non-Windows when a managed environment is available.

- **Tests**
  - Added/expanded regression tests for diagnostics, venv health, subprocess gating, device resolution, and error/constraint truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->