### PR TITLE
ci: skip docs preview deploy for Dependabot pull requests

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -82,7 +82,7 @@ jobs:
             # inside the payload: a stray one silently drops files from the
             # preview while the build still reports success.
             - name: Strip .gitignore files from the build output
-              if: github.event.pull_request.head.repo.full_name == github.repository
+              if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
               run: |
                   set -euo pipefail
                   find ./site -name .gitignore -print -delete
@@ -98,6 +98,16 @@ jobs:
             # docs with that token available would mean running unreviewed code
             # with write access to the preview repository.
             #
+            # Skipped for Dependabot too. Its branches live in this repository,
+            # so the fork check above passes, but GitHub withholds repository
+            # secrets from Dependabot-triggered runs (they come from the separate
+            # Dependabot secret store) and downgrades GITHUB_TOKEN to read-only.
+            # PREVIEW_DEPLOY_TOKEN is therefore empty and the push to
+            # pages-preview dies on "Invalid username or token". Matching on
+            # pull_request.user rather than github.actor keeps the skip in place
+            # when a maintainer re-runs the job by hand -- the re-run still gets
+            # no secrets, but github.actor would then be the maintainer.
+            #
             # SETUP (one time): secret PREVIEW_DEPLOY_TOKEN, a fine-grained PAT
             # scoped to opengeos/pages-preview ONLY, with Contents: Read and
             # write (push to gh-pages) and Pages: Read (poll the Pages build so
@@ -106,7 +116,7 @@ jobs:
             # burns its timeout and fails with a misleading "Timed out waiting
             # for build to start". The token needs no access to this repository.
             - name: Deploy preview to GitHub Pages
-              if: github.event.pull_request.head.repo.full_name == github.repository
+              if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
               # Pinned to a SHA rather than the mutable tag: this is a
               # third-party action that receives PREVIEW_DEPLOY_TOKEN, so a
               # moved tag would hand that token to unreviewed code.

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -23,8 +23,10 @@ jobs:
     cleanup:
         runs-on: ubuntu-latest
         # Fork pull requests never got a preview (no secrets on `pull_request`),
-        # so there is nothing to remove.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        # and neither did Dependabot's (secrets are withheld from its runs), so
+        # there is nothing to remove -- and no token to remove it with. Keep this
+        # condition in step with the deploy guard in docs-build.
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
         steps:
             # The publish action runs `git config` in the workspace root, so
             # that root has to be a git repository even when only removing.


### PR DESCRIPTION
Fixes the `docs-build` failure on Dependabot PRs such as #874.

## Problem

`docs-build` already skips the preview deploy for fork PRs, since `pull_request` grants forks no secrets. Dependabot branches live *in* this repository, so `head.repo.full_name == github.repository` passes and the deploy step runs — but GitHub withholds repository secrets from Dependabot-triggered runs (they come from the separate Dependabot secret store) and downgrades `GITHUB_TOKEN` to read-only. `PREVIEW_DEPLOY_TOKEN` is empty, so the push dies:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/opengeos/pages-preview.git/'
```

## Fix

Add `github.event.pull_request.user.login != 'dependabot[bot]'` to the deploy guard (and the `.gitignore` strip that only exists to feed it). Matching on `pull_request.user` rather than `github.actor` keeps the skip in place when a maintainer re-runs the job by hand — the re-run still gets no secrets, but `github.actor` would then be the maintainer.

`docs-preview-cleanup` gets the same condition: a Dependabot PR never published a preview, so on close there is nothing to remove and no token to remove it with.

Tests and the docs build still run on Dependabot PRs — only the preview publish is skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation preview workflows for automated dependency update pull requests.
  * Prevented unnecessary cleanup and deployment attempts when preview credentials are unavailable.
  * Ensured manually rerun workflows continue to apply the correct safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->