### PR TITLE
docs: pin pixi QGIS to 3.44 to avoid the 3.42.2 qgz save regression

### DIFF
--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -169,6 +169,16 @@ Open `pixi.toml` in the `geo` directory and replace its contents with the follow
 
 If you have a NVIDIA GPU with CUDA, run `nvidia-smi` to check the CUDA version.
 
+> **Note:** QGIS is pinned to `3.44.*` on purpose. Do not lower it to `3.42.*`:
+> with the dependencies below, that pin resolves to QGIS 3.42.2 (3.42.3 conflicts
+> with the rest of the stack), and 3.42.2 shipped a Windows regression that makes
+> saving any `.qgz` project fail with "Unable to perform zip"
+> ([QGIS #61560](https://github.com/qgis/QGIS/issues/61560), fixed by
+> [QGIS #61567](https://github.com/qgis/QGIS/pull/61567)). qgis.org reissued its
+> 3.42.2 Windows installer with the fix, but conda-forge builds 3.42.2 from the
+> original release, so the broken code is what you get. The bug is in QGIS itself
+> and is unrelated to this plugin.
+
 - For GPU with CUDA 12.x:
 
 ```toml
@@ -183,7 +193,7 @@ cuda = "12.0"
 [dependencies]
 python = "3.12.*"
 pytorch-gpu = ">=2.7.1,<3"
-qgis = "3.42.*"
+qgis = "3.44.*"
 pyqt = "5.15.*"
 geoai = ">=0.27.0"
 segment-geospatial = ">=1.2.0"
@@ -205,7 +215,7 @@ cuda = "13.0"
 [dependencies]
 python = "3.12.*"
 pytorch-gpu = ">=2.7.1,<3"
-qgis = "3.42.*"
+qgis = "3.44.*"
 pyqt = "5.15.*"
 geoai = ">=0.27.0"
 segment-geospatial = ">=1.2.0"
@@ -224,7 +234,7 @@ platforms = ["linux-64", "win-64"]
 [dependencies]
 python = "3.12.*"
 pytorch-cpu = ">=2.7.1,<3"
-qgis = "3.42.*"
+qgis = "3.44.*"
 pyqt = "5.15.*"
 geoai = ">=0.27.0"
 segment-geospatial = ">=1.2.0"

--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -178,6 +178,17 @@ If you have a NVIDIA GPU with CUDA, run `nvidia-smi` to check the CUDA version.
 > 3.42.2 Windows installer with the fix, but conda-forge builds 3.42.2 from the
 > original release, so the broken code is what you get. The bug is in QGIS itself
 > and is unrelated to this plugin.
+>
+> If you already created the environment and hit this, update QGIS in place:
+>
+> ```bash
+> cd geo
+> pixi update qgis
+> ```
+>
+> Check **Help → About** to confirm you are off 3.42.2. Until you can update,
+> save with *Save As* → **QGIS Project File (\*.qgs)**; `.qgs` is uncompressed
+> XML and never touches the zip path, so it is unaffected.
 
 - For GPU with CUDA 12.x:
 

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -115,6 +115,16 @@ Open `pixi.toml` in the `geo` directory and replace its contents with the follow
 
 If you have a NVIDIA GPU with CUDA, run `nvidia-smi` to check the CUDA version.
 
+> **Note:** QGIS is pinned to `3.44.*` on purpose. Do not lower it to `3.42.*`:
+> with the dependencies below, that pin resolves to QGIS 3.42.2 (3.42.3 conflicts
+> with the rest of the stack), and 3.42.2 shipped a Windows regression that makes
+> saving any `.qgz` project fail with "Unable to perform zip"
+> ([QGIS #61560](https://github.com/qgis/QGIS/issues/61560), fixed by
+> [QGIS #61567](https://github.com/qgis/QGIS/pull/61567)). qgis.org reissued its
+> 3.42.2 Windows installer with the fix, but conda-forge builds 3.42.2 from the
+> original release, so the broken code is what you get. The bug is in QGIS itself
+> and is unrelated to this plugin.
+
 - For GPU with CUDA 12.x:
 
 ```toml
@@ -129,7 +139,7 @@ cuda = "12.0"
 [dependencies]
 python = "3.12.*"
 pytorch-gpu = ">=2.7.1,<3"
-qgis = "3.42.*"
+qgis = "3.44.*"
 pyqt = "5.15.*"
 geoai = ">=0.24.0"
 segment-geospatial = ">=1.2.0"
@@ -151,7 +161,7 @@ cuda = "13.0"
 [dependencies]
 python = "3.12.*"
 pytorch-gpu = ">=2.7.1,<3"
-qgis = "3.42.*"
+qgis = "3.44.*"
 pyqt = "5.15.*"
 geoai = ">=0.24.0"
 segment-geospatial = ">=1.2.0"
@@ -169,7 +179,7 @@ platforms = ["linux-64", "win-64"]
 [dependencies]
 python = "3.12.*"
 pytorch-cpu = ">=2.7.1,<3"
-qgis = "3.42.*"
+qgis = "3.44.*"
 pyqt = "5.15.*"
 geoai = ">=0.24.0"
 segment-geospatial = ">=1.2.0"

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -124,6 +124,17 @@ If you have a NVIDIA GPU with CUDA, run `nvidia-smi` to check the CUDA version.
 > 3.42.2 Windows installer with the fix, but conda-forge builds 3.42.2 from the
 > original release, so the broken code is what you get. The bug is in QGIS itself
 > and is unrelated to this plugin.
+>
+> If you already created the environment and hit this, update QGIS in place:
+>
+> ```bash
+> cd geo
+> pixi update qgis
+> ```
+>
+> Check **Help → About** to confirm you are off 3.42.2. Until you can update,
+> save with *Save As* → **QGIS Project File (\*.qgs)**; `.qgs` is uncompressed
+> XML and never touches the zip path, so it is unaffected.
 
 - For GPU with CUDA 12.x:
 


### PR DESCRIPTION
Fixes #851.

## The report

Following the documented pixi setup produces a QGIS that cannot save **any** `.qgz` project — empty or not — failing with `Unable to perform zip`. The reporter noted it works on QGIS installed from qgis.org, and only fails on the pixi install.

## This is not a plugin bug

The reporter confirmed it still happens with the GeoAI plugin **disabled**, and the log entry comes from `QgsArchive`, which is QGIS C++ core with no Python involvement.

QGIS 3.42.2 built `QgsArchive::zip()` on a `QTemporaryFile`, which stays open and blocks the rename on Windows — [QGIS #61560](https://github.com/qgis/QGIS/issues/61560), fixed by [QGIS #61567](https://github.com/qgis/QGIS/pull/61567) ("QTemporaryFile apparently keeps the file open and prevents it's rename on Windows").

I checked the affected range directly against the release tags rather than assuming:

| tag | `QgsArchive::zip()` | |
| --- | --- | --- |
| `final-3_42_0` | plain path | ok |
| `final-3_42_1` | plain path | ok |
| `final-3_42_2` | `QTemporaryFile tmpFilePath(...)` | **affected** |
| `final-3_42_3` | plain path | ok |
| `final-3_44_7` | plain path | ok |

**Only 3.42.2.** qgis.org reissued its 3.42.2 Windows installer with the fix, but conda-forge builds 3.42.2 from the original release — which is exactly why the reporter sees it on pixi and not on the qgis.org download, at the same version number.

## Why our docs are still at fault

The docs pinned `qgis = "3.42.*"`. That *looks* like it would pick the fixed 3.42.3, but it doesn't. With the rest of the documented stack, 3.42.3 is **unsolvable** (libgdal/geos/libprotobuf conflicts reached via `geoai` → `rasterio`), so the solver falls back to precisely the one broken build.

Verified against conda-forge, on `win-64`, with the full documented dependency set:

```
qgis = "3.42.*"        ->  qgis 3.42.2   (the broken build — today, on a fresh solve)
qgis = ">=3.42.3,<3.43" ->  could not solve for environment specs
qgis = "3.44.*"        ->  qgis 3.44.7   (clean)
```

So our recommended `pixi.toml` deterministically produces the bug. My first attempt was to pin `>=3.42.3`; testing showed it breaks the environment outright, which would have been worse than the bug — hence 3.44.

## The fix

Pin `qgis = "3.44.*"` across all three variants in both `qgis_plugin/README.md` and `docs/qgis_plugin.md`, plus a note explaining why it must not be lowered back to `3.42.*`.

Verified every documented variant resolves cleanly, keeping `pyqt = 5.15` and `python = 3.12` exactly as documented:

| variant | platform | result |
| --- | --- | --- |
| GPU / CUDA 12.x + 13.x | win-64 | qgis 3.44.7, pyqt 5.15.11, py 3.12.13, pytorch-gpu 2.10.0 |
| CPU | win-64 | qgis 3.44.7 |
| GPU | linux-64 | qgis 3.44.7 |
| full set incl. `sam3` | win-64 | qgis 3.44.7, sam3 0.1.0.20260515 |

Docs-only; no code paths touched.

## Note for existing users

Bumping the pin only helps new environments. Anyone with an existing `geo` env needs `pixi update qgis` to move off 3.42.2. Until then, saving as `.qgs` (uncompressed XML) avoids the zip path entirely and works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated QGIS plugin setup instructions to pin QGIS to version `3.44.*` (instead of `3.42.*`).
  - Added a clear warning about a Windows regression in QGIS `3.42.2` that can cause `.qgz` saving failures, plus recommended update steps (e.g., updating QGIS in place) and workarounds.
  - Updated the Pixi/TOML example dependency snippets for CUDA 12.x, CUDA 13.x, and CPU to use `3.44.*`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->