### PR TITLE
ci: stop uv run from re-resolving the project in the docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,13 +52,13 @@ jobs:
             - name: Running pytest
               run: |
                   export PYTHONPATH=$(pwd)
-                  uv run pytest tests --verbose
+                  .venv/bin/python -m pytest tests --verbose
 
             - name: Build docs with Zensical
               run: |
                   uv pip install -r requirements_docs.txt
-                  uv run python scripts/convert_notebooks.py
-                  uv run zensical build
+                  .venv/bin/python scripts/convert_notebooks.py
+                  .venv/bin/zensical build
 
             - name: Deploy to GitHub Pages
               uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4


### PR DESCRIPTION
## Problem

The `docs` deploy job [failed on `24d66162`](https://github.com/opengeos/geoai/actions/runs/30161538275/job/89687535931) at the **Running pytest** step, while trying to build `vllm==0.1.3` from source:

```
RuntimeError: Cannot find CUDA_HOME. CUDA must be available in order to build the package.
hint: `vllm` (v0.1.3) was included because `geoai-py[vllm]` (v0.41.2) depends on `vllm`
```

## Cause

The job never asks for the `vllm` extra — it installs `.` plus `geoai-py[extra]` via `uv pip install`. The trigger is `uv run`:

1. With no `uv.lock` in the repo, `uv run` locks the project before executing.
2. A uv lockfile is **universal**, so it resolves *every* optional-dependency group — including the `vllm` extra added in #868.
3. No vllm wheel satisfies `requires-python = ">=3.12"` across all of 3.12/3.13/3.14, so uv backtracks to the ancient `0.1.3` sdist, which builds from source and demands CUDA.

This also silently discarded the carefully staged `uv pip install` layers above it, since `uv run` syncs the environment to its own resolution.

## Fix

Invoke the already-populated `.venv` directly, matching what `ubuntu.yml` and `docs-build.yml` (dbfe603c) already do:

```diff
-    uv run pytest tests --verbose
+    .venv/bin/python -m pytest tests --verbose
...
-    uv run python scripts/convert_notebooks.py
-    uv run zensical build
+    .venv/bin/python scripts/convert_notebooks.py
+    .venv/bin/zensical build
```

`docs.yml` was the only workflow still on `uv run`, and the only one that failed on `24d66162` — Linux, Windows, macOS, and Minimal import all passed. It looks like it was simply missed when the other docs workflow was migrated.

No change to `pyproject.toml` is needed: the `vllm` extra itself is fine and installs correctly when a user explicitly opts into it on a CUDA machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test execution to use the project’s configured Python environment.
  * Updated documentation builds and notebook conversion to use the project’s configured tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->