### PR TITLE
ci: replace Netlify docs preview with gh-pages preview

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -9,8 +9,11 @@ permissions:
     # Needed for the sticky preview comment on the PR.
     pull-requests: write
 
+# Shared with docs-preview-cleanup so the two cannot run against the same PR at
+# once: closing a PR mid-build would otherwise remove the preview and then let
+# the finishing build publish it right back, orphaning the directory.
 concurrency:
-    group: docs-build-${{ github.event.pull_request.number }}
+    group: docs-preview-${{ github.event.pull_request.number }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,6 +4,15 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+    # Needed for the sticky preview comment on the PR.
+    pull-requests: write
+
+concurrency:
+    group: docs-build-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
 jobs:
     docs-build:
         runs-on: ubuntu-latest
@@ -59,19 +68,50 @@ jobs:
                   .venv/bin/python scripts/convert_notebooks.py
                   .venv/bin/zensical build
 
-            - name: Deploy to Netlify
-              uses: nwtgck/actions-netlify@v4.0
+            # Publishing happens through `git add`, which honors any .gitignore
+            # inside the payload: a stray one silently drops files from the
+            # preview while the build still reports success.
+            - name: Strip .gitignore files from the build output
+              if: github.event.pull_request.head.repo.full_name == github.repository
+              run: |
+                  set -euo pipefail
+                  find ./site -name .gitignore -print -delete
+                  echo "preview size: $(du -sh ./site | cut -f1)"
+
+            # Publishes to opengeos/pages-preview under geoai/pr-<N>/, rebuilt on
+            # every push and removed when the PR closes (see docs-preview-cleanup).
+            #
+            #   https://opengeos.org/pages-preview/geoai/pr-<N>/
+            #
+            # Skipped for fork pull requests: `pull_request` grants them no
+            # secrets, so PREVIEW_DEPLOY_TOKEN would be empty. Building a fork's
+            # docs with that token available would mean running unreviewed code
+            # with write access to the preview repository.
+            #
+            # SETUP (one time): secret PREVIEW_DEPLOY_TOKEN, a fine-grained PAT
+            # scoped to opengeos/pages-preview ONLY, with Contents: Read and
+            # write (push to gh-pages) and Pages: Read (poll the Pages build so
+            # the comment is only posted once the URL resolves). Pages read is
+            # not optional with wait-for-pages-deployment; without it the job
+            # burns its timeout and fails with a misleading "Timed out waiting
+            # for build to start". The token needs no access to this repository.
+            - name: Deploy preview to GitHub Pages
+              if: github.event.pull_request.head.repo.full_name == github.repository
+              # Pinned to a SHA rather than the mutable tag: this is a
+              # third-party action that receives PREVIEW_DEPLOY_TOKEN, so a
+              # moved tag would hand that token to unreviewed code.
+              uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
               with:
-                  publish-dir: "./site"
-                  production-branch: master
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  deploy-message: "Deploy from GitHub Actions"
-                  enable-pull-request-comment: true
-                  enable-commit-comment: false
-                  overwrites-pull-request-comment: true
-              env:
-                  NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-                  NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+                  source-dir: ./site
+                  deploy-repository: opengeos/pages-preview
+                  token: ${{ secrets.PREVIEW_DEPLOY_TOKEN }}
+                  pages-base-url: opengeos.org/pages-preview
+                  preview-branch: gh-pages
+                  # pages-preview is shared across opengeos repositories and the
+                  # action composes the path as "<umbrella-dir>/pr-<number>", so
+                  # this is what keeps our pr-42 off another repository's pr-42.
+                  umbrella-dir: geoai
+                  wait-for-pages-deployment: true
 
             - name: Cleanup
               if: always()

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -26,6 +26,13 @@ jobs:
             - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
+                  # Required by the preview deploy below. Left on, checkout
+                  # writes an http.https://github.com/.extraheader auth header
+                  # carrying GITHUB_TOKEN into the local git config, and that
+                  # header overrides the PAT embedded in the push URL -- so the
+                  # push to pages-preview authenticates as github-actions[bot]
+                  # and 403s no matter how well-scoped PREVIEW_DEPLOY_TOKEN is.
+                  persist-credentials: false
 
             # - name: Install GDAL system dependencies
             #   run: sudo apt-get update && sudo apt-get install -y gdal-bin libgdal-dev
@@ -77,15 +84,6 @@ jobs:
                   set -euo pipefail
                   find ./site -name .gitignore -print -delete
                   echo "preview size: $(du -sh ./site | cut -f1)"
-
-            # TEMPORARY diagnostic -- remove once the preview deploys.
-            - name: Check the deploy token is visible to this job
-              if: github.event.pull_request.head.repo.full_name == github.repository
-              env:
-                  TOK: ${{ secrets.PREVIEW_DEPLOY_TOKEN }}
-              run: |
-                  echo "PREVIEW_DEPLOY_TOKEN length: ${#TOK}"
-                  echo "starts with github_pat_: $(case "$TOK" in github_pat_*) echo yes;; *) echo no;; esac)"
 
             # Publishes to opengeos/pages-preview under geoai/pr-<N>/, rebuilt on
             # every push and removed when the PR closes (see docs-preview-cleanup).

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -78,6 +78,15 @@ jobs:
                   find ./site -name .gitignore -print -delete
                   echo "preview size: $(du -sh ./site | cut -f1)"
 
+            # TEMPORARY diagnostic -- remove once the preview deploys.
+            - name: Check the deploy token is visible to this job
+              if: github.event.pull_request.head.repo.full_name == github.repository
+              env:
+                  TOK: ${{ secrets.PREVIEW_DEPLOY_TOKEN }}
+              run: |
+                  echo "PREVIEW_DEPLOY_TOKEN length: ${#TOK}"
+                  echo "starts with github_pat_: $(case "$TOK" in github_pat_*) echo yes;; *) echo no;; esac)"
+
             # Publishes to opengeos/pages-preview under geoai/pr-<N>/, rebuilt on
             # every push and removed when the PR closes (see docs-preview-cleanup).
             #

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,0 +1,47 @@
+# Removes the per-PR docs preview that docs-build published to
+# opengeos/pages-preview under geoai/pr-<N>/, and updates the sticky comment.
+#
+# This lives apart from docs-build so closing a pull request does not drag the
+# whole install-test-build chain along just to delete a directory.
+name: docs-preview-cleanup
+
+on:
+    pull_request:
+        types: [closed]
+        branches:
+            - main
+
+permissions:
+    contents: read
+    pull-requests: write
+
+concurrency:
+    group: docs-preview-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    cleanup:
+        runs-on: ubuntu-latest
+        # Fork pull requests never got a preview (no secrets on `pull_request`),
+        # so there is nothing to remove.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        steps:
+            # The publish action runs `git config` in the workspace root, so
+            # that root has to be a git repository even when only removing.
+            - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
+                  fetch-depth: 1
+
+            - name: Remove preview
+              # Pinned to a SHA rather than the mutable tag: this is a
+              # third-party action that receives PREVIEW_DEPLOY_TOKEN, so a
+              # moved tag would hand that token to unreviewed code.
+              uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+              with:
+                  deploy-repository: opengeos/pages-preview
+                  token: ${{ secrets.PREVIEW_DEPLOY_TOKEN }}
+                  pages-base-url: opengeos.org/pages-preview
+                  preview-branch: gh-pages
+                  umbrella-dir: geoai
+                  action: remove


### PR DESCRIPTION
Publishes per-PR docs previews to [`opengeos/pages-preview`](https://github.com/opengeos/pages-preview) instead of Netlify:

```
https://opengeos.org/pages-preview/geoai/pr-<N>/
```

## Changes

**`docs-build.yml`** — after `zensical build`, strip any `.gitignore` from `./site` and deploy with [`rossjrw/pr-preview-action`](https://github.com/rossjrw/pr-preview-action) (pinned to the v1.8.1 SHA) using `umbrella-dir: geoai`. The Netlify deploy step is removed. Also adds an explicit `permissions` block (contents read, pull-requests write for the sticky comment) and a `concurrency` group so new pushes cancel in-flight builds.

The `.gitignore` strip is not cosmetic: publishing goes through `git add`, which honors any `.gitignore` inside the payload, so a stray one drops those files from the preview while the build still reports success.

**`docs-preview-cleanup.yml`** (new) — on PR close, runs the same action with `action: remove`. Kept in its own file so closing a PR doesn't drag the whole install → pytest → build chain along just to delete a directory.

## Before this works

`PREVIEW_DEPLOY_TOKEN` is not yet set on this repository. It needs to be a fine-grained PAT scoped to `opengeos/pages-preview` **only**, with:

| Permission | Why |
| --- | --- |
| `Contents: Read and write` | push the preview to `gh-pages` |
| `Pages: Read` | poll the Pages build so the comment is only posted once the URL resolves |

`Pages: Read` is not optional with `wait-for-pages-deployment` — without it the job burns its timeout and fails with a misleading "Timed out waiting for build to start". The token needs no access to this repository; the sticky comment is posted with the workflow's own `GITHUB_TOKEN`.

## Fork pull requests

The deploy steps are gated on same-repo PRs. `pull_request` grants forks no secrets, and this workflow executes PR code (`uv pip install .`, pytest, `convert_notebooks.py`), so switching to `pull_request_target` to reach the secret would hand a fork write access to the preview repository. Fork previews would need a split build/deploy via `workflow_run` or an artifact handoff — out of scope here.

The `NETLIFY_*` secrets are left in place; they can be deleted separately if nothing else uses them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub Pages previews for documentation builds on pull requests.
  * Added automatic cleanup of documentation previews when pull requests are closed.

* **Improvements**
  * Improved preview deployment to publish to GitHub Pages with safer output handling to avoid silently dropped files.
  * Added concurrency controls and tightened workflow permissions to prevent overlapping runs and improve reliability.
  * Ensured preview deploys and cleanups only occur for pull requests from the same repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->