### PR TITLE
chore: bump version to 0.41.2 (qgis plugin 1.6.2)

### DIFF
--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -8,7 +8,7 @@ only when a specific symbol is first accessed.
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.41.1"
+__version__ = "0.41.2"
 
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geoai-py"
-version = "0.41.1"
+version = "0.41.2"
 dynamic = [
     "dependencies",
 ]
@@ -59,7 +59,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.41.1"
+current_version = "0.41.2"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.6.1
+version=1.6.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 


### PR DESCRIPTION
Bumps the patch version for both the Python package and the QGIS plugin.

- Python package: `0.41.1` → `0.41.2` (`pyproject.toml`, `geoai/__init__.py`, bumpversion `current_version`)
- QGIS plugin: `1.6.1` → `1.6.2` (`qgis_plugin/geoai/metadata.txt`)

Both are bumped in the same commit so the plugin publish does not fail the way v0.41.1 did, when `metadata.txt` still carried an already-published version.

Verified `0.41.2` is unpublished on PyPI and `1.6.2` is unpublished on plugins.qgis.org (which currently has 1.6.0 and 1.6.1), and that the plugin zip builds with `version=1.6.2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the GeoAI package version to 0.41.2.
  - Updated the QGIS plugin version to 1.6.2.
  - Synchronized release metadata and versioning configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->