### PR TITLE
fix: make quiet/verbose flags actually suppress progress bars

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,0 +1,14 @@
+# progress module
+
+Centralizes progress bar handling for GeoAI. Every progress bar in the package is created through the `tqdm` wrapper defined here, so all of them can be silenced at once with `geoai.disable_progress_bars()` or the `GEOAI_DISABLE_PROGRESS` environment variable. This is handy in notebooks (e.g., Google Colab) where long-running progress output can freeze the browser tab.
+
+```python
+import geoai
+
+geoai.disable_progress_bars()  # silence every progress bar
+geoai.enable_progress_bars()  # turn them back on
+```
+
+Individual functions still honor their own `quiet=True` / `verbose=False` arguments.
+
+::: geoai.progress

--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -203,6 +203,11 @@ _LAZY_SYMBOL_MAP = {
     "DETECTION_MODELS": ("train", None),
     "get_detection_model": ("train", None),
     "model_has_masks": ("train", None),
+    # --- geoai.progress ---
+    "disable_progress_bars": ("progress", None),
+    "enable_progress_bars": ("progress", None),
+    "set_progress_bars": ("progress", None),
+    "progress_bars_disabled": ("progress", None),
     # --- geoai.utils ---
     "clean_instance_mask": ("utils", None),
     "orthogonalize": ("utils", None),
@@ -493,6 +498,7 @@ _LAZY_SUBMODULES = {
     "dinov3_finetune",
     "esrgan",
     "foundation_models",
+    "progress",
 }
 
 

--- a/geoai/auto.py
+++ b/geoai/auto.py
@@ -34,7 +34,6 @@ from PIL import Image
 from rasterio.features import shapes
 from rasterio.windows import Window
 from shapely.geometry import box, shape
-from tqdm import tqdm
 from transformers import (
     AutoConfig,
     AutoImageProcessor,
@@ -52,6 +51,7 @@ from transformers import (
 
 from transformers.utils import logging as hf_logging
 
+from .progress import tqdm
 from .utils import get_device
 
 hf_logging.set_verbosity_error()  # silence HF load reports

--- a/geoai/classify.py
+++ b/geoai/classify.py
@@ -394,7 +394,7 @@ def _classify_image(
     from torchgeo.datasets import RasterDataset, stack_samples
     from torchgeo.samplers import GridGeoSampler
     from torchgeo.trainers import SemanticSegmentationTask
-    from tqdm import tqdm
+    from .progress import tqdm
 
     # Set default output path if not provided
     if output_path is None:
@@ -870,7 +870,7 @@ def classify_images(
     # Import required libraries
     import glob
 
-    from tqdm import tqdm
+    from .progress import tqdm
 
     # Process directory input
     if isinstance(image_paths, str) and os.path.isdir(image_paths):

--- a/geoai/clip_classify.py
+++ b/geoai/clip_classify.py
@@ -25,8 +25,8 @@ import rasterio
 import torch
 from PIL import Image
 from rasterio.windows import Window, from_bounds as window_from_bounds
-from tqdm import tqdm
 from transformers import CLIPModel, CLIPProcessor
+from .progress import tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/geoai/dinov3_finetune.py
+++ b/geoai/dinov3_finetune.py
@@ -881,7 +881,7 @@ def dinov3_segment_geotiff(
     """
     import rasterio
     from rasterio.windows import Window
-    from tqdm import tqdm
+    from .progress import tqdm
 
     if overlap >= window_size:
         raise ValueError(

--- a/geoai/download.py
+++ b/geoai/download.py
@@ -19,7 +19,7 @@ import rioxarray as rxr
 import xarray as xr
 from pystac_client import Client
 from shapely.geometry import box
-from tqdm import tqdm
+from .progress import tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/geoai/embeddings.py
+++ b/geoai/embeddings.py
@@ -1413,7 +1413,7 @@ def download_google_satellite_embedding(
 
                     # Read bands with progress bar
                     try:
-                        from tqdm import tqdm
+                        from .progress import tqdm
 
                         band_arrays = []
                         desc = f"Year {year}"

--- a/geoai/esrgan.py
+++ b/geoai/esrgan.py
@@ -21,7 +21,6 @@ from skimage.exposure import match_histograms
 from torch.amp import GradScaler
 from torch.nn.utils import clip_grad_norm_
 from torch.utils.data import DataLoader, Dataset, random_split, SubsetRandomSampler
-from tqdm import tqdm
 import numpy as np
 import torch
 import torch.multiprocessing as mp
@@ -31,6 +30,7 @@ import torch.optim as optim
 import torch.utils.data
 import torchvision.models as models
 
+from .progress import tqdm
 from .utils.device import get_device
 
 

--- a/geoai/extract.py
+++ b/geoai/extract.py
@@ -1132,10 +1132,11 @@ class ObjectDetector:
             output_path = os.path.splitext(raster_path)[0] + "_masks.tif"
 
         # Print parameters being used
-        logger.info(f"Processing masks with parameters:")
-        logger.info(f"- Confidence threshold: {confidence_threshold}")
-        logger.info(f"- Chip size: {chip_size}")
-        logger.info(f"- Mask threshold: {mask_threshold}")
+        if verbose:
+            logger.info(f"Processing masks with parameters:")
+            logger.info(f"- Confidence threshold: {confidence_threshold}")
+            logger.info(f"- Chip size: {chip_size}")
+            logger.info(f"- Mask threshold: {mask_threshold}")
 
         # Create dataset
         dataset = CustomDataset(
@@ -1333,7 +1334,8 @@ class ObjectDetector:
                 # Write the final mask to the output file
                 dst.write(mask_array, 1)
 
-        logger.info(f"Object masks saved to {output_path}")
+        if verbose:
+            logger.info(f"Object masks saved to {output_path}")
         return output_path
 
     def regularize_objects(
@@ -2168,7 +2170,8 @@ class ObjectDetector:
                 dst.write(mask_array, 1)
                 dst.write(conf_array, 2)
 
-            logger.info(f"Masks with confidence values saved to {output_path}")
+            if verbose:
+                logger.info(f"Masks with confidence values saved to {output_path}")
             return output_path
 
     def vectorize_masks(

--- a/geoai/extract.py
+++ b/geoai/extract.py
@@ -20,9 +20,9 @@ from torchvision.models.detection import (
     fasterrcnn_resnet50_fpn_v2,
     maskrcnn_resnet50_fpn,
 )
-from tqdm import tqdm
 
 # Local Imports
+from .progress import tqdm
 from .utils import get_raster_stats
 
 logger = logging.getLogger(__name__)
@@ -163,16 +163,19 @@ class CustomDataset(NonGeoDataset):
             self.rows = len(self.row_starts)
             self.cols = len(self.col_starts)
 
-            logger.info(
-                f"Dataset initialized with {self.rows} rows and {self.cols} columns of chips"
-            )
-            logger.info(f"Image dimensions: {self.width} x {self.height} pixels")
-            logger.info(f"Chip size: {self.chip_size[1]} x {self.chip_size[0]} pixels")
-            logger.info(
-                f"Overlap: {overlap*100}% (stride_x={self.stride_x}, stride_y={self.stride_y})"
-            )
-            if src.crs:
-                logger.info(f"CRS: {src.crs}")
+            if self.verbose:
+                logger.info(
+                    f"Dataset initialized with {self.rows} rows and {self.cols} columns of chips"
+                )
+                logger.info(f"Image dimensions: {self.width} x {self.height} pixels")
+                logger.info(
+                    f"Chip size: {self.chip_size[1]} x {self.chip_size[0]} pixels"
+                )
+                logger.info(
+                    f"Overlap: {overlap*100}% (stride_x={self.stride_x}, stride_y={self.stride_y})"
+                )
+                if src.crs:
+                    logger.info(f"CRS: {src.crs}")
 
         # Get raster stats
         self.raster_stats = get_raster_stats(raster_path, divide_by=255)
@@ -1201,8 +1204,9 @@ class ObjectDetector:
                 )
 
                 # Process batches
-                logger.info(f"Processing raster with {len(dataloader)} batches")
-                for batch in tqdm(dataloader):
+                if verbose:
+                    logger.info(f"Processing raster with {len(dataloader)} batches")
+                for batch in tqdm(dataloader, disable=not verbose):
                     # Move images to device
                     images = batch["image"].to(self.device)
                     coords = batch["coords"]  # (i, j) coordinates in pixels
@@ -1360,7 +1364,7 @@ class ObjectDetector:
         import numpy as np
         from shapely.affinity import rotate, translate
         from shapely.geometry import MultiPolygon, Polygon, box
-        from tqdm import tqdm
+        from .progress import tqdm
 
         def get_angle(
             p1: Tuple[float, float], p2: Tuple[float, float], p3: Tuple[float, float]
@@ -2076,8 +2080,9 @@ class ObjectDetector:
             )
 
             # Process batches
-            logger.info(f"Processing raster with {len(dataloader)} batches")
-            for batch in tqdm(dataloader):
+            if verbose:
+                logger.info(f"Processing raster with {len(dataloader)} batches")
+            for batch in tqdm(dataloader, disable=not verbose):
                 # Move images to device
                 images = batch["image"].to(self.device)
                 coords = batch["coords"]  # Tensor of shape [batch_size, 2]

--- a/geoai/extract.py
+++ b/geoai/extract.py
@@ -1133,7 +1133,7 @@ class ObjectDetector:
 
         # Print parameters being used
         if verbose:
-            logger.info(f"Processing masks with parameters:")
+            logger.info("Processing masks with parameters:")
             logger.info(f"- Confidence threshold: {confidence_threshold}")
             logger.info(f"- Chip size: {chip_size}")
             logger.info(f"- Mask threshold: {mask_threshold}")

--- a/geoai/hf.py
+++ b/geoai/hf.py
@@ -11,8 +11,8 @@ import numpy as np
 import pandas as pd
 import rasterio
 from PIL import Image
-from tqdm import tqdm
 from transformers import AutoConfig, AutoModelForMaskedImageModeling, pipeline
+from .progress import tqdm
 
 __all__ = [
     "get_model_config",

--- a/geoai/inference.py
+++ b/geoai/inference.py
@@ -352,7 +352,7 @@ def predict_geotiff(
     import torch
     import rasterio
     from rasterio.windows import Window
-    from tqdm.auto import tqdm
+    from .progress import tqdm
 
     from geoai.utils import get_device
 
@@ -604,7 +604,7 @@ def predict_geotiff_superres(
     import torch
     import rasterio
     from rasterio.windows import Window
-    from tqdm.auto import tqdm
+    from .progress import tqdm
 
     from geoai.utils import get_device
 

--- a/geoai/landcover_utils.py
+++ b/geoai/landcover_utils.py
@@ -30,7 +30,7 @@ from rasterio import features
 from rasterio.windows import Window
 from skimage.filters import threshold_multiotsu
 from sklearn.linear_model import LinearRegression
-from tqdm import tqdm
+from .progress import tqdm
 
 __all__ = [
     "export_landcover_tiles",

--- a/geoai/moondream.py
+++ b/geoai/moondream.py
@@ -21,9 +21,9 @@ import rasterio
 import torch
 from PIL import Image
 from shapely.geometry import Point, box
-from tqdm import tqdm
 from transformers.utils import logging as hf_logging
 
+from .progress import tqdm
 from .utils import get_device
 
 hf_logging.set_verbosity_error()  # silence HF load reports

--- a/geoai/onnx.py
+++ b/geoai/onnx.py
@@ -45,7 +45,7 @@ from PIL import Image
 from rasterio.features import shapes
 from rasterio.windows import Window
 from shapely.geometry import shape
-from tqdm import tqdm
+from .progress import tqdm
 
 
 def _check_onnx_deps() -> None:

--- a/geoai/pipeline.py
+++ b/geoai/pipeline.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
-from tqdm import tqdm
+from .progress import tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/geoai/progress.py
+++ b/geoai/progress.py
@@ -1,0 +1,120 @@
+"""Centralized progress bar handling for geoai.
+
+Every progress bar in geoai is created through the :class:`tqdm` wrapper defined
+in this module. The wrapper behaves exactly like ``tqdm.auto.tqdm`` but honors a
+package-wide switch, so users can silence all progress reporting at once::
+
+    import geoai
+
+    geoai.disable_progress_bars()
+
+The switch can also be set before importing geoai with the
+``GEOAI_DISABLE_PROGRESS`` environment variable::
+
+    import os
+
+    os.environ["GEOAI_DISABLE_PROGRESS"] = "1"
+
+Using ``tqdm.auto`` means notebooks (Jupyter, Colab) get widget-based progress
+bars that update in place instead of streaming thousands of text updates to the
+front end, which could freeze or crash the browser tab.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from tqdm.auto import tqdm as _tqdm
+
+__all__ = [
+    "tqdm",
+    "disable_progress_bars",
+    "enable_progress_bars",
+    "set_progress_bars",
+    "progress_bars_disabled",
+]
+
+_TRUTHY = {"1", "true", "t", "yes", "y", "on"}
+
+# Package-wide switch. ``None`` means "not explicitly set", in which case the
+# ``GEOAI_DISABLE_PROGRESS`` environment variable decides.
+_DISABLED: bool | None = None
+
+
+def _env_disabled() -> bool:
+    """Check whether progress bars are disabled via environment variable.
+
+    Returns:
+        bool: True if ``GEOAI_DISABLE_PROGRESS`` is set to a truthy value.
+    """
+    return os.environ.get("GEOAI_DISABLE_PROGRESS", "").strip().lower() in _TRUTHY
+
+
+def progress_bars_disabled() -> bool:
+    """Report whether geoai progress bars are currently disabled.
+
+    Returns:
+        bool: True if progress bars are globally disabled, False otherwise.
+    """
+    if _DISABLED is not None:
+        return _DISABLED
+    return _env_disabled()
+
+
+def set_progress_bars(enabled: bool) -> None:
+    """Enable or disable all geoai progress bars.
+
+    Args:
+        enabled (bool): If True, progress bars are shown. If False, every
+            progress bar created by geoai is suppressed.
+
+    Returns:
+        None
+    """
+    global _DISABLED
+    _DISABLED = not bool(enabled)
+
+
+def disable_progress_bars() -> None:
+    """Disable all geoai progress bars.
+
+    Useful in notebooks (e.g., Google Colab) where a long-running progress bar
+    can flood the output and freeze the browser tab.
+
+    Returns:
+        None
+    """
+    set_progress_bars(False)
+
+
+def enable_progress_bars() -> None:
+    """Re-enable all geoai progress bars.
+
+    Returns:
+        None
+    """
+    set_progress_bars(True)
+
+
+class tqdm(_tqdm):  # noqa: N801 - drop-in replacement for tqdm.auto.tqdm
+    """Drop-in replacement for ``tqdm.auto.tqdm`` that honors the global switch.
+
+    The only difference from ``tqdm.auto.tqdm`` is that the progress bar is
+    forced off when progress bars have been disabled with
+    :func:`disable_progress_bars`, :func:`set_progress_bars`, or the
+    ``GEOAI_DISABLE_PROGRESS`` environment variable.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the progress bar.
+
+        Args:
+            *args: Positional arguments forwarded to ``tqdm.auto.tqdm``.
+            **kwargs: Keyword arguments forwarded to ``tqdm.auto.tqdm``. The
+                ``disable`` keyword is forced to True when progress bars are
+                globally disabled.
+        """
+        if progress_bars_disabled():
+            kwargs["disable"] = True
+        super().__init__(*args, **kwargs)

--- a/geoai/recognize.py
+++ b/geoai/recognize.py
@@ -18,7 +18,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, Dataset
-from tqdm import tqdm
+from .progress import tqdm
 
 try:
     from PIL import Image

--- a/geoai/rfdetr.py
+++ b/geoai/rfdetr.py
@@ -336,7 +336,7 @@ def rfdetr_detect(
     from PIL import Image
     from rasterio.windows import Window
     from shapely.geometry import Polygon
-    from tqdm import tqdm
+    from .progress import tqdm
 
     check_rfdetr_available()
 

--- a/geoai/segment.py
+++ b/geoai/segment.py
@@ -13,7 +13,6 @@ from PIL import Image
 from rasterio.warp import transform_bounds
 from rasterio.windows import Window
 from shapely.geometry import Polygon, box
-from tqdm import tqdm
 from transformers import (
     AutoModelForMaskGeneration,
     AutoProcessor,
@@ -21,6 +20,7 @@ from transformers import (
     CLIPSegProcessor,
     pipeline,
 )
+from .progress import tqdm
 
 __all__ = [
     "BoundingBox",

--- a/geoai/timm_regress.py
+++ b/geoai/timm_regress.py
@@ -12,7 +12,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import Dataset, DataLoader
-from tqdm import tqdm
+from .progress import tqdm
 
 try:
     import timm

--- a/geoai/timm_segment.py
+++ b/geoai/timm_segment.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import Dataset, DataLoader
-from tqdm import tqdm
+from .progress import tqdm
 
 try:
     import timm

--- a/geoai/timm_train.py
+++ b/geoai/timm_train.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import Dataset, DataLoader
-from tqdm import tqdm
+from .progress import tqdm
 
 try:
     import timm

--- a/geoai/train.py
+++ b/geoai/train.py
@@ -28,8 +28,8 @@ from torchvision.models.detection import (
 )
 from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
 from torchvision.models.detection.mask_rcnn import MaskRCNNPredictor
-from tqdm import tqdm
 
+from .progress import tqdm
 from .utils import download_model_from_hf, get_device
 
 logger = logging.getLogger(__name__)

--- a/geoai/utils/download.py
+++ b/geoai/utils/download.py
@@ -34,7 +34,7 @@ def download_file(
 
     import zipfile
 
-    from tqdm import tqdm
+    from ..progress import tqdm
 
     if output_path is None:
         output_path = os.path.basename(url)

--- a/geoai/utils/geometry.py
+++ b/geoai/utils/geometry.py
@@ -15,8 +15,8 @@ import rioxarray as rxr
 import xarray as xr
 from rasterio import features
 from shapely.geometry import Polygon
-from tqdm import tqdm
 
+from ..progress import tqdm
 from .device import install_package, temp_file_path
 
 __all__ = [

--- a/geoai/utils/raster.py
+++ b/geoai/utils/raster.py
@@ -27,7 +27,7 @@ from rasterio import features
 from rasterio.plot import show
 from rasterio.windows import Window
 from shapely.geometry import Polygon, box, shape
-from tqdm import tqdm
+from ..progress import tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/geoai/utils/training.py
+++ b/geoai/utils/training.py
@@ -25,7 +25,7 @@ from rasterio.windows import Window
 from shapely.affinity import rotate
 from shapely.geometry import box
 from torchvision.transforms import RandomRotation
-from tqdm import tqdm
+from ..progress import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -1504,6 +1504,7 @@ def export_geotiff_tiles(
             total=min(total_tiles, max_tiles),
             desc="Generating tiles",
             bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]",
+            disable=quiet,
         )
 
         # Track statistics for summary
@@ -1779,11 +1780,14 @@ def export_geotiff_tiles(
                             label_dir,
                         )
 
-                # Update progress bar
-                pbar.update(1)
+                # Update progress bar. refresh=False lets tqdm throttle the
+                # redraws; otherwise every tile forces a redraw, which floods
+                # notebook front ends (e.g., Colab) and can freeze the tab.
                 pbar.set_description(
-                    f"Generated: {stats['total_tiles']}, With features: {stats['tiles_with_features']}"
+                    f"Generated: {stats['total_tiles']}, With features: {stats['tiles_with_features']}",
+                    refresh=False,
                 )
+                pbar.update(1)
 
                 tile_index += 1
                 if tile_index >= max_tiles:
@@ -2978,6 +2982,7 @@ def export_training_data(
             total=total_tiles,
             desc=f"Generating tiles (with features: 0)",
             bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]",
+            disable=quiet,
         )
 
         # Generate tiles
@@ -3434,11 +3439,12 @@ def export_training_data(
                             }
                         )
 
-                # Update progress bar
-                pbar.update(1)
+                # Update progress bar (refresh=False so tqdm throttles redraws)
                 pbar.set_description(
-                    f"Generated: {stats['total_tiles']}, With features: {stats['tiles_with_features']}"
+                    f"Generated: {stats['total_tiles']}, With features: {stats['tiles_with_features']}",
+                    refresh=False,
                 )
+                pbar.update(1)
 
                 chip_index += 1
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -246,6 +246,75 @@ class TestQuietFlags(unittest.TestCase):
             self.assertTrue(created, "expected a progress bar to be created")
             self.assertTrue(all(created), "expected every progress bar to be disabled")
 
+    @staticmethod
+    def _stub_detector(chip_size=(128, 128)):
+        """Build an ObjectDetector that runs without downloading model weights.
+
+        Args:
+            chip_size (tuple): Chip size used by the inference dataset.
+
+        Returns:
+            ObjectDetector: An instance whose model returns no detections.
+        """
+        import torch
+
+        from geoai.extract import ObjectDetector
+
+        def stub_model(images):
+            """Return an empty prediction for every image in the batch."""
+            return [
+                {
+                    "masks": torch.zeros((0, 1, *chip_size)),
+                    "scores": torch.zeros(0),
+                }
+                for _ in images
+            ]
+
+        detector = ObjectDetector.__new__(ObjectDetector)
+        detector.device = torch.device("cpu")
+        detector.model = stub_model
+        detector.chip_size = chip_size
+        detector.confidence_threshold = 0.5
+        detector.mask_threshold = 0.5
+        return detector
+
+    def test_generate_masks_quiet_when_not_verbose(self):
+        """generate_masks(verbose=False) creates no visible progress bar."""
+        import tempfile
+
+        detector = self._stub_detector()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            raster_path, _ = self._create_data(tmp_dir)
+            with self._record_bars() as created:
+                with self.assertNoLogs("geoai.extract", level="INFO"):
+                    detector.generate_masks(
+                        raster_path=raster_path,
+                        output_path=os.path.join(tmp_dir, "masks.tif"),
+                        verbose=False,
+                    )
+
+            self.assertTrue(created, "expected a progress bar to be created")
+            self.assertTrue(all(created), "expected every progress bar to be disabled")
+
+    def test_generate_masks_progress_shown_when_verbose(self):
+        """generate_masks(verbose=True) still shows the progress bar."""
+        import tempfile
+
+        detector = self._stub_detector()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            raster_path, _ = self._create_data(tmp_dir)
+            with self._record_bars() as created:
+                detector.generate_masks(
+                    raster_path=raster_path,
+                    output_path=os.path.join(tmp_dir, "masks.tif"),
+                    verbose=True,
+                )
+
+            self.assertTrue(
+                any(not flag for flag in created),
+                "expected at least one visible progress bar",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python
+
+"""Tests for `geoai.progress` and the ``quiet``/``verbose`` flags that use it."""
+
+import ast
+import contextlib
+import os
+import pathlib
+import unittest
+from unittest.mock import patch
+
+import geopandas as gpd
+import numpy as np
+import rasterio
+from rasterio.transform import from_bounds
+from shapely.geometry import box
+
+from geoai import progress
+
+
+class TestProgressSwitch(unittest.TestCase):
+    """Tests for the package-wide progress bar switch."""
+
+    def setUp(self):
+        """Remember the current switch state."""
+        self._original = progress._DISABLED
+
+    def tearDown(self):
+        """Restore the original switch state."""
+        progress._DISABLED = self._original
+
+    def test_enabled_by_default(self):
+        """Progress bars are shown unless explicitly disabled."""
+        progress._DISABLED = None
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GEOAI_DISABLE_PROGRESS", None)
+            self.assertFalse(progress.progress_bars_disabled())
+
+    def test_disable_and_enable(self):
+        """disable_progress_bars/enable_progress_bars flip the switch."""
+        progress.disable_progress_bars()
+        self.assertTrue(progress.progress_bars_disabled())
+        progress.enable_progress_bars()
+        self.assertFalse(progress.progress_bars_disabled())
+
+    def test_set_progress_bars(self):
+        """set_progress_bars takes an ``enabled`` flag."""
+        progress.set_progress_bars(False)
+        self.assertTrue(progress.progress_bars_disabled())
+        progress.set_progress_bars(True)
+        self.assertFalse(progress.progress_bars_disabled())
+
+    def test_environment_variable(self):
+        """GEOAI_DISABLE_PROGRESS disables progress bars when unset in code."""
+        progress._DISABLED = None
+        with patch.dict(os.environ, {"GEOAI_DISABLE_PROGRESS": "1"}):
+            self.assertTrue(progress.progress_bars_disabled())
+        with patch.dict(os.environ, {"GEOAI_DISABLE_PROGRESS": "0"}):
+            self.assertFalse(progress.progress_bars_disabled())
+
+    def test_explicit_call_overrides_environment_variable(self):
+        """An explicit call wins over the environment variable."""
+        with patch.dict(os.environ, {"GEOAI_DISABLE_PROGRESS": "1"}):
+            progress.enable_progress_bars()
+            self.assertFalse(progress.progress_bars_disabled())
+
+    def test_tqdm_respects_global_switch(self):
+        """The tqdm wrapper is disabled when progress bars are turned off."""
+        progress.disable_progress_bars()
+        with progress.tqdm(range(3)) as pbar:
+            self.assertTrue(pbar.disable)
+
+        progress.enable_progress_bars()
+        with progress.tqdm(range(3), disable=True) as pbar:
+            self.assertTrue(pbar.disable)
+        with progress.tqdm(range(3), disable=False) as pbar:
+            self.assertFalse(pbar.disable)
+
+    def test_tqdm_still_iterates_when_disabled(self):
+        """Disabling progress bars must not change iteration results."""
+        progress.disable_progress_bars()
+        self.assertEqual(list(progress.tqdm(range(4))), [0, 1, 2, 3])
+
+    def test_exposed_from_top_level_package(self):
+        """The switch is reachable as ``geoai.disable_progress_bars`` etc."""
+        import geoai
+
+        self.assertIs(geoai.disable_progress_bars, progress.disable_progress_bars)
+        self.assertIs(geoai.enable_progress_bars, progress.enable_progress_bars)
+        self.assertIs(geoai.set_progress_bars, progress.set_progress_bars)
+        self.assertIs(geoai.progress_bars_disabled, progress.progress_bars_disabled)
+
+
+class TestNoDirectTqdmImports(unittest.TestCase):
+    """Guard the invariant that all progress bars go through geoai.progress."""
+
+    def test_modules_import_tqdm_from_geoai_progress(self):
+        """No geoai module imports tqdm directly."""
+        package_dir = pathlib.Path(progress.__file__).parent
+        offenders = []
+        for path in sorted(package_dir.rglob("*.py")):
+            if path.name == "progress.py":
+                continue
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(
+                    "tqdm"
+                ):
+                    offenders.append(f"{path.name}:{node.lineno}")
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name.split(".")[0] == "tqdm":
+                            offenders.append(f"{path.name}:{node.lineno}")
+        self.assertEqual(
+            offenders,
+            [],
+            f"Import tqdm from geoai.progress instead: {offenders}",
+        )
+
+
+class TestQuietFlags(unittest.TestCase):
+    """Tests that ``quiet``/``verbose`` flags actually suppress progress bars."""
+
+    def setUp(self):
+        """Remember the current switch state."""
+        self._original = progress._DISABLED
+        progress._DISABLED = False
+
+    def tearDown(self):
+        """Restore the original switch state."""
+        progress._DISABLED = self._original
+
+    @contextlib.contextmanager
+    def _record_bars(self):
+        """Record the resolved ``disable`` flag of every progress bar created.
+
+        The flag has to be captured at construction time because ``tqdm.close()``
+        sets ``disable`` to True on the way out.
+
+        Yields:
+            list: Booleans, one per progress bar created inside the context.
+        """
+        flags = []
+        original_init = progress.tqdm.__init__
+
+        def record_init(pbar, *args, **kwargs):
+            original_init(pbar, *args, **kwargs)
+            flags.append(pbar.disable)
+
+        with patch.object(progress.tqdm, "__init__", record_init):
+            yield flags
+
+    @staticmethod
+    def _create_data(tmp_dir):
+        """Create a small raster and matching vector file for tiling."""
+        raster_path = os.path.join(tmp_dir, "raster.tif")
+        vector_path = os.path.join(tmp_dir, "vector.geojson")
+
+        width = height = 300
+        data = np.random.randint(0, 256, (3, height, width), dtype=np.uint8)
+        transform = from_bounds(-122.5, 37.7, -122.3, 37.9, width, height)
+        with rasterio.open(
+            raster_path,
+            "w",
+            driver="GTiff",
+            height=height,
+            width=width,
+            count=3,
+            dtype="uint8",
+            crs="EPSG:4326",
+            transform=transform,
+        ) as dst:
+            dst.write(data)
+
+        gdf = gpd.GeoDataFrame(
+            {"class": [1]},
+            geometry=[box(-122.45, 37.75, -122.4, 37.8)],
+            crs="EPSG:4326",
+        )
+        gdf.to_file(vector_path, driver="GeoJSON")
+        return raster_path, vector_path
+
+    def test_export_geotiff_tiles_quiet(self):
+        """export_geotiff_tiles(quiet=True) writes no progress output."""
+        import tempfile
+
+        from geoai.utils import export_geotiff_tiles
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            raster_path, vector_path = self._create_data(tmp_dir)
+            with self._record_bars() as created:
+                export_geotiff_tiles(
+                    in_raster=raster_path,
+                    out_folder=os.path.join(tmp_dir, "output"),
+                    in_class_data=vector_path,
+                    tile_size=128,
+                    stride=64,
+                    quiet=True,
+                )
+
+            self.assertTrue(created, "expected a progress bar to be created")
+            self.assertTrue(all(created), "expected every progress bar to be disabled")
+
+    def test_export_geotiff_tiles_progress_shown_by_default(self):
+        """The progress bar is still enabled when quiet=False."""
+        import tempfile
+
+        from geoai.utils import export_geotiff_tiles
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            raster_path, vector_path = self._create_data(tmp_dir)
+            with self._record_bars() as created:
+                export_geotiff_tiles(
+                    in_raster=raster_path,
+                    out_folder=os.path.join(tmp_dir, "output"),
+                    in_class_data=vector_path,
+                    tile_size=128,
+                    stride=64,
+                    quiet=False,
+                )
+
+            self.assertTrue(
+                any(not flag for flag in created),
+                "expected at least one visible progress bar",
+            )
+
+    def test_export_geotiff_tiles_respects_global_switch(self):
+        """Globally disabling progress bars silences export_geotiff_tiles."""
+        import tempfile
+
+        from geoai.utils import export_geotiff_tiles
+
+        progress.disable_progress_bars()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            raster_path, vector_path = self._create_data(tmp_dir)
+            with self._record_bars() as created:
+                export_geotiff_tiles(
+                    in_raster=raster_path,
+                    out_folder=os.path.join(tmp_dir, "output"),
+                    in_class_data=vector_path,
+                    tile_size=128,
+                    stride=64,
+                    quiet=False,
+                )
+
+            self.assertTrue(created, "expected a progress bar to be created")
+            self.assertTrue(all(created), "expected every progress bar to be disabled")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zensical.toml
+++ b/zensical.toml
@@ -146,6 +146,7 @@ nav = [
     { "networks module" = "networks.md" },
     { "onnx module" = "onnx.md" },
     { "prithvi module" = "prithvi.md" },
+    { "progress module" = "progress.md" },
     { "recognize module" = "recognize.md" },
     { "rfdetr module" = "rfdetr.md" },
     { "sam module" = "sam.md" },


### PR DESCRIPTION
Fixes #870

## Problem

`quiet=True` / `verbose=False` were ignored by several progress bars, so detailed progress kept streaming even when the user asked for silence. In Colab the flood of updates could freeze and crash the tab. The reporter had to fall back to patching `tqdm` globally.

Two things were wrong:

1. Some `tqdm(...)` calls never received a `disable=` argument, even though the enclosing function had a `quiet`/`verbose` parameter.
2. The tiling loops called `pbar.set_description(...)` on every tile, which forces a redraw and bypasses tqdm's throttling — one output write per tile is what actually floods a notebook front end.

## Changes

**New `geoai.progress` module.** A `tqdm` wrapper (backed by `tqdm.auto`, so notebooks get widget-based bars instead of thousands of text writes) with a package-wide switch:

```python
import geoai

geoai.disable_progress_bars()   # silence every geoai progress bar
geoai.enable_progress_bars()
geoai.set_progress_bars(False)
geoai.progress_bars_disabled()
```

It can also be set before import with `GEOAI_DISABLE_PROGRESS=1`. Every geoai module now imports `tqdm` from here, so the switch reaches all progress bars, including the ones in functions that have no `quiet` argument of their own.

**Wired the flags that were being ignored:**

- `export_geotiff_tiles(quiet=...)`
- `export_training_data(quiet=...)`
- `ObjectDetector.save_masks_as_geotiff(verbose=...)`
- `ObjectDetector.generate_masks(verbose=...)`
- `CustomDataset` no longer logs its setup details when `verbose=False`

**Throttled redraws:** `pbar.set_description(..., refresh=False)` in both tiling loops. On an 81-tile export this drops from 81 forced redraws to 4 throttled ones.

## Verification

Ran the reported reproducer (`export_geotiff_tiles(..., quiet=True)` from `image_chips.ipynb`) against a synthetic NAIP-like raster:

- before: progress output on stderr despite `quiet=True`
- after: 0 bytes of output with `quiet=True`; bar still shown with `quiet=False`; 0 bytes after `geoai.disable_progress_bars()`

New `tests/test_progress.py` covers the switch, the env var, the wrapper, `export_geotiff_tiles` under all three modes, and an AST guard that no geoai module imports `tqdm` directly. Full suite: 1235 passed, 9 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized, package-wide controls to enable/disable progress bars.
  * Added new public progress APIs (`disable_progress_bars`, `enable_progress_bars`, `set_progress_bars`, and status query) and support for `GEOAI_DISABLE_PROGRESS`.
  * Progress bars now use a shared in-package implementation across major workflows.
* **Documentation**
  * Added a new documentation page for the progress module, including a usage example and API reference.
* **Bug Fixes**
  * Improved progress behavior to reduce redraw overhead and honor `quiet`/`verbose` expectations more consistently.
* **Tests**
  * Added tests validating global progress switching, per-call overrides, and `quiet`/`verbose` scenarios across workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->