### PR TITLE
Add mining footprint mapping notebook

### DIFF
--- a/docs/examples/mining_footprint_mapping.ipynb
+++ b/docs/examples/mining_footprint_mapping.ipynb
@@ -1,0 +1,351 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Mining Footprint Mapping with Text Prompt Segmentation\n",
+    "\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/geoai/blob/main/docs/examples/mining_footprint_mapping.ipynb)\n",
+    "\n",
+    "This notebook demonstrates how to delineate open-pit mine footprints from aerial imagery using [CLIPSegmentation](https://huggingface.co/docs/transformers/model_doc/clipseg) — a zero-shot text-guided segmentation model. No labelled training data or domain-specific model is required; a plain-language text prompt such as `\"open pit mine\"` is sufficient to isolate the mine pit from surrounding terrain.\n",
+    "\n",
+    "**Study area:** Bingham Canyon Copper Mine, Utah, USA — one of the largest open-pit mines in the world (~4 km wide, ~1.2 km deep).\n",
+    "\n",
+    "**Outline:**\n",
+    "- Download NAIP aerial imagery via Planetary Computer\n",
+    "- Initialise a CLIPSegmentation model\n",
+    "- Generate a mine-pit probability mask using a text prompt\n",
+    "- Vectorise the mask and visualise the mine footprint\n",
+    "\n",
+    "## Install package\n",
+    "To use the `geoai-py` package, ensure it is installed in your environment. Uncomment the command below if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install geoai-py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geoai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an interactive map\n",
+    "\n",
+    "Centre the map on the Bingham Canyon Mine in Utah. You can pan and zoom to adjust the area of interest before downloading imagery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geoai.LeafMap(center=[40.5237, -112.1480], zoom=13)\n",
+    "m.add_basemap(\"Esri.WorldImagery\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define area of interest\n",
+    "\n",
+    "The bounding box below covers the Bingham Canyon open-pit and its immediate surroundings. Replace it with `m.user_roi_bounds()` if you drew a custom rectangle on the map above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# [west, south, east, north] in WGS84 decimal degrees\n",
+    "if m.user_roi is not None:\n",
+    "    bbox = m.user_roi_bounds()\n",
+    "else:\n",
+    "    bbox = (-112.2200, 40.5050, -112.0800, 40.5850)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download NAIP imagery\n",
+    "\n",
+    "Download a National Agriculture Imagery Program (NAIP) scene from Planetary Computer. NAIP provides ~0.6 m/pixel 4-band (R, G, B, NIR) imagery across the continental United States."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "naip_paths = geoai.download_naip(\n",
+    "    bbox=bbox,\n",
+    "    output_dir=\"naip_bingham\",\n",
+    "    year=2020,\n",
+    "    max_items=1,\n",
+    ")\n",
+    "raster_path = naip_paths[0]\n",
+    "print(f\"Downloaded: {raster_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect raster metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geoai.print_raster_info(raster_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualise imagery\n",
+    "\n",
+    "Display the natural-colour composite (R-G-B bands 1-2-3) on an interactive map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geoai.view_raster(raster_path, layer_name=\"NAIP Imagery\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialise CLIPSegmentation model\n",
+    "\n",
+    "CLIPSeg is a vision-language model that segments objects described by free-form text. The model runs on CPU if no GPU is available, though GPU inference is substantially faster for large rasters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "segmenter = geoai.CLIPSegmentation(tile_size=512, overlap=32)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Segment mine footprint using text prompt\n",
+    "\n",
+    "Pass a natural-language description of the target feature. CLIPSeg scores each image patch against the prompt and produces a probability mask — no labelled samples required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask_path = \"mine_mask.tif\"\n",
+    "text_prompt = \"open pit mine\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "segmenter.segment_image(\n",
+    "    raster_path,\n",
+    "    output_path=mask_path,\n",
+    "    text_prompt=text_prompt,\n",
+    "    threshold=0.4,\n",
+    "    smoothing_sigma=1.5,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualise segmentation mask\n",
+    "\n",
+    "Overlay the mine probability mask on the NAIP imagery. Brighter colours indicate higher confidence that a pixel belongs to the mine pit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geoai.view_raster(\n",
+    "    mask_path,\n",
+    "    nodata=0,\n",
+    "    opacity=0.7,\n",
+    "    colormap=\"hot\",\n",
+    "    layer_name=\"Mine Mask\",\n",
+    "    basemap=raster_path,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Side-by-side comparison\n",
+    "\n",
+    "Use a split map to compare the original imagery with the segmentation output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geoai.create_split_map(\n",
+    "    left_layer=mask_path,\n",
+    "    right_layer=raster_path,\n",
+    "    left_label=\"Mine Mask\",\n",
+    "    right_label=\"NAIP Imagery\",\n",
+    "    left_args={\"nodata\": 0, \"opacity\": 0.8, \"colormap\": \"hot\"},\n",
+    "    basemap=raster_path,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Vectorise mine footprint\n",
+    "\n",
+    "Convert the raster mask to vector polygons for use in GIS workflows. Small fragments below `min_area` are discarded to retain only the main pit boundary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf = geoai.orthogonalize(\n",
+    "    input_path=mask_path,\n",
+    "    output_path=\"mine_footprint.geojson\",\n",
+    "    epsilon=0.5,\n",
+    ")\n",
+    "print(f\"Polygons extracted: {len(gdf)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geoai.view_vector_interactive(\n",
+    "    gdf,\n",
+    "    style_kwds={\"color\": \"#E8441A\", \"fillOpacity\": 0.2, \"weight\": 2},\n",
+    "    layer_name=\"Mine Footprint\",\n",
+    "    tiles=raster_path,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook showed how to:\n",
+    "\n",
+    "1. Download NAIP aerial imagery for a mine area using `geoai.download_naip`\n",
+    "2. Apply zero-shot text-prompt segmentation with `geoai.CLIPSegmentation` — no labelled data required\n",
+    "3. Use the prompt `\"open pit mine\"` to isolate the pit from surrounding terrain\n",
+    "4. Vectorise the raster mask and visualise the extracted footprint\n",
+    "\n",
+    "The same pipeline can be adapted to other extractive sites (quarries, tailing ponds, coal surface mines) by changing the `text_prompt` and `bbox`. For time-series mine expansion analysis, run the pipeline on multiple acquisition years and overlay the resulting footprint polygons.\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "- [CLIPSeg: Image Segmentation Using Text and Image Prompts](https://arxiv.org/abs/2112.10003) — Lüddecke & Ecker, 2022\n",
+    "- [geoai](https://geoai.gishub.org/) — Wu et al.\n",
+    "- [NAIP on Planetary Computer](https://planetarycomputer.microsoft.com/dataset/naip)\n",
+    "- [Bingham Canyon Mine](https://en.wikipedia.org/wiki/Bingham_Canyon_Mine)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/mining_footprint_mapping.ipynb
+++ b/docs/examples/mining_footprint_mapping.ipynb
@@ -278,7 +278,10 @@
     "# NAIP is delivered in a projected UTM CRS, so areas are in square metres.\n",
     "min_area = 10_000  # 1 hectare; raise or lower to suit the target feature size\n",
     "gdf = gdf[gdf.geometry.area >= min_area].copy()\n",
-    "gdf.to_file(\"mine_footprint.geojson\")\n",
+    "\n",
+    "# to_file() writes coordinates as-is, so reproject to WGS84 for a spec-compliant\n",
+    "# GeoJSON. The in-memory gdf stays in UTM for any further area calculations.\n",
+    "gdf.to_crs(\"EPSG:4326\").to_file(\"mine_footprint.geojson\", driver=\"GeoJSON\")\n",
     "print(f\"Polygons extracted: {len(gdf)}\")"
    ]
   },

--- a/docs/examples/mining_footprint_mapping.ipynb
+++ b/docs/examples/mining_footprint_mapping.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "## Define area of interest\n",
     "\n",
-    "The bounding box below covers the Bingham Canyon open-pit and its immediate surroundings. Replace it with `m.user_roi_bounds()` if you drew a custom rectangle on the map above."
+    "The default bounding box covers the Bingham Canyon open-pit and sits entirely within a single NAIP quarter-quad tile (~5 x 7 km), so one download covers the whole pit. If you draw your own rectangle on the map above it is used instead — a larger ROI may span several NAIP tiles, in which case raise `max_items` below and merge the downloads with `geoai.mosaic_geotiffs()` before segmenting."
    ]
   },
   {
@@ -86,7 +86,7 @@
     "if m.user_roi is not None:\n",
     "    bbox = m.user_roi_bounds()\n",
     "else:\n",
-    "    bbox = (-112.2200, 40.5050, -112.0800, 40.5850)"
+    "    bbox = (-112.1800, 40.5100, -112.1300, 40.5450)"
    ]
   },
   {
@@ -95,7 +95,7 @@
    "source": [
     "## Download NAIP imagery\n",
     "\n",
-    "Download a National Agriculture Imagery Program (NAIP) scene from Planetary Computer. NAIP provides ~0.6 m/pixel 4-band (R, G, B, NIR) imagery across the continental United States."
+    "Download a National Agriculture Imagery Program (NAIP) scene from Planetary Computer. NAIP provides ~0.6 m/pixel 4-band (R, G, B, NIR) imagery across the continental United States. NAIP is flown on a multi-year cycle that varies by state, so `year` must be one that exists for the area of interest — Utah was last flown in 2021."
    ]
   },
   {
@@ -107,9 +107,14 @@
     "naip_paths = geoai.download_naip(\n",
     "    bbox=bbox,\n",
     "    output_dir=\"naip_bingham\",\n",
-    "    year=2020,\n",
+    "    year=2021,\n",
     "    max_items=1,\n",
     ")\n",
+    "if not naip_paths:\n",
+    "    raise RuntimeError(\n",
+    "        \"No NAIP imagery found for this area and year. \"\n",
+    "        \"Try a different year or a larger bounding box.\"\n",
+    "    )\n",
     "raster_path = naip_paths[0]\n",
     "print(f\"Downloaded: {raster_path}\")"
    ]
@@ -256,7 +261,7 @@
    "source": [
     "## Vectorise mine footprint\n",
     "\n",
-    "Convert the raster mask to vector polygons for use in GIS workflows. Small fragments below `min_area` are discarded to retain only the main pit boundary."
+    "Convert the raster mask to vector polygons for use in GIS workflows. Note that the `min_area` argument of `geoai.orthogonalize` only decides which polygons are *orthogonalised* — small ones are passed through unchanged rather than removed. To keep just the main pit boundary, filter the returned GeoDataFrame by area before exporting."
    ]
   },
   {
@@ -267,9 +272,13 @@
    "source": [
     "gdf = geoai.orthogonalize(\n",
     "    input_path=mask_path,\n",
-    "    output_path=\"mine_footprint.geojson\",\n",
     "    epsilon=0.5,\n",
     ")\n",
+    "\n",
+    "# NAIP is delivered in a projected UTM CRS, so areas are in square metres.\n",
+    "min_area = 10_000  # 1 hectare; raise or lower to suit the target feature size\n",
+    "gdf = gdf[gdf.geometry.area >= min_area].copy()\n",
+    "gdf.to_file(\"mine_footprint.geojson\")\n",
     "print(f\"Polygons extracted: {len(gdf)}\")"
    ]
   },

--- a/zensical.toml
+++ b/zensical.toml
@@ -110,6 +110,7 @@ nav = [
     "examples/rfdetr_detection.md",
     "examples/rfdetr_segmentation.md",
     "examples/image_captioning.md",
+    "examples/mining_footprint_mapping.md",
   ] },
   { "Workshops" = [
     "workshops/GeoAI_Workshop_2025.md",


### PR DESCRIPTION
## Summary

- Adds `docs/examples/mining_footprint_mapping.ipynb` — a new end-to-end example that maps open-pit mine footprints from NAIP aerial imagery using zero-shot text-prompt segmentation
- Uses `geoai.CLIPSegmentation` with the prompt `"open pit mine"` — no labelled training data required
- Demonstrates `geoai.download_naip` → `CLIPSegmentation.segment_image` → `geoai.create_split_map` → `geoai.orthogonalize` → `geoai.view_vector_interactive` in a single coherent workflow
- Study area: **Bingham Canyon Copper Mine, Utah, USA** — clearly visible open-pit in NAIP imagery, making it a good reference case for validation

## Why this is useful

Mining and quarry footprint delineation is a recurring need in environmental monitoring, land-cover change studies, and disaster risk assessment (e.g., tailings dam proximity to settlements). Text-prompt segmentation removes the need for labelled mine imagery, making this approach accessible to practitioners who don't have annotated training data.

## Test plan

- [ ] `# %pip install geoai-py` installs cleanly
- [ ] `geoai.download_naip(bbox=(-112.22, 40.505, -112.08, 40.585), output_dir="naip_bingham", year=2020, max_items=1)` returns at least one `.tif` path
- [ ] `geoai.CLIPSegmentation(tile_size=512, overlap=32).segment_image(...)` produces a non-empty probability mask
- [ ] `geoai.create_split_map` renders side-by-side comparison
- [ ] `geoai.orthogonalize` extracts at least one polygon for the main pit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new end-to-end Jupyter notebook example showcasing extraction of open-pit mine footprints from NAIP aerial imagery using zero-shot text-prompt segmentation.
  * Includes interactive ROI selection, NAIP download and metadata display, tiled segmentation with configurable threshold/smoothing, and probability-mask export to GeoTIFF.
  * Demonstrates raster-to-vector orthogonalization, minimum-area filtering, GeoJSON export, and interactive vector visualization.
  * Updated MkDocs navigation to include the new example page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->