### PR TITLE
chore: bump version to 0.43.0 (qgis plugin 1.8.0)

### DIFF
--- a/geoai/__init__.py
+++ b/geoai/__init__.py
@@ -8,7 +8,7 @@ only when a specific symbol is first accessed.
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.42.0"
+__version__ = "0.43.0"
 
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geoai-py"
-version = "0.42.0"
+version = "0.43.0"
 dynamic = [
     "dependencies",
 ]
@@ -61,7 +61,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.42.0"
+current_version = "0.43.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/qgis_plugin/geoai/metadata.txt
+++ b/qgis_plugin/geoai/metadata.txt
@@ -3,7 +3,7 @@ name=GeoAI
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=GeoAI plugin for QGIS providing AI-powered geospatial analysis including tree segmentation (DeepForest), water segmentation (OmniWaterMask), Moondream vision-language model, Segment Anything (SAM1/SAM2/SAM3), semantic segmentation, and instance segmentation (Mask R-CNN).
-version=1.7.0
+version=1.8.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 


### PR DESCRIPTION
Bumps the minor version for both the Python package and the QGIS plugin.

- **geoai-py: 0.42.0 → 0.43.0** — `pyproject.toml` (project version + bumpversion `current_version`) and `geoai/__init__.py`. Minor rather than patch: this cycle adds optically shallow/deep water classification (#875) and early stopping for Mask R-CNN training (#887).
- **QGIS plugin: 1.7.0 → 1.8.0** — `qgis_plugin/geoai/metadata.txt`, matching the package's minor bump as in v0.42.0 (plugin 1.6.2 → 1.7.0). Bumping both in the same PR keeps the plugin publish from failing on an already-published version.

`pre-commit run --all-files` passes.

https://claude.ai/code/session_01J9zFEPF1V8BArJe2JW6XWb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GeoAI package version to 0.43.0.
  * Updated the QGIS GeoAI plugin version to 1.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->