### PR TITLE
chore: bump version to 0.42.0 (qgis plugin 1.7.0)

### DIFF
--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -8,7 +8,7 @@ only when a specific symbol is first accessed.
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.41.2"
+__version__ = "0.42.0"
 
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geoai-py"
-version = "0.41.2"
+version = "0.42.0"
 dynamic = [
     "dependencies",
 ]
@@ -60,7 +60,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.41.2"
+current_version = "0.42.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.6.2
+version=1.7.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 


### PR DESCRIPTION
Version bump for the v0.42.0 release.

- Python package `0.41.2` -> `0.42.0` (`pyproject.toml` version + bumpversion `current_version`, `geoai/__init__.py`).
- QGIS plugin `1.6.2` -> `1.7.0` (`qgis_plugin/geoai/metadata.txt`).

**Why minor:** this cycle adds two new backends — the vLLM inference backend (#868) and the UniverSat wrapper (#860) — not just fixes.

**Why the plugin moves too, in the same commit:** `publish.yml` uploads to plugins.qgis.org using the version in `metadata.txt`, which is rejected if that version is already published. This is the v0.41.1 failure mode. The minor-for-minor pairing follows v0.41.0, where the plugin went 1.5.1 -> 1.6.0.

Shipping in this release:

**Features**
- vLLM inference backend for open-source model deployment (#868)
- UniverSat wrapper support (#860)

**Bug fixes**
- Make quiet/verbose flags actually suppress progress bars (#871)

**Docs**
- Add mining footprint mapping notebook (#869)

**CI**
- Stop `uv run` from re-resolving the project in the docs workflow (#872)
- Replace Netlify docs preview with gh-pages preview (#867)
- Add automated Claude code review workflow for pull requests (#862)
- Bump actions/checkout from 6 to 7 (#863)

Note: `docs/changelog.md` is not updated — it has been unmaintained since v0.35.0, with release notes living on the GitHub release instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GeoAI package version to 0.42.0.
  * Updated the QGIS plugin version to 1.7.0.
  * Aligned release metadata for consistent version reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->