### PR TITLE
fix: improve canopy checkpoint loading

### DIFF
--- a/geoai/canopy.py
+++ b/geoai/canopy.py
@@ -863,8 +863,16 @@ def _download_checkpoint(model_name: str, cache_dir: str = DEFAULT_CACHE_DIR) ->
     return checkpoint_path
 
 
-def _load_checkpoint(checkpoint_path: str, map_location: str):
-    """Load a checkpoint without allowing arbitrary Python objects."""
+def _load_checkpoint(checkpoint_path: str, map_location: str) -> Dict:
+    """Load a checkpoint without allowing arbitrary Python objects.
+
+    Args:
+        checkpoint_path: Path to the checkpoint file on disk.
+        map_location: Device to which storage locations are mapped.
+
+    Returns:
+        The checkpoint state dictionary or wrapper dictionary.
+    """
     return torch.load(checkpoint_path, map_location=map_location, weights_only=True)
 
 

--- a/geoai/canopy.py
+++ b/geoai/canopy.py
@@ -863,6 +863,11 @@ def _download_checkpoint(model_name: str, cache_dir: str = DEFAULT_CACHE_DIR) ->
     return checkpoint_path
 
 
+def _load_checkpoint(checkpoint_path: str, map_location: str):
+    """Load a checkpoint without allowing arbitrary Python objects."""
+    return torch.load(checkpoint_path, map_location=map_location, weights_only=True)
+
+
 def _load_model(
     model_name: str, checkpoint_path: str, device: str = "cpu"
 ) -> nn.Module:
@@ -880,10 +885,7 @@ def _load_model(
     model = _SSLAE(classify=True, huge=info["huge"]).eval()
 
     if info["compressed"]:
-        # weights_only=False is required for quantized checkpoints which
-        # contain non-tensor objects (packed params, scales, zero points).
-        # Checkpoints are only loaded from trusted Meta S3 URLs.
-        ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+        ckpt = _load_checkpoint(checkpoint_path, map_location="cpu")
         # Compressed checkpoints store quantized state dicts.  Always load
         # into a quantized model on CPU first so keys match correctly.
         model_q = torch.quantization.quantize_dynamic(
@@ -924,9 +926,7 @@ def _load_model(
             model.load_state_dict(float_sd, strict=False)
             model = model.to(device)
     else:
-        # weights_only=False is needed because some checkpoints wrap
-        # state_dict in a Lightning-style dict.  Only trusted Meta URLs.
-        ckpt = torch.load(checkpoint_path, map_location=device, weights_only=False)
+        ckpt = _load_checkpoint(checkpoint_path, map_location=device)
         state_dict = ckpt["state_dict"] if "state_dict" in ckpt else ckpt
         # Remove 'chm_module_.' prefix if present (from SSLModule wrapper)
         cleaned = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ scikit-learn
 smoothify
 timm
 tokenizers>=0.22.2
-torch
+torch>=2.10.0
 # torchange
 torchgeo
 torchinfo

--- a/tests/test_canopy.py
+++ b/tests/test_canopy.py
@@ -326,6 +326,39 @@ class TestLoadCheckpoint(unittest.TestCase):
 
         self.assertTrue(torch.equal(actual["weight"], expected["weight"]))
 
+    def test_loads_lightning_wrapped_state_dict(self):
+        import torch
+
+        from geoai.canopy import _load_checkpoint
+
+        with tempfile.TemporaryDirectory() as td:
+            checkpoint_path = os.path.join(td, "weights.pth")
+            expected = {"weight": torch.tensor([1.0, 2.0])}
+            torch.save({"state_dict": expected, "epoch": 3}, checkpoint_path)
+
+            actual = _load_checkpoint(checkpoint_path, map_location="cpu")
+
+        self.assertEqual(actual["epoch"], 3)
+        self.assertTrue(torch.equal(actual["state_dict"]["weight"], expected["weight"]))
+
+    def test_loads_quantized_state_dict(self):
+        import torch
+        import torch.nn as nn
+
+        from geoai.canopy import _load_checkpoint
+
+        model = torch.quantization.quantize_dynamic(
+            nn.Sequential(nn.Linear(4, 2)), {nn.Linear}, dtype=torch.qint8
+        )
+        with tempfile.TemporaryDirectory() as td:
+            checkpoint_path = os.path.join(td, "weights.pth")
+            expected = model.state_dict()
+            torch.save(expected, checkpoint_path)
+
+            actual = _load_checkpoint(checkpoint_path, map_location="cpu")
+
+        self.assertEqual(actual.keys(), expected.keys())
+
     def test_rejects_objects_with_pickle_callbacks(self):
         import torch
 

--- a/tests/test_canopy.py
+++ b/tests/test_canopy.py
@@ -309,5 +309,45 @@ class TestDownloadCheckpoint(unittest.TestCase):
             self.assertEqual(path, ckpt_path)
 
 
+class TestLoadCheckpoint(unittest.TestCase):
+    """Tests for restricted checkpoint deserialization."""
+
+    def test_loads_tensor_state_dict(self):
+        import torch
+
+        from geoai.canopy import _load_checkpoint
+
+        with tempfile.TemporaryDirectory() as td:
+            checkpoint_path = os.path.join(td, "weights.pth")
+            expected = {"weight": torch.tensor([1.0, 2.0])}
+            torch.save(expected, checkpoint_path)
+
+            actual = _load_checkpoint(checkpoint_path, map_location="cpu")
+
+        self.assertTrue(torch.equal(actual["weight"], expected["weight"]))
+
+    def test_rejects_objects_with_pickle_callbacks(self):
+        import torch
+
+        from geoai.canopy import _load_checkpoint
+
+        class PickleCallback:
+            def __reduce__(self):
+                return (os.mkdir, (marker_path,))
+
+        with tempfile.TemporaryDirectory() as td:
+            checkpoint_path = os.path.join(td, "weights.pth")
+            marker_path = os.path.join(td, "callback-ran")
+            torch.save(
+                {"weight": torch.tensor([1.0]), "extra": PickleCallback()},
+                checkpoint_path,
+            )
+
+            with self.assertRaises(Exception):
+                _load_checkpoint(checkpoint_path, map_location="cpu")
+
+            self.assertFalse(os.path.exists(marker_path))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- standardize canopy checkpoint loading behavior
- add coverage for supported checkpoint contents

## Test plan
- [x] `conda run -n geo pytest -q tests/test_canopy.py`
- [x] verify compressed state dictionaries load correctly
- [x] `uvx pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved model checkpoint loading to reject unsafe serialized Python objects.
  * Checkpoint callbacks and other arbitrary code are no longer executed during loading.
  * Supported checkpoint formats continue to load securely, including plain, wrapped, and quantized model state data.

* **Tests**
  * Added coverage for supported checkpoint formats and unsafe checkpoint rejection.
  * Verified that rejected checkpoint payloads cannot execute embedded callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->