### PR TITLE
fix(pipeline): RasterToVectorStep passes output= but raster_to_vector expects output_path=

### DIFF
--- a/geoai/pipeline.py
+++ b/geoai/pipeline.py
@@ -479,7 +479,7 @@ class RasterToVectorStep(PipelineStep):
         os.makedirs(output_dir, exist_ok=True)
         vector_path = os.path.join(output_dir, f"{base_name}{self.output_format}")
 
-        gdf = raster_to_vector(raster_path, output=vector_path)
+        gdf = raster_to_vector(raster_path, output_path=vector_path)
         if self.simplify_tolerance and gdf is not None:
             gdf["geometry"] = gdf.geometry.simplify(self.simplify_tolerance)
             gdf.to_file(vector_path)


### PR DESCRIPTION
### Problem

`RasterToVectorStep.process()` calls `raster_to_vector` with an `output=` keyword:

```python
# geoai/pipeline.py
gdf = raster_to_vector(raster_path, output=vector_path)
```

But `raster_to_vector` (in `geoai/utils/raster.py`) has no `output` parameter — the keyword for the destination path is `output_path`:

```python
def raster_to_vector(
    raster_path: str,
    output_path: Optional[str] = None,
    ...
) -> gpd.GeoDataFrame:
```

So **every** call to `RasterToVectorStep.process()` fails immediately with:

```
TypeError: raster_to_vector() got an unexpected keyword argument 'output'
```

The step never gets to vectorize anything.

### Reproduction

```python
import inspect
sig = inspect.signature(raster_to_vector)
sig.bind("mask.tif", output="out.geojson")       # TypeError: unexpected keyword argument 'output'
sig.bind("mask.tif", output_path="out.geojson")  # OK
```

### Fix

Pass the intended keyword `output_path=`, so the step actually writes the vector file to `vector_path` as the docstring promises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed raster mask conversion so vector output files are generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->