### PR TITLE
ci: allow the Claude review workflow to check out fork PR heads

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -125,6 +125,25 @@ jobs:
           # it, and this job never installs deps or executes the checked-out code.
           # Combined with the prompt's read-scope guardrails, the untrusted head is
           # safe to have on disk here.
+          #
+          # actions/checkout v7 refuses to check out fork PR code from a
+          # pull_request_target workflow unless allow-unsafe-pr-checkout is set,
+          # because doing so is normally how "pwn request" vulnerabilities happen:
+          # the fork's code runs with the base repo's token and secrets. That is
+          # the flag's intended opt-in, and this job is the case it exists for —
+          # it only puts the head on disk for Read/Grep/Glob. Nothing in the
+          # checkout is ever executed: no dependency install, no build, no test,
+          # no setup-* action, and Claude has no Bash tool (see the header). The
+          # fork therefore controls bytes Claude reads, not code the runner runs.
+          #
+          # Without this flag every fork PR fails this check at the checkout step,
+          # which is exactly the population the review is most valuable for.
+          #
+          # If a future edit adds any step that EXECUTES the checked-out tree —
+          # `pip install .`, `npm ci`, a test run, a linter that loads project
+          # config/plugins — this opt-in becomes unsafe and must be removed (move
+          # such steps to a `pull_request` workflow, which has no secrets).
+          allow-unsafe-pr-checkout: true
           ref: ${{ steps.pr.outputs.sha }}
           persist-credentials: false
           fetch-depth: 1


### PR DESCRIPTION
## Problem

Since the `actions/checkout` v6 → v7 bump in #863, the `claude-review` check fails at the checkout step on **every PR opened from a fork** — e.g. [#875](https://github.com/opengeos/geoai/pull/875), where @HarshShinde0 [asked about it](https://github.com/opengeos/geoai/pull/875#issuecomment-3600743793) after seeing all 11 build checks pass but `claude-review` fail in 4s:

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target'
workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets,
default-branch cache scope, and runner access. Fetching and executing a fork's
code in that trusted context commonly leads to "pwn request" vulnerabilities.
To opt in, review the risks at https://gh.io/securely-using-pull_request_target
and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

The job dies before Claude runs, so fork PRs — the ones the review is most valuable for — get no review at all. This is unrelated to the contents of any given PR.

## Fix

Set `allow-unsafe-pr-checkout: true` on that one checkout step. `claude-code-review.yml` is the only workflow in the repo using `pull_request_target`.

## Why this is the safe case for that flag

The guardrail exists to stop "pwn request" attacks, where a fork's code is **executed** in a context holding the base repo's token and secrets. This job never executes the checked-out tree:

- no dependency install, no build, no test, no linter that would load project config or plugins
- no `setup-*` action
- Claude has **no Bash tool** — `--allowedTools` is `Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment`, and the action's subprocess env scrub (documented at the top of the file) strips `GITHUB_TOKEN`/`GH_TOKEN` from anything it could spawn anyway
- `persist-credentials: false` keeps the write-scoped token out of `.git/config`

The head is on disk only so `Read`/`Grep`/`Glob` show the *proposed* file contents rather than pre-change context. The fork controls **bytes Claude reads**, not **code the runner runs** — treated as untrusted input by the prompt's existing injection guardrails.

## Guarding the invariant

The inline comment states the condition that would invalidate this: if a future edit adds any step that executes the checked-out tree (`pip install .`, a test run, a config-loading linter), this opt-in becomes unsafe and must be removed, with that step moved to a `pull_request` workflow that has no secrets.

## Verification

YAML parses and the step resolves as intended; `pre-commit run --files .github/workflows/claude-code-review.yml` passes. End-to-end confirmation needs a fork PR to run against once this is on `main` — #875 is the natural candidate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request review automation to support checking out contributions from forked repositories.
  * Added security guidance and safeguards for the review workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->