### PR TITLE
fix: allow AlphaEarth embeddings for 2017 and 2025, and fix index download

### DIFF
--- a/geoai/embeddings.py
+++ b/geoai/embeddings.py
@@ -29,6 +29,7 @@ Example usage:
 
 import logging
 import os
+import uuid
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -1312,7 +1313,9 @@ def download_google_satellite_embedding(
             response.raise_for_status()
             # Write to a temporary path first so an interrupted download
             # cannot leave a truncated index cached for every later call.
-            tmp_path = f"{index_path}.part"
+            # The unique suffix keeps concurrent downloads from interleaving
+            # chunks into a shared temporary file.
+            tmp_path = f"{index_path}.{uuid.uuid4().hex}.part"
             try:
                 with open(tmp_path, "wb") as f:
                     for chunk in response.iter_content(chunk_size=1024 * 1024):

--- a/geoai/embeddings.py
+++ b/geoai/embeddings.py
@@ -1104,7 +1104,13 @@ def embedding_to_geotiff(
 
 _AEF_BASE_URL = "https://data.source.coop/tge-labs/aef/v1/annual"
 _AEF_INDEX_URL = f"{_AEF_BASE_URL}/aef_index.parquet"
-_AEF_AVAILABLE_YEARS = list(range(2018, 2025))
+
+# Years present in aef_index.parquet. This guard only catches typos early; the
+# index itself is the source of truth, and a year with no tiles is reported per
+# year further down. Verify with:
+#   SELECT DISTINCT year FROM read_parquet('<_AEF_INDEX_URL>') ORDER BY year
+_AEF_AVAILABLE_YEARS = list(range(2017, 2026))
+_AEF_LATEST_YEAR = max(_AEF_AVAILABLE_YEARS)
 
 
 def _merge_tiles(
@@ -1215,7 +1221,7 @@ def download_google_satellite_embedding(
     Downloads pre-computed 64-D satellite embedding vectors at 10 m
     resolution from `Source Cooperative
     <https://source.coop/tge-labs/aef>`_. The embeddings are annual
-    composites available from 2018 to 2024 and cover the entire globe.
+    composites available from 2017 to 2025 and cover the entire globe.
 
     The function uses the spatial index to identify which Cloud-Optimized
     GeoTIFF tiles intersect the bounding box, performs windowed reads
@@ -1228,7 +1234,7 @@ def download_google_satellite_embedding(
         output_dir: Directory to save downloaded GeoTIFF files.
             Created if it does not exist.
         years: Year or list of years to download. Available years are
-            2018-2024. If ``None``, downloads only the latest year (2024).
+            2017-2025. If ``None``, downloads only the latest year (2025).
         bands: List of band names to download (e.g., ``["A00", "A01"]``).
             If ``None``, all 64 bands (A00-A63) are downloaded.
         resolution: Output pixel resolution in CRS units. Defaults to
@@ -1265,7 +1271,7 @@ def download_google_satellite_embedding(
 
     # --- Validate years ---
     if years is None:
-        years = [2024]
+        years = [_AEF_LATEST_YEAR]
     elif isinstance(years, int):
         years = [years]
     for y in years:
@@ -1293,9 +1299,29 @@ def download_google_satellite_embedding(
 
     if not os.path.exists(index_path):
         logger.info("Downloading spatial index (aef_index.parquet, ~68 MB)...")
-        import urllib.request
+        import requests
 
-        urllib.request.urlretrieve(_AEF_INDEX_URL, index_path)
+        # Send an explicit User-Agent: data.source.coop rejects urllib's
+        # default "Python-urllib/x.y" with HTTP 403.
+        with requests.get(
+            _AEF_INDEX_URL,
+            stream=True,
+            timeout=60,
+            headers={"User-Agent": "geoai"},
+        ) as response:
+            response.raise_for_status()
+            # Write to a temporary path first so an interrupted download
+            # cannot leave a truncated index cached for every later call.
+            tmp_path = f"{index_path}.part"
+            try:
+                with open(tmp_path, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=1024 * 1024):
+                        f.write(chunk)
+                os.replace(tmp_path, index_path)
+            except BaseException:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+                raise
         logger.info(f"Spatial index saved to {index_path}")
 
     # --- Load index and find intersecting tiles ---

--- a/tests/test_embeddings_aef.py
+++ b/tests/test_embeddings_aef.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+"""Tests for the Google/AlphaEarth embedding download metadata.
+
+These are offline: the year guard runs before any network access, so the
+available-year set can be checked without touching Source Cooperative.
+"""
+
+import pytest
+
+from geoai.embeddings import (
+    _AEF_AVAILABLE_YEARS,
+    _AEF_LATEST_YEAR,
+    EMBEDDING_DATASETS,
+    download_google_satellite_embedding,
+)
+
+
+def test_available_years_cover_full_published_range():
+    """The index publishes 2017-2025; 2017 and 2025 were both missing."""
+    assert _AEF_AVAILABLE_YEARS == list(range(2017, 2026))
+
+
+def test_available_years_include_2017():
+    """Regression test for issue #849."""
+    assert 2017 in _AEF_AVAILABLE_YEARS
+
+
+def test_latest_year_tracks_available_years():
+    assert _AEF_LATEST_YEAR == max(_AEF_AVAILABLE_YEARS)
+
+
+def test_available_years_match_catalog_temporal_extent():
+    """The registry and the download guard must not drift apart."""
+    extent = EMBEDDING_DATASETS["google_satellite"]["temporal_extent"]
+    start, end = (int(part) for part in extent.split("-"))
+    assert [start, end] == [_AEF_AVAILABLE_YEARS[0], _AEF_AVAILABLE_YEARS[-1]]
+
+
+@pytest.mark.parametrize("year", [2016, 2026])
+def test_unavailable_year_is_rejected(year):
+    """Years outside the published range still fail fast, before any download."""
+    with pytest.raises(ValueError, match="not available"):
+        download_google_satellite_embedding(bbox=(0.0, 0.0, 0.01, 0.01), years=year)


### PR DESCRIPTION
Fixes #849.

## The reported bug

`download_google_satellite_embedding` gated years on `_AEF_AVAILABLE_YEARS = list(range(2018, 2025))` — 2018-2024. The reporter needed 2017 and could see the files in the index.

I checked the index rather than taking either side on trust:

```sql
SELECT year, COUNT(*) FROM read_parquet('.../aef_index.parquet') GROUP BY year ORDER BY year
```

| year | tiles | | year | tiles |
| --- | --- | --- | --- | --- |
| **2017** | **33,148** | | 2022 | 33,700 |
| 2018 | 33,291 | | 2023 | 34,151 |
| 2019 | 33,385 | | 2024 | 34,149 |
| 2020 | 33,206 | | **2025** | **34,155** |
| 2021 | 33,281 | | | |

So **both ends were unreachable** — 2025 was missing too, which nobody had noticed.

The module already contradicted itself: the `EMBEDDING_DATASETS` registry entry for `google_satellite` declares `"temporal_extent": "2017-2025"` while the download guard said 2018-2024. The index and the registry were right; the constant was stale.

## The reporter's other question

> are there further challenges in making the API fetch work?

**Yes — one that made the function unusable for everyone, not just for 2017.** `data.source.coop` rejects urllib's default User-Agent:

```console
$ curl -o /dev/null -w "%{http_code}" -r 0-100 .../aef_index.parquet          # 206
$ curl -o /dev/null -w "%{http_code}" -A "Python-urllib/3.12" -r 0-100 ...    # 403
```

`urllib.request.urlretrieve` sends exactly that UA, so the index download raised `HTTP Error 403: Forbidden` on any machine without an already-cached index — the function was broken end to end regardless of year. Answering the reporter's question honestly meant fixing this too, otherwise the year change would be unverifiable and they'd still be stuck.

Switched to `requests` (already a dependency, `pyproject.toml:52`, and the convention in `geoai/download.py`) with an explicit User-Agent. The index now also lands via a temp file + `os.replace`, so an interrupted download can't leave a truncated parquet cached for every later call — the old code wrote straight to the cache path.

## Also

`years=None` hardcoded `[2024]` while documenting "the latest year". Now derived from `_AEF_LATEST_YEAR` so it can't drift again. This is a small behavior change: `years=None` now fetches 2025 rather than 2024, which is what the docstring always promised.

## Verification

Ran against the **live archive**, not mocks — a fresh index download (cache cleared) plus real windowed COG reads over San Francisco:

| year | shape | CRS | res | finite | A00 range |
| --- | --- | --- | --- | --- | --- |
| 2017 | (2, 112, 88) | EPSG:32610 | 10 m | 19712/19712 | -0.0062 – 0.1929 |
| 2020 | (2, 112, 88) | EPSG:32610 | 10 m | 19712/19712 | 0.0298 – 0.2442 |
| 2025 | (2, 112, 88) | EPSG:32610 | 10 m | 19712/19712 | -0.0089 – 0.1999 |

Each year's data is distinct from the others, confirming real per-year fetches rather than one year repeated.

6 new offline tests in `tests/test_embeddings_aef.py` (the year guard runs before any network access). One pins the guard against the registry's `temporal_extent` so the two can't drift apart again. Verified non-vacuous: restoring `range(2018, 2025)` fails 3 of them. Black and codespell clean.

## Separate issue found, deliberately not fixed here

The **documented example produces a 1×1-pixel raster**. Defaults are `crs="EPSG:4326"` and `resolution=10.0`, and under EPSG:4326 that resolution means *10 degrees* per pixel:

```python
>>> geoai.download_google_satellite_embedding(bbox=(-122.5, 37.7, -122.4, 37.8), years=[2020, 2024])
# -> shape (64, 1, 1), bounds spanning 10° x 10°
```

The docstring does say "degrees for EPSG:4326", so it's documented — but the default *combination* is unusable, and it's why my first test run returned a single zero pixel. Fixing it means changing a default, which is a behavior change beyond this issue's scope, so I've left it for a separate decision. Happy to follow up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google/AlphaEarth embedding downloads now support data from 2017 through 2025.
  * If no year is specified, downloads now default to the latest available year (2025).
* **Bug Fixes**
  * Improved robustness of spatial index downloads using safer, atomic caching so partial downloads are not left behind.
  * Invalid years outside the supported availability range are now rejected clearly (before any download).
* **Tests**
  * Added coverage to validate availability metadata and year range validation without network access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->