### PR TITLE
docs: add Hugging Face authentication guide for SAM 3

### DIFF
--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -369,18 +369,18 @@ QGIS → `Plugins` → `Manage and Install Plugins...` → enable `GeoAI`. After
 
 SAM 3 lives in a [gated Hugging Face repository](https://huggingface.co/facebook/sam3), so the plugin cannot download it until you authenticate. If you try to load SAM 3 without doing so, the model fails with an error saying you do not have access to the gated repo. SAM 1 and SAM 2 are not gated and need no authentication.
 
-### 1. Request access
+### Request access
 
 Fill out the access form at <https://huggingface.co/facebook/sam3> while logged in to your Hugging Face account. Approval is not instant. Before continuing, revisit that page and confirm you see a banner stating that you have been granted access rather than the request form — having a token is not the same as having access.
 
-### 2. Create an access token
+### Create an access token
 
 Go to <https://huggingface.co/settings/tokens> and create a token:
 
 - A token of type **Read** works as-is.
 - If you create a **Fine-grained** token instead, you must check **Read access to contents of all public gated repos you can access**. Without that permission, the download fails with the same gated-repo error even after your access request is approved.
 
-### 3. Authenticate
+### Authenticate
 
 The `hf` command is installed inside the plugin's Python environment, not on your system `PATH`. Running a bare `hf auth login` in a terminal fails with `'hf' is not recognized...` (Windows) or `command not found` (Linux/macOS) no matter which directory you are in. Use the method that matches how you installed the dependencies.
 
@@ -438,7 +438,6 @@ export HF_TOKEN=hf_your_token_here
 On Windows, QGIS must be launched *after* running `setx` to inherit the variable.
 
 **Important Note**: SAM 3 currently requires a NVIDIA GPU with CUDA support. You won't be able to use SAM 3 if you have a CPU only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`. Use SAM 1 or SAM 2 on CPU-only systems.
-
 
 ## Usage
 

--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -304,7 +304,7 @@ pixi run pip install -U numpy transformers
 
 #### Request access to SAM 3
 
-To use SAM 3, you will need to request access by filling out this form on Hugging Face at <https://huggingface.co/facebook/sam3>. Once your request has been approved, run the following command in the terminal to authenticate:
+SAM 3 is hosted in a gated Hugging Face repository. Request access at <https://huggingface.co/facebook/sam3>, then authenticate from the Pixi project folder:
 
 ```bash
 pixi run hf auth login
@@ -315,6 +315,8 @@ After authentication, you can download the SAM 3 model from Hugging Face:
 ```bash
 pixi run hf download facebook/sam3
 ```
+
+See [Hugging Face Authentication (SAM 3)](#hugging-face-authentication-sam-3) for token requirements and troubleshooting.
 
 **Important Note**: SAM 3 currently requires a NVIDIA GPU with CUDA support. You won't be able to use SAM 3 if you have a CPU only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`.
 
@@ -362,6 +364,81 @@ Launch QGIS: `pixi run qgis`
 QGIS → `Plugins` → `Manage and Install Plugins...` → enable `GeoAI`. After updates, toggle the plugin off/on or restart QGIS to reload.
 
 ![](https://github.com/user-attachments/assets/1b6dab14-311d-4f62-85aa-1faed73ead5b)
+
+## Hugging Face Authentication (SAM 3)
+
+SAM 3 lives in a [gated Hugging Face repository](https://huggingface.co/facebook/sam3), so the plugin cannot download it until you authenticate. If you try to load SAM 3 without doing so, the model fails with an error saying you do not have access to the gated repo. SAM 1 and SAM 2 are not gated and need no authentication.
+
+### 1. Request access
+
+Fill out the access form at <https://huggingface.co/facebook/sam3> while logged in to your Hugging Face account. Approval is not instant. Before continuing, revisit that page and confirm you see a banner stating that you have been granted access rather than the request form — having a token is not the same as having access.
+
+### 2. Create an access token
+
+Go to <https://huggingface.co/settings/tokens> and create a token:
+
+- A token of type **Read** works as-is.
+- If you create a **Fine-grained** token instead, you must check **Read access to contents of all public gated repos you can access**. Without that permission, the download fails with the same gated-repo error even after your access request is approved.
+
+### 3. Authenticate
+
+The `hf` command is installed inside the plugin's Python environment, not on your system `PATH`. Running a bare `hf auth login` in a terminal fails with `'hf' is not recognized...` (Windows) or `command not found` (Linux/macOS) no matter which directory you are in. Use the method that matches how you installed the dependencies.
+
+#### If you used the built-in dependency installer (Option A)
+
+Call `hf` by its full path inside the managed environment at `~/.qgis_geoai/`. The environment folder is named after your QGIS Python version (for example, `venv_py3.12`); to see the exact path, use `GeoAI` menu → `Generate Diagnostics Report...` and look for **Virtual environment path**.
+
+Windows (PowerShell — any directory):
+
+```powershell
+# List the environment folder name (e.g. venv_py3.12)
+Get-ChildItem "$env:USERPROFILE\.qgis_geoai" -Filter "venv_py*"
+
+# Authenticate, substituting the folder name from above
+& "$env:USERPROFILE\.qgis_geoai\venv_py3.12\Scripts\hf.exe" auth login
+```
+
+Linux/macOS:
+
+```bash
+ls ~/.qgis_geoai            # e.g. venv_py3.12
+~/.qgis_geoai/venv_py3.12/bin/hf auth login
+```
+
+Paste your token when prompted, then restart QGIS.
+
+#### If you used the Pixi environment (Option B)
+
+Run this from the Pixi project folder (the `geo` directory you created):
+
+```bash
+pixi run hf auth login
+```
+
+Optionally pre-download the model so the first run does not stall:
+
+```bash
+pixi run hf download facebook/sam3
+```
+
+#### Alternative: use an environment variable
+
+Both installation methods pass your environment through to the model process, so you can skip the CLI entirely by setting `HF_TOKEN` and restarting QGIS:
+
+```powershell
+# Windows (PowerShell) - persists for future sessions
+setx HF_TOKEN "hf_your_token_here"
+```
+
+```bash
+# Linux/macOS - add to ~/.bashrc or ~/.zshrc to persist
+export HF_TOKEN=hf_your_token_here
+```
+
+On Windows, QGIS must be launched *after* running `setx` to inherit the variable.
+
+**Important Note**: SAM 3 currently requires a NVIDIA GPU with CUDA support. You won't be able to use SAM 3 if you have a CPU only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`. Use SAM 1 or SAM 2 on CPU-only systems.
+
 
 ## Usage
 
@@ -613,6 +690,7 @@ The QGIS plugin supports any models supported by [Pytorch Segmentation Models](h
 - Plugin missing after install: confirm the plugin folder exists in your QGIS profile path and that you restarted QGIS.
 - CUDA OOM: use the **GPU** button to clear cache, lower batch sizes, or switch to CPU for smaller runs.
 - Model download failures: check network/firewall, then retry loading models from the panel.
+- SAM 3 fails to load with a gated-repo access error, or `hf` is not recognized as a command: see [Hugging Face Authentication (SAM 3)](#hugging-face-authentication-sam-3). The `hf` command is not on your system `PATH`; it lives inside the plugin's Python environment.
 
 ## License
 

--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -318,7 +318,7 @@ pixi run hf download facebook/sam3
 
 See [Hugging Face Authentication (SAM 3)](#hugging-face-authentication-sam-3) for token requirements and troubleshooting.
 
-**Important Note**: SAM 3 currently requires a NVIDIA GPU with CUDA support. You won't be able to use SAM 3 if you have a CPU only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`.
+**Important Note**: SAM 3 currently requires an NVIDIA GPU with CUDA support. You won't be able to use SAM 3 if you have a CPU-only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`.
 
 ### 2. Install the QGIS plugin
 
@@ -423,7 +423,7 @@ pixi run hf download facebook/sam3
 
 #### Alternative: use an environment variable
 
-Both installation methods pass your environment through to the model process, so you can skip the CLI entirely by setting `HF_TOKEN` and restarting QGIS:
+Both installation methods pass the QGIS process environment through to the model process, so you can skip the CLI by setting `HF_TOKEN`. The catch is that the variable must exist in the environment that *launches* QGIS:
 
 ```powershell
 # Windows (PowerShell) - persists for future sessions
@@ -431,13 +431,16 @@ setx HF_TOKEN "hf_your_token_here"
 ```
 
 ```bash
-# Linux/macOS - add to ~/.bashrc or ~/.zshrc to persist
+# Linux/macOS
 export HF_TOKEN=hf_your_token_here
 ```
 
-On Windows, QGIS must be launched *after* running `setx` to inherit the variable.
+- On Windows, launch QGIS *after* running `setx`; an already-running QGIS will not pick it up.
+- On Linux/macOS, exporting in `~/.bashrc` or `~/.zshrc` only covers QGIS started from a terminal in that shell. Desktop shortcuts and application launchers do not read shell startup files, so either start QGIS from that terminal or set the variable somewhere your desktop session reads it (for example `~/.profile` or `~/.config/environment.d/` on Linux, or `launchctl setenv HF_TOKEN <token>` on macOS).
 
-**Important Note**: SAM 3 currently requires a NVIDIA GPU with CUDA support. You won't be able to use SAM 3 if you have a CPU only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`. Use SAM 1 or SAM 2 on CPU-only systems.
+If that is awkward, prefer `hf auth login` above: it writes the token to `~/.cache/huggingface/token`, which is read no matter how QGIS was started.
+
+**Important Note**: SAM 3 currently requires an NVIDIA GPU with CUDA support. You won't be able to use SAM 3 if you have a CPU-only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`. Use SAM 1 or SAM 2 on CPU-only systems.
 
 ## Usage
 

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -236,7 +236,7 @@ If CUDA is `False`, check:
 
 #### Request access to SAM 3
 
-To use SAM 3, you will need to request access by filling out this form on Hugging Face at <https://huggingface.co/facebook/sam3>. Once your request has been approved, run the following command in the terminal to authenticate:
+SAM 3 is hosted in a gated Hugging Face repository. Request access at <https://huggingface.co/facebook/sam3>, then authenticate from the Pixi project folder:
 
 ```bash
 pixi run hf auth login

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -242,6 +242,8 @@ To use SAM 3, you will need to request access by filling out this form on Huggin
 pixi run hf auth login
 ```
 
+If you installed the dependencies with the plugin's built-in installer instead of Pixi, `hf` is not on your `PATH` — see [Hugging Face Authentication (SAM 3)](https://opengeoai.org/qgis_plugin/#hugging-face-authentication-sam-3) for the full instructions.
+
 After authentication, you can download the SAM 3 model from Hugging Face:
 
 ```bash

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -250,7 +250,7 @@ After authentication, you can download the SAM 3 model from Hugging Face:
 pixi run hf download facebook/sam3
 ```
 
-**Important Note**: SAM 3 currently requires a NVIDIA GPU with CUDA support. You won't be able to use SAM 3 if you have a CPU only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`.
+**Important Note**: SAM 3 currently requires an NVIDIA GPU with CUDA support. You won't be able to use SAM 3 if you have a CPU-only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`.
 
 ### 2. Install the QGIS plugin
 


### PR DESCRIPTION
Closes the documentation gap behind discussion #897.

## Problem

The SAM 3 authentication instructions only covered the Pixi install path (`pixi run hf auth login`). Users who install dependencies with the plugin's built-in installer get an isolated venv at `~/.qgis_geoai/venv_pyX.Y/`, which is never added to `PATH` — so a bare `hf auth login` fails with `'hf' is not recognized as the name of a cmdlet...` on Windows regardless of which directory they run it from, with nothing in the docs to explain why.

## Changes

New `## Hugging Face Authentication (SAM 3)` section in `docs/qgis_plugin.md` covering:

- Requesting access, and the fact that holding a token is not the same as having an approved request.
- The **Read access to contents of all public gated repos you can access** permission that fine-grained tokens need — omitting it produces the same gated-repo error after approval.
- Authenticating via the full path to `hf` inside the managed venv (Windows PowerShell and Linux/macOS), with a pointer to `Generate Diagnostics Report...` for the exact environment path.
- Authenticating via `pixi run hf auth login` for the Pixi path.
- The `HF_TOKEN` environment variable alternative, which works for both paths since the plugin passes the environment through to the model subprocess.

Also cross-linked from the Pixi `Request access to SAM 3` subsection, from Troubleshooting, and from `qgis_plugin/README.md`.

Docs only — no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded SAM 3 setup instructions, including Hugging Face access requests, token creation, authentication methods, and `HF_TOKEN` configuration.
  * Added troubleshooting guidance for SAM 3 loading failures and unavailable `hf` commands.
  * Updated the plugin README to direct users to the online authentication documentation when using the built-in dependency installer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->